### PR TITLE
When computing the a node/edge view, also check if the column has a default value when determining the row value to map

### DIFF
--- a/src/models/VisualStyleModel/impl/visualStyle-utils.ts
+++ b/src/models/VisualStyleModel/impl/visualStyle-utils.ts
@@ -305,11 +305,13 @@ export const computeView = (
       pairs.set(name, bypass)
     } else if (mapping !== undefined) {
       // Mapping is available.
-      // TODO: compute mapping
       const attrName: string = mapping.attribute
-      const attributeValueAssigned: ValueType | undefined = row[attrName]
+      const column = columns.get(attrName)
+      const attributeValue: ValueType | undefined =
+        row[attrName] ?? column?.defaultValue
+      const attributeValueAssigned: boolean = attributeValue !== undefined
 
-      if (attributeValueAssigned !== undefined) {
+      if (attributeValueAssigned) {
         // const computedValue: VisualPropertyValueType = getMappedValue(
         //   mapping,
         //   attributeValueAssigned,
@@ -324,9 +326,7 @@ export const computeView = (
             `Mapping is defined, but Mapper for ${vp.name} is not found`,
           )
         }
-        const computedValue: VisualPropertyValueType = mapper(
-          attributeValueAssigned,
-        )
+        const computedValue: VisualPropertyValueType = mapper(attributeValue)
         pairs.set(name, computedValue)
       } else {
         pairs.set(name, defaultValue)


### PR DESCRIPTION

When getting the attribute value for a mapping in `computeView`, columns sometime contain a `defaultValue`.  If the row for a specific node/edge does not have a value, also check the column's defaultValue before deciding if the value is found or not.