### PR TITLE
slightly improve ux for the mapping form

### DIFF
--- a/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
+++ b/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
@@ -5,6 +5,7 @@ import {
   MappingFunctionType,
   VisualPropertyValueTypeName,
   VisualPropertyValueType,
+  VisualProperty,
 } from '..'
 
 import { CXContinuousMappingFunction } from './cxVisualPropertyConverter'
@@ -20,6 +21,27 @@ const valueType2BaseType: Record<ValueTypeName, SingleValueType | null> = {
   [ValueTypeName.ListDouble]: null,
   [ValueTypeName.ListInteger]: null,
   [ValueTypeName.ListString]: null,
+}
+
+// This function will be redundant once continuous discrete mapping ui is available
+// Until then, only return valid mappings for a given visual property
+// Continuous mappings cannot be applied to vps that are not numbers or colors
+export const validMappingsForVP = (
+  vp: VisualProperty<VisualPropertyValueType>,
+): MappingFunctionType[] => {
+  const { type } = vp
+  if (
+    type === VisualPropertyValueTypeName.Number ||
+    type === VisualPropertyValueTypeName.Color
+  ) {
+    return [
+      MappingFunctionType.Continuous,
+      MappingFunctionType.Discrete,
+      MappingFunctionType.Passthrough,
+    ]
+  }
+
+  return [MappingFunctionType.Discrete, MappingFunctionType.Passthrough]
 }
 
 // check whether a given value type can be applied to a given visual property value type


### PR DESCRIPTION
- disable continuous mapping functions for the visual properties that do not support it and provide a tooltip stating why it is disabled
- rename 'attribute' to 'column' for all the lines of code I touched to eventually remove all uses of 'attribute'
- when the user clicks a attribute, filter the mapping types based on the type of the attribute
- when a user clicks a mapping type, filter the attributes based on the ones that are compatible with the mapping type