### PR TITLE
Export cx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "@glideapps/glide-data-grid": "^5.2.1",
-        "@js4cytoscape/ndex-client": "0.4.3-alpha.0",
+        "@js4cytoscape/ndex-client": "0.4.3-alpha.2",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.0",
         "@visx/axis": "^3.0.0",
@@ -2985,11 +2985,11 @@
       }
     },
     "node_modules/@js4cytoscape/ndex-client": {
-      "version": "0.4.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@js4cytoscape/ndex-client/-/ndex-client-0.4.3-alpha.0.tgz",
-      "integrity": "sha512-EV/ref7Z8Ju2Nt5E3hSOu4RzNixakZotk31ZtkhWUTwXGj9PFEbfJhuvwlAJX4T/Zu8PD3b2iWOL+p6cpw3Ewg==",
+      "version": "0.4.3-alpha.2",
+      "resolved": "https://registry.npmjs.org/@js4cytoscape/ndex-client/-/ndex-client-0.4.3-alpha.2.tgz",
+      "integrity": "sha512-o45td8CuMsXrLMr9woIx+gXF/dpOlaBh2LS3IG81UQDGq3L8/5s207fDGlZxELJzcSP6Pwde48vgqwvWSEpmTw==",
       "dependencies": {
-        "axios": "^0.26.0"
+        "axios": "^1.3.4"
       },
       "engines": {
         "node": ">=12.16.1"
@@ -6711,8 +6711,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -6739,11 +6738,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-core": {
@@ -7701,7 +7702,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8400,7 +8400,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10307,7 +10306,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -16106,6 +16104,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@glideapps/glide-data-grid": "^5.2.1",
-    "@js4cytoscape/ndex-client": "0.4.3-alpha.0",
+    "@js4cytoscape/ndex-client": "0.4.3-alpha.2",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.0",
     "@visx/axis": "^3.0.0",

--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -69,7 +69,9 @@ export const CopyNetworkToNDExMenuItem = (
       })
 
       console.log(
-        `Saved a copy of the current network to NDEx with new uuid ${uuid}`,
+        `Saved a copy of the current network to NDEx with new uuid ${
+          uuid as string
+        }`,
       )
     } catch (e) {
       console.log(e)

--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -76,9 +76,12 @@ export const CopyNetworkToNDExMenuItem = (
       })
 
       addNetworkToWorkspace(uuid as IdType)
+      // in the other places that this function is used, it seems that a setTimeout is required
+      // for it to work properly
+      // todo this should not be necessary
       setTimeout(() => {
         setCurrentNetworkId(uuid as IdType)
-      }, 200)
+      }, 500)
 
       console.log(
         `Saved a copy of the current network to NDEx with new uuid ${

--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -14,6 +14,7 @@ import { useCredentialStore } from '../../../store/CredentialStore'
 import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore'
 import { exportNetworkToCx2 } from '../../../store/exportCX'
 import { Network } from '../../../models/NetworkModel'
+import { IdType } from '../../../models/IdType'
 import { AppConfigContext } from '../../../AppConfigContext'
 
 export const CopyNetworkToNDExMenuItem = (
@@ -47,6 +48,12 @@ export const CopyNetworkToNDExMenuItem = (
   const client = useCredentialStore((state) => state.client)
   const authenticated: boolean = client?.authenticated ?? false
 
+  const addNetworkToWorkspace = useWorkspaceStore(
+    (state) => state.addNetworkIds,
+  )
+  const setCurrentNetworkId = useWorkspaceStore(
+    (state) => state.setCurrentNetworkId,
+  )
   const saveCopyToNDEx = async (): Promise<void> => {
     const ndexClient = new NDEx(`${ndexBaseUrl}/v2`)
     const accessToken = await getToken()
@@ -67,6 +74,11 @@ export const CopyNetworkToNDExMenuItem = (
       updateSummary(currentNetworkId, {
         modificationTime: newNdexModificationTime,
       })
+
+      addNetworkToWorkspace(uuid as IdType)
+      setTimeout(() => {
+        setCurrentNetworkId(uuid as IdType)
+      }, 200)
 
       console.log(
         `Saved a copy of the current network to NDEx with new uuid ${

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -105,7 +105,9 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
       })
 
       console.log(
-        `Saved a copy of the current network to NDEx with new uuid ${uuid}`,
+        `Saved a copy of the current network to NDEx with new uuid ${
+          uuid as string
+        }`,
       )
     } catch (e) {
       console.log(e)

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -1,0 +1,66 @@
+import { MenuItem } from '@mui/material'
+import { ReactElement, useContext } from 'react'
+import { BaseMenuProps } from '../BaseMenuProps'
+
+// @ts-expect-error-next-line
+import { NDEx } from '@js4cytoscape/ndex-client'
+
+import { useWorkspaceStore } from '../../../store/WorkspaceStore'
+import { useNetworkStore } from '../../../store/NetworkStore'
+import { useTableStore } from '../../../store/TableStore'
+import { useViewModelStore } from '../../../store/ViewModelStore'
+import { useVisualStyleStore } from '../../../store/VisualStyleStore'
+import { useCredentialStore } from '../../../store/CredentialStore'
+import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore'
+import { exportNetworkToCx2 } from '../../../store/exportCX'
+import { Network } from '../../../models/NetworkModel'
+import { AppConfigContext } from '../../../AppConfigContext'
+
+export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
+  const { ndexBaseUrl } = useContext(AppConfigContext)
+
+  const currentNetworkId = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
+  )
+
+  const table = useTableStore((state) => state.tables[currentNetworkId])
+
+  const summary = useNetworkSummaryStore(
+    (state) => state.summaries[currentNetworkId],
+  )
+
+  const viewModel = useViewModelStore(
+    (state) => state.viewModels[currentNetworkId],
+  )
+  const visualStyle = useVisualStyleStore(
+    (state) => state.visualStyles[currentNetworkId],
+  )
+  const network = useNetworkStore((state) =>
+    state.networks.get(currentNetworkId),
+  ) as Network
+
+  const getToken = useCredentialStore((state) => state.getToken)
+  const handleSaveCurrentNetworkToNDEx = async (): Promise<void> => {
+    const cx = exportNetworkToCx2(
+      network,
+      visualStyle,
+      summary,
+      table.nodeTable,
+      table.edgeTable,
+      viewModel,
+    )
+
+    const ndexClient = new NDEx(`${ndexBaseUrl}/v2`)
+    const accessToken = await getToken()
+    ndexClient.setAuthToken(accessToken)
+    ndexClient.createNetworkFromRawCX2(cx)
+
+    props.handleClose()
+  }
+
+  return (
+    <MenuItem onClick={handleSaveCurrentNetworkToNDEx}>
+      Save current network to NDEx
+    </MenuItem>
+  )
+}

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -25,6 +25,7 @@ import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore'
 import { exportNetworkToCx2 } from '../../../store/exportCX'
 import { Network } from '../../../models/NetworkModel'
 import { AppConfigContext } from '../../../AppConfigContext'
+import { IdType } from '../../../models/IdType'
 
 export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
   const { ndexBaseUrl } = useContext(AppConfigContext)
@@ -51,6 +52,13 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
   const network = useNetworkStore((state) =>
     state.networks.get(currentNetworkId),
   ) as Network
+
+  const addNetworkToWorkspace = useWorkspaceStore(
+    (state) => state.addNetworkIds,
+  )
+  const setCurrentNetworkId = useWorkspaceStore(
+    (state) => state.setCurrentNetworkId,
+  )
 
   const getToken = useCredentialStore((state) => state.getToken)
   const client = useCredentialStore((state) => state.client)
@@ -103,6 +111,11 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
       updateSummary(currentNetworkId, {
         modificationTime: newNdexModificationTime,
       })
+
+      addNetworkToWorkspace(uuid as IdType)
+      setTimeout(() => {
+        setCurrentNetworkId(uuid as IdType)
+      }, 200)
 
       console.log(
         `Saved a copy of the current network to NDEx with new uuid ${

--- a/src/components/ToolBar/DataMenu/index.tsx
+++ b/src/components/ToolBar/DataMenu/index.tsx
@@ -5,14 +5,8 @@ import { RemoveAllNetworksMenuItem } from './RemoveAllNetworksMenuItem'
 import { RemoveNetworkMenuItem } from './RemoveNetworkMenuItem'
 import { LoadDemoNetworksMenuItem } from './LoadDemoNetworksMenuItem'
 import { LoadFromNdexMenuItem } from './LoadFromNdexMenuItem'
+import { SaveToNDExMenuItem } from './SaveToNDExMenuItem'
 import { useState } from 'react'
-import { useWorkspaceStore } from '../../../store/WorkspaceStore'
-import { useNetworkStore } from '../../../store/NetworkStore'
-import { useTableStore } from '../../../store/TableStore'
-import { useViewModelStore } from '../../../store/ViewModelStore'
-import { useVisualStyleStore } from '../../../store/VisualStyleStore'
-import { exportNetworkToCx2 } from '../../../store/exportCX'
-import { Network } from '../../../models/NetworkModel'
 interface DropdownMenuProps {
   label: string
   children?: React.ReactNode
@@ -25,10 +19,6 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
 
-  const currentNetworkId = useWorkspaceStore(
-    (state) => state.workspace.currentNetworkId,
-  )
-
   const handleOpenDropdownMenu = (
     event: React.MouseEvent<HTMLButtonElement>,
   ): void => {
@@ -37,30 +27,6 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
 
   const handleClose = (): void => {
     setAnchorEl(null)
-  }
-
-  // const tables = useTableStore((state) => state.tables)
-  const table = useTableStore((state) => state.tables[currentNetworkId])
-
-  const viewModels = useViewModelStore((state) => state.viewModels)
-  const visualStyles = useVisualStyleStore((state) => state.visualStyles)
-  const networks = useNetworkStore((state) => state.networks)
-
-  const handleClick = (): void => {
-    // const table = useTableStore((state) => state.tables[currentNetworkId])
-    const viewModel = viewModels[currentNetworkId]
-    const visualStyle = visualStyles[currentNetworkId]
-    const network = networks.get(currentNetworkId) as Network
-
-    console.log(
-      exportNetworkToCx2(
-        network,
-        visualStyle,
-        table.nodeTable,
-        table.edgeTable,
-        viewModel,
-      ),
-    )
   }
 
   return (
@@ -92,7 +58,7 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
         <RemoveNetworkMenuItem handleClose={handleClose} />
         <RemoveAllNetworksMenuItem handleClose={handleClose} />
         <Divider />
-        <Button onClick={handleClick}>Export to NDEx</Button>
+        <SaveToNDExMenuItem handleClose={handleClose} />
       </Menu>
     </div>
   )

--- a/src/components/ToolBar/DataMenu/index.tsx
+++ b/src/components/ToolBar/DataMenu/index.tsx
@@ -6,7 +6,13 @@ import { RemoveNetworkMenuItem } from './RemoveNetworkMenuItem'
 import { LoadDemoNetworksMenuItem } from './LoadDemoNetworksMenuItem'
 import { LoadFromNdexMenuItem } from './LoadFromNdexMenuItem'
 import { useState } from 'react'
-
+import { useWorkspaceStore } from '../../../store/WorkspaceStore'
+import { useNetworkStore } from '../../../store/NetworkStore'
+import { useTableStore } from '../../../store/TableStore'
+import { useViewModelStore } from '../../../store/ViewModelStore'
+import { useVisualStyleStore } from '../../../store/VisualStyleStore'
+import { exportNetworkToCx2 } from '../../../store/exportCX'
+import { Network } from '../../../models/NetworkModel'
 interface DropdownMenuProps {
   label: string
   children?: React.ReactNode
@@ -19,6 +25,10 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
 
+  const currentNetworkId = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
+  )
+
   const handleOpenDropdownMenu = (
     event: React.MouseEvent<HTMLButtonElement>,
   ): void => {
@@ -27,6 +37,30 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
 
   const handleClose = (): void => {
     setAnchorEl(null)
+  }
+
+  // const tables = useTableStore((state) => state.tables)
+  const table = useTableStore((state) => state.tables[currentNetworkId])
+
+  const viewModels = useViewModelStore((state) => state.viewModels)
+  const visualStyles = useVisualStyleStore((state) => state.visualStyles)
+  const networks = useNetworkStore((state) => state.networks)
+
+  const handleClick = (): void => {
+    // const table = useTableStore((state) => state.tables[currentNetworkId])
+    const viewModel = viewModels[currentNetworkId]
+    const visualStyle = visualStyles[currentNetworkId]
+    const network = networks.get(currentNetworkId) as Network
+
+    console.log(
+      exportNetworkToCx2(
+        network,
+        visualStyle,
+        table.nodeTable,
+        table.edgeTable,
+        viewModel,
+      ),
+    )
   }
 
   return (
@@ -58,6 +92,7 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
         <RemoveNetworkMenuItem handleClose={handleClose} />
         <RemoveAllNetworksMenuItem handleClose={handleClose} />
         <Divider />
+        <Button onClick={handleClick}>Export to NDEx</Button>
       </Menu>
     </div>
   )

--- a/src/components/ToolBar/DataMenu/index.tsx
+++ b/src/components/ToolBar/DataMenu/index.tsx
@@ -6,6 +6,7 @@ import { RemoveNetworkMenuItem } from './RemoveNetworkMenuItem'
 import { LoadDemoNetworksMenuItem } from './LoadDemoNetworksMenuItem'
 import { LoadFromNdexMenuItem } from './LoadFromNdexMenuItem'
 import { SaveToNDExMenuItem } from './SaveToNDExMenuItem'
+import { CopyNetworkToNDExMenuItem } from './CopyNetworkToNDExMenuItem'
 import { useState } from 'react'
 interface DropdownMenuProps {
   label: string
@@ -59,6 +60,7 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
         <RemoveAllNetworksMenuItem handleClose={handleClose} />
         <Divider />
         <SaveToNDExMenuItem handleClose={handleClose} />
+        <CopyNetworkToNDExMenuItem handleClose={handleClose} />
       </Menu>
     </div>
   )

--- a/src/components/Vizmapper/Forms/MappingForm/index.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/index.tsx
@@ -202,7 +202,7 @@ function MappingFormContent(props: {
       : columns
   const validColumnNames = validColumns.map((c) => c.name)
 
-  const validMappings = validMappingsForVP(props.visualProperty).filter(
+  const validMappings = validMappingsForVP(props.visualProperty.type).filter(
     (mappingType) => {
       if (column === '') {
         return true

--- a/src/models/NetworkModel/impl/CyNetwork.ts
+++ b/src/models/NetworkModel/impl/CyNetwork.ts
@@ -17,13 +17,13 @@ type GroupType = typeof GroupType[keyof typeof GroupType]
 /**
  * Private class implementing graph object using
  * Cytoscape.js
- * 
+ *
  * Simply stores graph structure only, no attributes
- * 
+ *
  */
 class CyNetwork implements Network {
   readonly id: IdType
-  
+
   // Graph storage, using Cytoscape
   // Only topology is stored here, attributes are stored in the table
   private readonly _store: Core
@@ -32,7 +32,6 @@ class CyNetwork implements Network {
     this.id = id
     this._store = createCyDataStore()
   }
-
 
   get nodes(): Node[] {
     return this._store.nodes().map((node: NodeSingular) => ({
@@ -74,6 +73,8 @@ export const createNetwork = (id: IdType): Network => new CyNetwork(id)
 // when converting cx ids to cy ids, we add a prefix to edges
 export const translateCXEdgeId = (id: IdType): IdType => `e${id}`
 
+export const translateEdgeIdToCX = (id: IdType): IdType => id.slice(1)
+
 /**
  * Create a network from a CX object
  *
@@ -83,7 +84,6 @@ export const translateCXEdgeId = (id: IdType): IdType => `e${id}`
  *
  */
 export const createNetworkFromCx = (id: IdType, cx: Cx2): Network => {
-
   // Create an empty CyNetwork
   const cyNet: CyNetwork = new CyNetwork(id)
 
@@ -113,10 +113,10 @@ export const createNetworkFromCx = (id: IdType, cx: Cx2): Network => {
 
 /**
  * Create a Cytoscape.js object from a Cyjs JSON
- * 
- * @param id 
- * @param cyJson 
- * @returns 
+ *
+ * @param id
+ * @param cyJson
+ * @returns
  */
 export const createFromCyJson = (id: IdType, cyJson: object): Network => {
   const cyNet: CyNetwork = new CyNetwork(id)
@@ -125,18 +125,15 @@ export const createFromCyJson = (id: IdType, cyJson: object): Network => {
   return cyNet
 }
 
-const addToCyStoreFromLists = (network:Network, cyNet: CyNetwork):void => {
+const addToCyStoreFromLists = (network: Network, cyNet: CyNetwork): void => {
   cyNet.store.add(
     network.nodes.map((node: Node) => createCyNode(node.id.toString())),
   )
 
   cyNet.store.add(
-    network.edges.map((edge: Edge) => createCyEdge(
-        edge.id.toString(),
-        edge.s.toString(),
-        edge.t.toString(),
-      )
-    )
+    network.edges.map((edge: Edge) =>
+      createCyEdge(edge.id.toString(), edge.s.toString(), edge.t.toString()),
+    ),
   )
 }
 

--- a/src/models/NetworkSummaryModel/NdexNetworkProperty.ts
+++ b/src/models/NetworkSummaryModel/NdexNetworkProperty.ts
@@ -1,9 +1,9 @@
 import { IdType } from '../IdType'
-import { ValueTypeName } from '../TableModel'
+import { ValueTypeName, ValueType } from '../TableModel'
 
 export interface NdexNetworkProperty {
   subNetworkId: IdType | null
-  value: string
+  value: ValueType
   predicateString: string
   dataType: ValueTypeName
 }

--- a/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
+++ b/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
@@ -1,21 +1,6 @@
 import { ValueTypeName } from '../../TableModel'
 import { SingleValueType } from '../../TableModel/ValueType'
-import {
-  ContinuousMappingFunction,
-  MappingFunctionType,
-  VisualPropertyValueTypeName,
-  VisualPropertyValueType,
-  VisualProperty,
-  DiscreteMappingFunction,
-  PassthroughMappingFunction,
-} from '..'
-
-import {
-  CXContinuousMappingFunction,
-  CXDiscreteMappingFunction,
-  CXPassthroughMappingFunction,
-  CXVisualPropertyValue,
-} from './cxVisualPropertyConverter'
+import { MappingFunctionType, VisualPropertyValueTypeName } from '..'
 
 const valueType2BaseType: Record<ValueTypeName, SingleValueType | null> = {
   [ValueTypeName.String]: 'string',
@@ -34,12 +19,11 @@ const valueType2BaseType: Record<ValueTypeName, SingleValueType | null> = {
 // Until then, only return valid mappings for a given visual property
 // Continuous mappings cannot be applied to vps that are not numbers or colors
 export const validMappingsForVP = (
-  vp: VisualProperty<VisualPropertyValueType>,
+  vpType: VisualPropertyValueTypeName,
 ): MappingFunctionType[] => {
-  const { type } = vp
   if (
-    type === VisualPropertyValueTypeName.Number ||
-    type === VisualPropertyValueTypeName.Color
+    vpType === VisualPropertyValueTypeName.Number ||
+    vpType === VisualPropertyValueTypeName.Color
   ) {
     return [
       MappingFunctionType.Continuous,
@@ -80,79 +64,4 @@ export const typesCanBeMapped = (
   }
 
   return true
-}
-
-export const convertPassthroughMappingToCX = (
-  mapping: PassthroughMappingFunction,
-): CXPassthroughMappingFunction => {
-  const { attribute } = mapping
-
-  return {
-    type: 'PASSTHROUGH',
-    definition: {
-      attribute,
-    },
-  }
-}
-
-export const convertDiscreteMappingToCX = (
-  mapping: DiscreteMappingFunction,
-): CXDiscreteMappingFunction<CXVisualPropertyValue> => {
-  const { vpValueMap, attribute } = mapping
-
-  return {
-    type: 'DISCRETE',
-    definition: {
-      attribute,
-      map: Array.from(vpValueMap.entries()).map(([value, vpValue]) => ({
-        v: value,
-        vp: vpValue,
-      })),
-    },
-  }
-}
-export const convertContinuousMappingToCX = (
-  mapping: ContinuousMappingFunction,
-): CXContinuousMappingFunction<CXVisualPropertyValue> => {
-  const { min, max, controlPoints, attribute } = mapping
-
-  const intervals = []
-
-  for (let i = 0; i < controlPoints.length - 1; i++) {
-    const curr = controlPoints[i]
-    const next = controlPoints[i + 1]
-
-    if (curr != null && next != null) {
-      intervals.push({
-        min: curr.value as number,
-        max: next.value as number,
-        minVPValue: curr.vpValue,
-        maxVPValue: next.vpValue,
-        includeMin: curr.inclusive ?? true,
-        includeMax: next.inclusive ?? true,
-      })
-    }
-  }
-
-  return {
-    type: 'CONTINUOUS',
-    definition: {
-      map: [
-        {
-          max: min.value as number,
-          maxVPValue: min.vpValue,
-          includeMax: min.inclusive ?? true,
-          includeMin: true, // dummy value, not actually used here
-        },
-        ...intervals,
-        {
-          min: max.value as number,
-          minVPValue: max.vpValue,
-          includeMin: max.inclusive ?? true,
-          includeMax: true, // dummy value, not actually used here
-        },
-      ],
-      attribute,
-    },
-  }
 }

--- a/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
+++ b/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
@@ -6,9 +6,16 @@ import {
   VisualPropertyValueTypeName,
   VisualPropertyValueType,
   VisualProperty,
+  DiscreteMappingFunction,
+  PassthroughMappingFunction,
 } from '..'
 
-import { CXContinuousMappingFunction } from './cxVisualPropertyConverter'
+import {
+  CXContinuousMappingFunction,
+  CXDiscreteMappingFunction,
+  CXPassthroughMappingFunction,
+  CXVisualPropertyValue,
+} from './cxVisualPropertyConverter'
 
 const valueType2BaseType: Record<ValueTypeName, SingleValueType | null> = {
   [ValueTypeName.String]: 'string',
@@ -75,9 +82,38 @@ export const typesCanBeMapped = (
   return true
 }
 
-export const convertContinuousMappingToCx = (
+export const convertPassthroughMappingToCX = (
+  mapping: PassthroughMappingFunction,
+): CXPassthroughMappingFunction => {
+  const { attribute } = mapping
+
+  return {
+    type: 'PASSTHROUGH',
+    definition: {
+      attribute,
+    },
+  }
+}
+
+export const convertDiscreteMappingToCX = (
+  mapping: DiscreteMappingFunction,
+): CXDiscreteMappingFunction<CXVisualPropertyValue> => {
+  const { vpValueMap, attribute } = mapping
+
+  return {
+    type: 'DISCRETE',
+    definition: {
+      attribute,
+      map: Array.from(vpValueMap.entries()).map(([value, vpValue]) => ({
+        v: value,
+        vp: vpValue,
+      })),
+    },
+  }
+}
+export const convertContinuousMappingToCX = (
   mapping: ContinuousMappingFunction,
-): CXContinuousMappingFunction<VisualPropertyValueType> => {
+): CXContinuousMappingFunction<CXVisualPropertyValue> => {
   const { min, max, controlPoints, attribute } = mapping
 
   const intervals = []

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -12,13 +12,23 @@ import {
   EdgeLineType,
   EdgeArrowShapeType,
 } from '../VisualPropertyValue'
+import {
+  DiscreteMappingFunction,
+  ContinuousMappingFunction,
+  PassthroughMappingFunction,
+  VisualProperty,
+  VisualStyle,
+} from '..'
 
 type CXLabelPositionValueType = 'center' | 'top' | 'bottom' | 'left' | 'right'
-interface CXLabelPositionType {
+export interface CXLabelPositionType {
   HORIZONTAL_ALIGN: CXLabelPositionValueType
   VERTICAL_ALIGN: CXLabelPositionValueType
   HORIZONTAL_ANCHOR: CXLabelPositionValueType
   VERTICAL_ANCHOR: CXLabelPositionValueType
+  MARGIN_X: number
+  MARGIN_Y: number
+  JUSTIFICATION: CXLabelPositionValueType
 }
 
 interface CXFontFaceType {
@@ -31,6 +41,7 @@ export type CXVisualPropertyValue =
   | VisualPropertyValueType
   | CXLabelPositionType
   | CXFontFaceType
+  | CXLabelPositionType
 
 export interface CXDiscreteMappingFunction<T> {
   type: 'DISCRETE'
@@ -71,6 +82,121 @@ export type CXVisualMappingFunction<T> =
   | CXPassthroughMappingFunction
 
 export type CXId = number
+
+export const vpToCX = (
+  vpName: VisualPropertyName,
+  vpValue: VisualPropertyValueType,
+): CXVisualPropertyValue => {
+  const defaultNodeLabelPosition: CXLabelPositionType = {
+    HORIZONTAL_ALIGN: 'center',
+    HORIZONTAL_ANCHOR: 'center',
+    JUSTIFICATION: 'center',
+    MARGIN_X: 0.0,
+    MARGIN_Y: 0.0,
+    VERTICAL_ALIGN: 'center',
+    VERTICAL_ANCHOR: 'center',
+  }
+
+  const defaultFontValue: CXVisualPropertyValue = {
+    FONT_FAMILY: 'sans-serif',
+    FONT_STYLE: 'normal',
+    FONT_WEIGHT: 'normal',
+  }
+
+  if (
+    vpName === 'nodeLabelVerticalAlign' ||
+    vpName === 'nodeLabelHorizontalAlign'
+  ) {
+    return Object.assign({}, defaultNodeLabelPosition)
+  }
+
+  if (vpName === 'nodeLabelFont' || vpName === 'edgeLabelFont') {
+    return Object.assign({}, defaultFontValue, { FONT_FAMILY: vpValue })
+  }
+
+  return vpValue as CXVisualPropertyValue
+}
+
+export const convertPassthroughMappingToCX = (
+  vs: VisualStyle,
+  vp: VisualProperty<VisualPropertyValueType>,
+  mapping: PassthroughMappingFunction,
+): CXPassthroughMappingFunction => {
+  const { attribute } = mapping
+
+  return {
+    type: 'PASSTHROUGH',
+    definition: {
+      attribute,
+    },
+  }
+}
+
+export const convertDiscreteMappingToCX = (
+  vs: VisualStyle,
+  vp: VisualProperty<VisualPropertyValueType>,
+  mapping: DiscreteMappingFunction,
+): CXDiscreteMappingFunction<CXVisualPropertyValue> => {
+  const { vpValueMap, attribute } = mapping
+
+  return {
+    type: 'DISCRETE',
+    definition: {
+      attribute,
+      map: Array.from(vpValueMap.entries()).map(([value, vpValue]) => ({
+        v: value,
+        vp: vpToCX(vp.name, vpValue),
+      })),
+    },
+  }
+}
+export const convertContinuousMappingToCX = (
+  vs: VisualStyle,
+  vp: VisualProperty<VisualPropertyValueType>,
+  mapping: ContinuousMappingFunction,
+): CXContinuousMappingFunction<CXVisualPropertyValue> => {
+  const { min, max, controlPoints, attribute } = mapping
+
+  const intervals = []
+
+  for (let i = 0; i < controlPoints.length - 1; i++) {
+    const curr = controlPoints[i]
+    const next = controlPoints[i + 1]
+
+    if (curr != null && next != null) {
+      intervals.push({
+        min: curr.value as number,
+        max: next.value as number,
+        minVPValue: vpToCX(vp.name, curr.vpValue),
+        maxVPValue: vpToCX(vp.name, next.vpValue),
+        includeMin: curr.inclusive ?? true,
+        includeMax: next.inclusive ?? true,
+      })
+    }
+  }
+
+  return {
+    type: 'CONTINUOUS',
+    definition: {
+      map: [
+        {
+          max: min.value as number,
+          maxVPValue: vpToCX(vp.name, min.vpValue),
+          includeMax: min.inclusive ?? true,
+          includeMin: true, // dummy value, not actually used here
+        },
+        ...intervals,
+        {
+          min: max.value as number,
+          minVPValue: vpToCX(vp.name, max.vpValue),
+          includeMin: max.inclusive ?? true,
+          includeMax: true, // dummy value, not actually used here
+        },
+      ],
+      attribute,
+    },
+  }
+}
 
 export interface CXVisualPropertyConverter<T> {
   cxVPName: string

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -1,3 +1,4 @@
+import { CxValue } from '../../../utils/cx/Cx2/CxValue'
 import { VisualPropertyName } from '../VisualPropertyName'
 import {
   ColorType,
@@ -36,7 +37,7 @@ export interface CXDiscreteMappingFunction<T> {
   definition: {
     attribute: string
     map: Array<{
-      v: number
+      v: CxValue
       vp: T
     }>
   }

--- a/src/store/NetworkSummaryStore.ts
+++ b/src/store/NetworkSummaryStore.ts
@@ -26,6 +26,7 @@ interface NetworkSummaryActions {
     url: string,
     accessToken?: string,
   ) => Promise<void>
+  update: (id: IdType, summary: Partial<NdexNetworkSummary>) => void
   delete: (networkId: IdType) => void
 }
 
@@ -63,7 +64,7 @@ const networkSummaryFetcher = async (
 }
 
 export const useNetworkSummaryStore = create(
-  immer<NetworkSummaryStore & NetworkSummaryActions>((set) => ({
+  immer<NetworkSummaryStore & NetworkSummaryActions>((set, get) => ({
     summaries: {},
     fetch: async (networkId: IdType, url: string, accessToken?: string) => {
       const localData: NdexNetworkSummary | undefined =
@@ -156,6 +157,19 @@ export const useNetworkSummaryStore = create(
       })
 
       // return newSummaries
+    },
+    update: (networkId: IdType, summaryUpdate: Partial<NdexNetworkSummary>) => {
+      const summary = get().summaries[networkId]
+      if (summary === undefined) {
+        return
+      }
+      set((state) => {
+        const newSummary = { ...summary, ...summaryUpdate }
+        const newSummaries = { ...state.summaries, [networkId]: newSummary }
+        return {
+          summaries: newSummaries,
+        }
+      })
     },
     delete: (networkId: IdType) => {
       set((state) => {

--- a/src/store/exportCX.ts
+++ b/src/store/exportCX.ts
@@ -1,0 +1,268 @@
+import {
+  AttributeName,
+  Table,
+  ValueType,
+  ValueTypeName,
+  Column,
+} from '../models/TableModel'
+
+import { NetworkView } from '../models/ViewModel'
+import { Network } from '../models/NetworkModel'
+
+import { IdType } from '../models/IdType'
+import {
+  VisualStyle,
+  VisualPropertyName,
+  VisualProperty,
+  VisualPropertyValueType,
+} from '../models/VisualStyleModel'
+
+import { translateEdgeIdToCX } from '../models/NetworkModel/impl/CyNetwork'
+import {
+  CXVisualMappingFunction,
+  cxVisualPropertyConverter,
+  CXVisualPropertyValue,
+} from '../models/VisualStyleModel/impl/cxVisualPropertyConverter'
+import {
+  edgeVisualProperties,
+  networkVisualProperties,
+  nodeVisualProperties,
+} from '../models/VisualStyleModel/impl/VisualStyleImpl'
+
+import {
+  convertContinuousMappingToCX,
+  convertPassthroughMappingToCX,
+  convertDiscreteMappingToCX,
+} from '../models/VisualStyleModel/impl/MappingFunctionImpl'
+import {
+  ContinuousMappingFunction,
+  DiscreteMappingFunction,
+  PassthroughMappingFunction,
+} from '../models/VisualStyleModel/VisualMappingFunction'
+
+export const exportNetworkToCx2 = (
+  network: Network,
+  vs: VisualStyle,
+  // networkSummary: NdexNetworkSummary,
+  nodeTable: Table,
+  edgeTable: Table,
+  networkView: NetworkView,
+): any => {
+  //   networkSummary.properties.forEach((property) => {
+  // attributeDeclarations[0].networkAttributes[property.predicateString] = {
+  //     d: property.dataType,
+  //     v: property.value,
+  // }
+  //   })
+
+  const networkAttributes: any = {}
+
+  const convertAttributes = (
+    acc: { [key: AttributeName]: { d: ValueTypeName; v?: ValueType } },
+    column: Column,
+  ) => {
+    acc[column.name] = {
+      d: column.type,
+    }
+
+    if (column.defaultValue) {
+      acc[column.name].v = column.defaultValue
+    }
+
+    return acc
+  }
+
+  const nodeAttributes: any = Array.from(nodeTable.columns.values()).reduce(
+    convertAttributes,
+    {},
+  )
+
+  const edgeAttributes: any = Array.from(edgeTable.columns.values()).reduce(
+    convertAttributes,
+    {},
+  )
+
+  const attributeDeclarations = [
+    {
+      networkAttributes,
+      nodeAttributes,
+      edgeAttributes,
+    },
+  ]
+
+  const nodes = network.nodes.map((node) => {
+    const nodeRow = nodeTable.rows.get(node.id)
+
+    return {
+      id: parseInt(node.id),
+      x: networkView.nodeViews[node.id].x,
+      y: networkView.nodeViews[node.id].y,
+      v: nodeRow,
+    }
+  })
+
+  const edges = network.edges.map((edge) => {
+    const edgeRow = edgeTable.rows.get(edge.id)
+    const edgeId = parseInt(translateEdgeIdToCX(edge.id))
+    const source = parseInt(edge.s)
+    const target = parseInt(edge.t)
+
+    return {
+      id: edgeId,
+      s: source,
+      t: target,
+      v: edgeRow,
+    }
+  })
+
+  const vpNameToCXName = (vpName: VisualPropertyName): string => {
+    return cxVisualPropertyConverter[vpName].cxVPName
+  }
+
+  // TODO flesh out CX vp types
+  type CXVPName = string
+
+  const populateDefaults = (
+    acc: { [key: CXVPName]: VisualPropertyValueType },
+    vp: VisualProperty<VisualPropertyValueType>,
+  ) => {
+    const { name, defaultValue } = vp
+    const cxVPName = vpNameToCXName(name)
+    acc[cxVPName] = defaultValue
+    return acc
+  }
+
+  const networkDefaultVps = networkVisualProperties(vs).reduce(
+    populateDefaults,
+    {},
+  )
+  const edgeDefaultVps = edgeVisualProperties(vs).reduce(populateDefaults, {})
+
+  const nodeDefaultVps = nodeVisualProperties(vs).reduce(populateDefaults, {})
+
+  const populateMapping = (
+    acc: { [key: CXVPName]: CXVisualMappingFunction<CXVisualPropertyValue> },
+    vp: VisualProperty<VisualPropertyValueType>,
+  ) => {
+    const { name, mapping } = vp
+    const cxVPName = vpNameToCXName(name)
+
+    if (mapping) {
+      switch (mapping.type) {
+        case 'continuous': {
+          // TODO use the enum instead of hard coded string
+          const convertedMapping = convertContinuousMappingToCX(
+            mapping as ContinuousMappingFunction,
+          )
+          acc[cxVPName] = convertedMapping
+          break
+        }
+        case 'discrete': {
+          const convertedMapping = convertDiscreteMappingToCX(
+            mapping as DiscreteMappingFunction,
+          )
+          acc[cxVPName] = convertedMapping
+          break
+        }
+        case 'passthrough': {
+          const convertedMapping = convertPassthroughMappingToCX(
+            mapping as PassthroughMappingFunction,
+          )
+          acc[cxVPName] = convertedMapping
+          break
+        }
+      }
+    }
+    return acc
+  }
+
+  const nodeMapping = nodeVisualProperties(vs)
+    .filter((vp) => vp.mapping != null)
+    .reduce(populateMapping, {})
+
+  const edgeMapping = edgeVisualProperties(vs)
+    .filter((vp) => vp.mapping != null)
+    .reduce(populateMapping, {})
+
+  const visualProperties = {}
+
+  const populateBypasses = (
+    acc: { [key: IdType]: { [key: CXVPName]: CXVisualPropertyValue } },
+    vp: VisualProperty<VisualPropertyValueType>,
+  ) => {
+    const { name, bypassMap } = vp
+    const cxVPName = vpNameToCXName(name)
+
+    bypassMap.forEach((value, id) => {
+      if (!acc[id]) {
+        acc[id] = {}
+      }
+      acc[id][cxVPName] = value
+    })
+
+    return acc
+  }
+
+  const nodeBypasses = Object.entries(
+    nodeVisualProperties(vs)
+      .filter((vp) => vp.bypassMap.size > 0)
+      .reduce(populateBypasses, {}),
+  ).map(([id, bypassObj]) => {
+    return {
+      id: parseInt(id),
+      v: bypassObj,
+    }
+  })
+
+  const edgeBypasses = Object.entries(
+    edgeVisualProperties(vs)
+      .filter((vp) => vp.bypassMap.size > 0)
+      .reduce(populateBypasses, {}),
+  ).map(([id, bypassObj]) => {
+    return {
+      id: parseInt(translateEdgeIdToCX(id)),
+      v: bypassObj,
+    }
+  })
+
+  return [
+    {
+      CXVersion: '2.0',
+      hasFragments: false,
+    },
+    {
+      metaData: [],
+    },
+    {
+      attributeDeclarations,
+    },
+    {
+      networkAttributes: [],
+    },
+    {
+      nodes,
+    },
+    { edges },
+
+    {
+      visualEditorProperties: [
+        {
+          properties: {
+            nodeSizeLocked: false,
+          },
+        },
+      ],
+    },
+    { cyTableColumn: [] },
+    { cyHiddenAttributes: [] },
+    { visualProperties },
+    { nodeBypasses },
+    { edgeBypasses },
+    {
+      status: {
+        error: '',
+        success: true,
+      },
+    },
+  ]
+}

--- a/src/store/exportCX.ts
+++ b/src/store/exportCX.ts
@@ -10,7 +10,7 @@ import { NetworkView } from '../models/ViewModel'
 import { Network } from '../models/NetworkModel'
 
 import { IdType } from '../models/IdType'
-import {
+import VisualStyleFn, {
   VisualStyle,
   VisualPropertyName,
   VisualProperty,
@@ -23,11 +23,6 @@ import {
   cxVisualPropertyConverter,
   CXVisualPropertyValue,
 } from '../models/VisualStyleModel/impl/cxVisualPropertyConverter'
-import {
-  edgeVisualProperties,
-  networkVisualProperties,
-  nodeVisualProperties,
-} from '../models/VisualStyleModel/impl/VisualStyleImpl'
 
 import {
   convertContinuousMappingToCX,
@@ -60,12 +55,12 @@ export const exportNetworkToCx2 = (
   const attributesAccumulator = (
     attributes: { [key: AttributeName]: { d: ValueTypeName; v?: ValueType } },
     column: Column,
-  ) => {
+  ): { [key: AttributeName]: { d: ValueTypeName; v?: ValueType } } => {
     attributes[column.name] = {
       d: column.type,
     }
 
-    if (column.defaultValue) {
+    if (column.defaultValue != null) {
       attributes[column.name].v = column.defaultValue
     }
 
@@ -83,7 +78,7 @@ export const exportNetworkToCx2 = (
   const vpDefaultsAccumulator = (
     defaults: { [key: CXVPName]: VisualPropertyValueType },
     vp: VisualProperty<VisualPropertyValueType>,
-  ) => {
+  ): { [key: CXVPName]: VisualPropertyValueType } => {
     const { name, defaultValue } = vp
     const cxVPName = vpNameToCXName(name)
     defaults[cxVPName] = defaultValue
@@ -96,11 +91,11 @@ export const exportNetworkToCx2 = (
       [key: CXVPName]: CXVisualMappingFunction<CXVisualPropertyValue>
     },
     vp: VisualProperty<VisualPropertyValueType>,
-  ) => {
+  ): { [key: CXVPName]: CXVisualMappingFunction<CXVisualPropertyValue> } => {
     const { name, mapping } = vp
     const cxVPName = vpNameToCXName(name)
 
-    if (mapping) {
+    if (mapping != null) {
       switch (mapping.type) {
         case MappingFunctionType.Continuous: {
           const convertedMapping = convertContinuousMappingToCX(
@@ -132,12 +127,12 @@ export const exportNetworkToCx2 = (
   const vpBypassesAccumulator = (
     bypasses: { [key: IdType]: { [key: CXVPName]: CXVisualPropertyValue } },
     vp: VisualProperty<VisualPropertyValueType>,
-  ) => {
+  ): { [key: IdType]: { [key: CXVPName]: CXVisualPropertyValue } } => {
     const { name, bypassMap } = vp
     const cxVPName = vpNameToCXName(name)
 
     bypassMap.forEach((value, id) => {
-      if (!bypasses[id]) {
+      if (bypasses[id] == null) {
         bypasses[id] = {}
       }
       bypasses[id][cxVPName] = value
@@ -199,21 +194,30 @@ export const exportNetworkToCx2 = (
   const visualProperties = [
     {
       default: {
-        network: networkVisualProperties(vs).reduce(vpDefaultsAccumulator, {}),
-        edge: edgeVisualProperties(vs).reduce(vpDefaultsAccumulator, {}),
-        node: nodeVisualProperties(vs).reduce(vpDefaultsAccumulator, {}),
+        network: VisualStyleFn.networkVisualProperties(vs).reduce(
+          vpDefaultsAccumulator,
+          {},
+        ),
+        edge: VisualStyleFn.edgeVisualProperties(vs).reduce(
+          vpDefaultsAccumulator,
+          {},
+        ),
+        node: VisualStyleFn.nodeVisualProperties(vs).reduce(
+          vpDefaultsAccumulator,
+          {},
+        ),
       },
-      nodeMapping: nodeVisualProperties(vs)
+      nodeMapping: VisualStyleFn.nodeVisualProperties(vs)
         .filter((vp) => vp.mapping != null)
         .reduce(vpMappingsAccumulator, {}),
-      edgeMapping: edgeVisualProperties(vs)
+      edgeMapping: VisualStyleFn.edgeVisualProperties(vs)
         .filter((vp) => vp.mapping != null)
         .reduce(vpMappingsAccumulator, {}),
     },
   ]
 
   const nodeBypasses = Object.entries(
-    nodeVisualProperties(vs)
+    VisualStyleFn.nodeVisualProperties(vs)
       .filter((vp) => vp.bypassMap.size > 0)
       .reduce(vpBypassesAccumulator, {}),
   ).map(([id, bypassObj]) => {
@@ -224,7 +228,7 @@ export const exportNetworkToCx2 = (
   })
 
   const edgeBypasses = Object.entries(
-    edgeVisualProperties(vs)
+    VisualStyleFn.edgeVisualProperties(vs)
       .filter((vp) => vp.bypassMap.size > 0)
       .reduce(vpBypassesAccumulator, {}),
   ).map(([id, bypassObj]) => {

--- a/src/store/exportCX.ts
+++ b/src/store/exportCX.ts
@@ -60,10 +60,6 @@ export const exportNetworkToCx2 = (
       d: column.type,
     }
 
-    if (column.defaultValue != null) {
-      attributes[column.name].v = column.defaultValue
-    }
-
     return attributes
   }
 
@@ -238,9 +234,6 @@ export const exportNetworkToCx2 = (
     }
   })
 
-  const cyTableColumn: any = []
-  const cyHiddenAttributes: any = []
-
   const descriptor = {
     CXVersion: '2.0',
     hasFragments: false,
@@ -255,8 +248,6 @@ export const exportNetworkToCx2 = (
     { key: 'nodeBypasses', aspect: nodeBypasses },
     { key: 'edgeBypasses', aspect: edgeBypasses },
     { key: 'visualEditorProperties', aspect: visualEditorProperties },
-    { key: 'cyTableColumn', aspect: cyTableColumn },
-    { key: 'cyHiddenAttributes', aspect: cyHiddenAttributes },
   ]
 
   const status = {
@@ -274,7 +265,7 @@ export const exportNetworkToCx2 = (
   return [
     descriptor,
     { metaData },
-    ...aspects.map((aspect) => ({ [aspect.key]: aspect.aspect })),
+    ...aspects.map(({ key, aspect }) => ({ [key]: aspect })),
     { status },
   ]
 }


### PR DESCRIPTION
- add conversion function for exporting cytoscape web models to cx
- add two menu options to allow the user to overwrite the current network to it's counterpart in ndex or create a copy as a seperate network
- compare modification times between the network in ndex and the modification time in cytoscape web to check if there is conflicting modifications. 
- if there is a conflict, present the user with a choice to confirm overwrite or to create a copy
- anytime the network is modified or copied, update the modification time locally in cytoscape web
- 