### PR TITLE
fix issues with setting the current network id

### DIFF
--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -51,30 +51,30 @@ export const NetworkPropertyPanel = ({
     setExpanded(!expanded)
   }
 
-
-  const backgroundColor: string = currentNetworkId === id ? blueGrey[100] : '#FFFFFF'
+  const backgroundColor: string =
+    currentNetworkId === id ? blueGrey[100] : '#FFFFFF'
 
   return (
     <Accordion
       expanded={expanded}
       onChange={handleChange}
       onClick={() => {
-        setTimeout(() => {
-          setCurrentNetworkId(id)
-        }, 200)
+        setCurrentNetworkId(id)
       }}
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
         aria-controls="network-props-content"
         id="network-props-header"
-        sx={{ backgroundColor, width: '100%'}}
+        sx={{ backgroundColor, width: '100%' }}
       >
-        <Box sx={{ width: '100%'}}>
-          <Typography variant={'body1'} sx={{ width: '100%' }}>{summary.name}</Typography>
+        <Box sx={{ width: '100%' }}>
+          <Typography variant={'body1'} sx={{ width: '100%' }}>
+            {summary.name}
+          </Typography>
           <Typography
             variant={'subtitle2'}
-            sx={{width: '100%', color: theme.palette.text.secondary}}
+            sx={{ width: '100%', color: theme.palette.text.secondary }}
           >
             {`N: ${summary.nodeCount} (${selectedNodes.length}) / 
           E: ${summary.edgeCount} (${selectedEdges.length})`}

--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -69,12 +69,7 @@ export const CopyNetworkToNDExMenuItem = (
     try {
       const { uuid } = await ndexClient.createNetworkFromRawCX2(cx)
       addNetworkToWorkspace(uuid as IdType)
-      // in the other places that this function is used, it seems that a setTimeout is required
-      // for it to work properly
-      // todo this should not be necessary
-      setTimeout(() => {
-        setCurrentNetworkId(uuid as IdType)
-      }, 500)
+      setCurrentNetworkId(uuid as IdType)
 
       console.log(
         `Saved a copy of the current network to NDEx with new uuid ${

--- a/src/components/ToolBar/DataMenu/LoadFromNdexMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexMenuItem.tsx
@@ -38,7 +38,7 @@ export const LoadFromNdexMenuItem = (props: BaseMenuProps): ReactElement => {
     }
 
     if (nextCurrentNetworkId !== undefined) {
-      setTimeout(() => setCurrentNetworkId(nextCurrentNetworkId as IdType), 500)
+      setCurrentNetworkId(nextCurrentNetworkId)
     }
     setOpenDialog(false)
     props.handleClose()

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -108,12 +108,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     try {
       const { uuid } = await ndexClient.createNetworkFromRawCX2(cx)
       addNetworkToWorkspace(uuid as IdType)
-      // in the other places that this function is used, it seems that a setTimeout is required
-      // for it to work properly
-      // todo this should not be necessary
-      setTimeout(() => {
-        setCurrentNetworkId(uuid as IdType)
-      }, 500)
+      setCurrentNetworkId(uuid as IdType)
 
       console.log(
         `Saved a copy of the current network to NDEx with new uuid ${

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -207,13 +207,22 @@ const WorkSpaceEditor: React.FC = () => {
     }
   }, [currentNetworkId])
 
+  /**
+   * if there is no current network id set, set the first network in the workspace to the current network
+   */
   useEffect(() => {
     let curId: IdType = ''
-    if (Object.keys(summaries).length !== 0) {
-      curId = Object.keys(summaries)[0]
+    if (
+      currentNetworkId === undefined ||
+      currentNetworkId === '' ||
+      !workspace.networkIds.includes(currentNetworkId)
+    ) {
+      if (Object.keys(summaries).length !== 0) {
+        curId = Object.keys(summaries)[0]
+        setCurrentNetworkId(curId)
+      }
     }
-    setCurrentNetworkId(curId)
-  }, [summaries])
+  }, [summaries, currentNetworkId])
 
   // TODO: avoid hardcoding pixel values
   return (


### PR DESCRIPTION
- sometimes calling setCurrentNetworkId would not change the network properly because of a useEffect that would always set the current network id to the first network id in the workspace
- change this behaviour to only set the current network id if it is not set yet.