### PR TITLE
Fix bypass UI hover

### DIFF
--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -204,6 +204,19 @@ const CyjsRenderer = ({ network }: NetworkRendererProps): ReactElement => {
     console.log('#Time to  apply style: ', performance.now() - t1)
   }
 
+  const applyHoverUpdate = (): void => {
+    if (cy === null) {
+      return
+    }
+    if (networkView.hoveredElement !== undefined) {
+      cy.elements().removeClass('hover')
+      const ele = cy.getElementById(networkView.hoveredElement)
+      if (ele !== undefined) {
+        ele.addClass('hover')
+      }
+    }
+  }
+
   // when the id changes, reset the cyjs element by
   // removing all elements and event listeners
   // this assumes we have a new network to render that was different from the current one
@@ -239,7 +252,7 @@ const CyjsRenderer = ({ network }: NetworkRendererProps): ReactElement => {
 
   // when hovered element changes, apply hover style to that element
   useEffect(() => {
-    applyStyleUpdate()
+    applyHoverUpdate()
   }, [networkView.hoveredElement])
 
   /**

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -253,7 +253,7 @@ const CyjsRenderer = ({ network }: NetworkRendererProps): ReactElement => {
   // when hovered element changes, apply hover style to that element
   useEffect(() => {
     applyHoverUpdate()
-  }, [networkView.hoveredElement])
+  }, [networkView?.hoveredElement])
 
   /**
    * Initializes the Cytoscape.js instance

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -204,18 +204,6 @@ const CyjsRenderer = ({ network }: NetworkRendererProps): ReactElement => {
     console.log('#Time to  apply style: ', performance.now() - t1)
   }
 
-  // TODO: fix this function for the new apply mechanism
-  // const applyHoverStyle = (): void => {
-  //   if (cy != null) {
-  //     cy.nodes().removeClass('hovered')
-  //     cy.edges().removeClass('hovered')
-
-  //     if (hoveredElement != null) {
-  //       cy.getElementById(hoveredElement).addClass('hovered')
-  //     }
-  //   }
-  // }
-
   // when the id changes, reset the cyjs element by
   // removing all elements and event listeners
   // this assumes we have a new network to render that was different from the current one
@@ -249,13 +237,10 @@ const CyjsRenderer = ({ network }: NetworkRendererProps): ReactElement => {
     applyUpdates()
   }, [vs, table])
 
-  // // when hovered element changes, apply hover style to that element
-  // useEffect(() => {
-  //   if (hoveredElement === null || hoveredElement === undefined) {
-  //     return
-  //   }
-  //   applyHoverStyle()
-  // }, [hoveredElement])
+  // when hovered element changes, apply hover style to that element
+  useEffect(() => {
+    applyStyleUpdate()
+  }, [networkView.hoveredElement])
 
   /**
    * Initializes the Cytoscape.js instance

--- a/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
+++ b/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
@@ -72,7 +72,7 @@ export const createCyjsDataMapper = (vs: VisualStyle): CyjsDirectMapper[] => {
     style: {
       'underlay-color': 'lightblue',
       'underlay-padding': 12,
-      'underlay-opacity': 0.3,
+      'underlay-opacity': 0.7,
       'underlay-shape': 'roundrectangle',
     },
   }

--- a/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
+++ b/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
@@ -85,6 +85,14 @@ export const applyViewModel = (cy: Core, networkView: NetworkView): void => {
   const { nodeViews, edgeViews } = networkView
   updateCyObjects<NodeView>(nodeViews, cy.nodes())
   updateCyObjects<EdgeView>(edgeViews, cy.edges())
+
+  if (networkView.hoveredElement !== undefined) {
+    cy.elements().removeClass('hover')
+    const ele = cy.getElementById(networkView.hoveredElement)
+    if (ele !== undefined) {
+      ele.addClass('hover')
+    }
+  }
 }
 
 const updateCyObjects = <T extends View>(

--- a/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
+++ b/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
@@ -85,14 +85,6 @@ export const applyViewModel = (cy: Core, networkView: NetworkView): void => {
   const { nodeViews, edgeViews } = networkView
   updateCyObjects<NodeView>(nodeViews, cy.nodes())
   updateCyObjects<EdgeView>(edgeViews, cy.edges())
-
-  if (networkView.hoveredElement !== undefined) {
-    cy.elements().removeClass('hover')
-    const ele = cy.getElementById(networkView.hoveredElement)
-    if (ele !== undefined) {
-      ele.addClass('hover')
-    }
-  }
 }
 
 const updateCyObjects = <T extends View>(

--- a/src/models/NetworkModel/impl/CyNetwork.ts
+++ b/src/models/NetworkModel/impl/CyNetwork.ts
@@ -12,7 +12,7 @@ import { Core, EdgeSingular, NodeSingular } from 'cytoscape'
 import * as cytoscape from 'cytoscape'
 
 const GroupType = { Nodes: 'nodes', Edges: 'edges' } as const
-type GroupType = typeof GroupType[keyof typeof GroupType]
+type GroupType = (typeof GroupType)[keyof typeof GroupType]
 
 /**
  * Private class implementing graph object using
@@ -72,6 +72,8 @@ export const createNetwork = (id: IdType): Network => new CyNetwork(id)
 // cy.js does not allow nodes and edges to have the same ids
 // when converting cx ids to cy ids, we add a prefix to edges
 export const translateCXEdgeId = (id: IdType): IdType => `e${id}`
+
+export const isEdgeId = (id: IdType): boolean => id.startsWith('e')
 
 export const translateEdgeIdToCX = (id: IdType): IdType => id.slice(1)
 

--- a/src/models/VisualStyleModel/impl/compute-view-util.ts
+++ b/src/models/VisualStyleModel/impl/compute-view-util.ts
@@ -95,7 +95,7 @@ export const updateNetworkView = (
   const { nodeViews } = networkView
   const mappers = buildMappers(vs)
 
-  return {
+  const nextView: NetworkView = {
     id: network.id,
     values: new Map<VisualPropertyName, VisualPropertyValueType>(),
     nodeViews: nodeViewBuilder(
@@ -114,6 +114,12 @@ export const updateNetworkView = (
     selectedNodes: networkView.selectedNodes,
     selectedEdges: networkView.selectedEdges,
   }
+
+  if (networkView.hoveredElement !== undefined) {
+    nextView.hoveredElement = networkView.hoveredElement
+  }
+
+  return nextView
 }
 
 const nodeViewBuilder = (

--- a/src/models/VisualStyleModel/impl/compute-view-util.ts
+++ b/src/models/VisualStyleModel/impl/compute-view-util.ts
@@ -111,8 +111,8 @@ export const updateNetworkView = (
       mappers,
       edgeTable,
     ),
-    selectedNodes: [],
-    selectedEdges: [],
+    selectedNodes: networkView.selectedNodes,
+    selectedEdges: networkView.selectedEdges,
   }
 }
 


### PR DESCRIPTION
- fix issues where hoveredElement and selectedNodes and selectedEdges were not being persisted across networkView updates
- implement applyHoverUpdate() in the cy.js renderer which applies hover styles when hoveredElement changes