### PR TITLE
Network modified and model save

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "no-prototype-builtins": "off",
     "@typescript-eslint/no-misused-promises": "off",
     "@typescript-eslint/promise-function-async": "off",
+    "@typescript-eslint/no-dynamic-delete": "off",
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "d3-scale": "^4.0.2",
         "dexie": "^3.2.2",
         "dexie-react-hooks": "^1.1.1",
+        "html-react-parser": "^3.0.12",
         "idb-keyval": "^6.2.0",
         "immer": "^9.0.16",
         "keycloak-js": "^21.0.0",
@@ -8582,7 +8583,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8702,7 +8702,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
       "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -10865,6 +10864,73 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-3.1.5.tgz",
+      "integrity": "sha512-9KTy2C7G7OcDDvnJ3Y7np84RF3OuO7X0PE5ZXyrNdOTI9NYam8thaUtxGEIM5lUqJkJR8T1aVe+zlN6H4PCtuA==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "8.0.1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -10908,6 +10974,34 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-3.0.12.tgz",
+      "integrity": "sha512-eOXg0EvKhXjYjljd8gtBPzL8Pqf49uRrb9JAjYLlqYFr95E+HoCvGt0/w0J1E/fR1ArsEMWY+K6M4/wUuvaQ5Q==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "3.1.5",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.3"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/html-react-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -11222,6 +11316,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -16537,6 +16636,11 @@
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "node_modules/react-reconciler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
@@ -18334,6 +18438,22 @@
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "peer": true
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.3.tgz",
+      "integrity": "sha512-zKI5gN/zb7LS/Vm0eUwjmjrXWw8IMtyA8aPBJZdYiQTXj4+wQ3IucOLIOnF7zCHxvW8UhIGh/uZh/t9zEHXNTQ==",
+      "dependencies": {
+        "style-to-object": "0.4.1"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "node_modules/stylis": {
       "version": "4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19566,9 +19566,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "d3-scale": "^4.0.2",
     "dexie": "^3.2.2",
     "dexie-react-hooks": "^1.1.1",
+    "html-react-parser": "^3.0.12",
     "idb-keyval": "^6.2.0",
     "immer": "^9.0.16",
     "keycloak-js": "^21.0.0",

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material'
 import { ReactElement, useEffect, useRef } from 'react'
 import { Outlet, useNavigate, useLocation } from 'react-router-dom'
-import { Workspace } from '../models/WorkspaceModel'
 import { useWorkspaceStore } from '../store/WorkspaceStore'
+import { getWorkspaceFromDb } from '../store/persist/db'
 
 import { ToolBar } from './ToolBar'
 
@@ -17,8 +17,9 @@ const AppShell = (): ReactElement => {
 
   const navigate = useNavigate()
   const location = useLocation()
-  const initWorkspace = useWorkspaceStore((state) => state.init)
-  const workspace: Workspace = useWorkspaceStore((state) => state.workspace)
+  const setWorkspace = useWorkspaceStore((state) => state.set)
+  const workspace = useWorkspaceStore((state) => state.workspace)
+
   const { id } = workspace
 
   useEffect(() => {
@@ -26,7 +27,9 @@ const AppShell = (): ReactElement => {
       initializedRef.current = true
       // TODO: Is this the best way to check the initial state?
       if (id === '') {
-        initWorkspace()
+        void getWorkspaceFromDb().then((workspace) => {
+          setWorkspace(workspace)
+        })
       }
     }
   }, [])

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -208,7 +208,7 @@ const CyjsRenderer = ({ network }: NetworkRendererProps): ReactElement => {
     if (cy === null) {
       return
     }
-    if (networkView.hoveredElement !== undefined) {
+    if (networkView?.hoveredElement !== undefined) {
       cy.elements().removeClass('hover')
       const ele = cy.getElementById(networkView.hoveredElement)
       if (ele !== undefined) {

--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -1,17 +1,18 @@
 import { ReactElement, useState } from 'react'
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
+  Tooltip,
+  IconButton,
   Box,
   Theme,
   Typography,
+  Divider,
+  Paper,
+  Popover,
 } from '@mui/material'
 import { blueGrey } from '@mui/material/colors'
 import { useTheme } from '@mui/material/styles'
+import EditIcon from '@mui/icons-material/Edit'
 
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import { SummaryPanel } from './SummaryPanel'
 import { IdType } from '../../models/IdType'
 import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
 import { useWorkspaceStore } from '../../store/WorkspaceStore'
@@ -26,6 +27,22 @@ export const NetworkPropertyPanel = ({
   summary,
 }: NetworkPropertyPanelProps): ReactElement => {
   const theme: Theme = useTheme()
+
+  const [editNetworkSummaryAnchorEl, setEditNetworkSummaryAnchorEl] = useState<
+    HTMLButtonElement | undefined
+  >(undefined)
+
+  const showEditNetworkSummaryForm = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ): void => {
+    event.stopPropagation()
+    setEditNetworkSummaryAnchorEl(event.currentTarget)
+  }
+
+  const hideEditNetworkSummaryForm = (event: any): void => {
+    event.stopPropagation()
+    setEditNetworkSummaryAnchorEl(undefined)
+  }
 
   const currentNetworkId: IdType = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
@@ -45,45 +62,65 @@ export const NetworkPropertyPanel = ({
     (state) => state.setCurrentNetworkId,
   )
 
-  const [expanded, setExpanded] = useState<boolean>(false)
-
-  const handleChange = (): void => {
-    setExpanded(!expanded)
-  }
-
   const backgroundColor: string =
     currentNetworkId === id ? blueGrey[100] : '#FFFFFF'
 
   return (
-    <Accordion
-      expanded={expanded}
-      onChange={handleChange}
-      onClick={() => {
-        setCurrentNetworkId(id)
-      }}
-    >
-      <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
-        aria-controls="network-props-content"
-        id="network-props-header"
-        sx={{ backgroundColor, width: '100%' }}
+    <>
+      <Divider />
+      <Box
+        sx={{
+          backgroundColor,
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          '&:hover': { cursor: 'pointer' },
+          p: 1,
+          pt: 2,
+          pb: 2,
+        }}
+        onClick={() => {
+          setCurrentNetworkId(id)
+        }}
       >
         <Box sx={{ width: '100%' }}>
-          <Typography variant={'body1'} sx={{ width: '100%' }}>
+          <Typography variant={'body2'} sx={{ width: '100%' }}>
             {summary.name}
           </Typography>
           <Typography
             variant={'subtitle2'}
             sx={{ width: '100%', color: theme.palette.text.secondary }}
           >
-            {`N: ${summary.nodeCount} (${selectedNodes.length}) / 
+            {`N: ${summary.nodeCount} (${selectedNodes.length}) /
           E: ${summary.edgeCount} (${selectedEdges.length})`}
           </Typography>
         </Box>
-      </AccordionSummary>
-      <AccordionDetails>
-        <SummaryPanel summary={summary} />
-      </AccordionDetails>
-    </Accordion>
+        <Tooltip title="Edit network properties">
+          <IconButton
+            size="small"
+            sx={{ width: 30, height: 30 }}
+            onClick={showEditNetworkSummaryForm}
+          >
+            <EditIcon sx={{ fontSize: 18 }} />
+          </IconButton>
+        </Tooltip>
+        <Popover
+          open={editNetworkSummaryAnchorEl !== undefined}
+          anchorEl={editNetworkSummaryAnchorEl}
+          onClose={hideEditNetworkSummaryForm}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+        >
+          <Paper sx={{ p: 1 }}>
+            <Typography variant={'body2'}>{summary.name}</Typography>
+            <Typography variant={'body2'}>
+              {JSON.stringify(summary, null, 2)}
+            </Typography>
+          </Paper>
+        </Popover>
+      </Box>
+    </>
   )
 }

--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -1,8 +1,10 @@
 import { ReactElement, useState } from 'react'
+import parse from 'html-react-parser'
 import {
   Tooltip,
   IconButton,
   Box,
+  Chip,
   Theme,
   Typography,
   Divider,
@@ -65,6 +67,12 @@ export const NetworkPropertyPanel = ({
   const backgroundColor: string =
     currentNetworkId === id ? blueGrey[100] : '#FFFFFF'
 
+  const descriptionContent = parse(summary.description ?? '')
+  const lastModifiedDate =
+    summary.modificationTime !== undefined
+      ? new Date(summary.modificationTime).toLocaleString()
+      : ''
+
   return (
     <>
       <Divider />
@@ -113,11 +121,36 @@ export const NetworkPropertyPanel = ({
             horizontal: 'right',
           }}
         >
-          <Paper sx={{ p: 1 }}>
-            <Typography variant={'body2'}>{summary.name}</Typography>
-            <Typography variant={'body2'}>
-              {JSON.stringify(summary, null, 2)}
+          <Paper
+            sx={{
+              p: 2,
+              width: '400px',
+              maxHeight: '600px',
+              overflowY: 'scroll',
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Typography variant={'body1'}>{summary.name ?? ''}</Typography>
+              <Chip
+                size="small"
+                label={
+                  <Typography variant="caption">
+                    {summary.visibility}
+                  </Typography>
+                }
+              />
+            </Box>
+            <Divider sx={{ pt: 1 }} />
+            <Typography variant="caption">
+              Last modified at: {lastModifiedDate}
             </Typography>
+            <Typography variant={'body2'}>{descriptionContent}</Typography>
           </Paper>
         </Popover>
       </Box>

--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { blueGrey } from '@mui/material/colors'
 import { useTheme } from '@mui/material/styles'
 import EditIcon from '@mui/icons-material/Edit'
+import CircleIcon from '@mui/icons-material/Circle'
 
 import { IdType } from '../../models/IdType'
 import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
@@ -64,6 +65,10 @@ export const NetworkPropertyPanel = ({
     (state) => state.setCurrentNetworkId,
   )
 
+  const networkModified = useWorkspaceStore(
+    (state) => state.workspace.networkModified[id],
+  )
+
   const backgroundColor: string =
     currentNetworkId === id ? blueGrey[100] : '#FFFFFF'
 
@@ -72,6 +77,12 @@ export const NetworkPropertyPanel = ({
     summary.modificationTime !== undefined
       ? new Date(summary.modificationTime).toLocaleString()
       : ''
+
+  const networkModifiedIcon = networkModified ? (
+    <Tooltip title="Network has been modified">
+      <CircleIcon sx={{ color: theme.palette.error.main, fontSize: 10 }} />
+    </Tooltip>
+  ) : null
 
   return (
     <>
@@ -92,8 +103,12 @@ export const NetworkPropertyPanel = ({
         }}
       >
         <Box sx={{ width: '100%' }}>
-          <Typography variant={'body2'} sx={{ width: '100%' }}>
+          <Typography
+            variant={'body2'}
+            sx={{ width: '100%', display: 'flex', alignItems: 'center' }}
+          >
             {summary.name}
+            {networkModifiedIcon}
           </Typography>
           <Typography
             variant={'subtitle2'}

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -60,6 +60,10 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     (state) => state.setCurrentNetworkId,
   )
 
+  const setNetworkModified = useWorkspaceStore(
+    (state) => state.setNetworkModified,
+  )
+
   const getToken = useCredentialStore((state) => state.getToken)
   const client = useCredentialStore((state) => state.client)
   const authenticated: boolean = client?.authenticated ?? false
@@ -78,6 +82,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     )
 
     // overwrite the current network on NDEx
+    console.log(ndexClient)
     await ndexClient.updateNetworkFromRawCX2(currentNetworkId, cx)
 
     // update the network summary with the newest modification time
@@ -86,6 +91,12 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     updateSummary(currentNetworkId, {
       modificationTime: newNdexModificationTime,
     })
+
+    setNetworkModified(currentNetworkId, false)
+
+    setTimeout(() => {
+      setCurrentNetworkId(currentNetworkId)
+    }, 500)
 
     setShowConfirmDialog(false)
     props.handleClose()

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -92,10 +92,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     })
 
     setNetworkModified(currentNetworkId, false)
-
-    setTimeout(() => {
-      setCurrentNetworkId(currentNetworkId)
-    }, 500)
+    setCurrentNetworkId(currentNetworkId)
 
     setShowConfirmDialog(false)
     props.handleClose()

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -82,7 +82,6 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     )
 
     // overwrite the current network on NDEx
-    console.log(ndexClient)
     await ndexClient.updateNetworkFromRawCX2(currentNetworkId, cx)
 
     // update the network summary with the newest modification time

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Suspense, useContext, useEffect, useState } from 'react'
 import { Allotment } from 'allotment'
+// import _ from 'lodash'
 import { Box, Tabs, Tab, Typography } from '@mui/material'
 import ShareIcon from '@mui/icons-material/Share'
 import PaletteIcon from '@mui/icons-material/Palette'
@@ -53,15 +54,25 @@ const WorkSpaceEditor: React.FC = () => {
     (state) => state.setCurrentNetworkId,
   )
 
+  const viewModels: Record<string, NetworkView> = useViewModelStore(
+    (state) => state.viewModels,
+  )
+
   const setNetworkModified: (id: IdType, isModified: boolean) => void =
     useWorkspaceStore((state) => state.setNetworkModified)
 
   useViewModelStore.subscribe(
     (state) => state.viewModels[currentNetworkId],
-    () => {
+    (prev: NetworkView, next: NetworkView) => {
+      // const viewModelChanged = !_.isEqual(prev, next)
+      const viewModelChanged = prev !== undefined && next !== undefined // assume view model changed when prev and next are defined
       const { networkModified } = workspace
-      const isModified: boolean | undefined = networkModified[currentNetworkId]
-      if (isModified !== undefined && !isModified) {
+      const currentNetworkIsNotModified =
+        networkModified[currentNetworkId] === undefined ??
+        !networkModified[currentNetworkId] ??
+        false
+
+      if (viewModelChanged && currentNetworkIsNotModified) {
         setNetworkModified(currentNetworkId, true)
       }
     },
@@ -93,9 +104,6 @@ const WorkSpaceEditor: React.FC = () => {
   const setTables = useTableStore((state) => state.setTables)
 
   const setViewModel = useViewModelStore((state) => state.setViewModel)
-  const viewModels: Record<string, NetworkView> = useViewModelStore(
-    (state) => state.viewModels,
-  )
 
   const loadNetworkSummaries = async (): Promise<void> => {
     // Check token first

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -68,13 +68,14 @@ const WorkSpaceEditor: React.FC = () => {
         prev !== undefined &&
         next !== undefined &&
         !_.isEqual(
-          _.omit(prev, ['hoveredElement', 'selectedNodes', 'selectedEdges']), //omit selection state and hovered element changes as valid viewModel changes
+          // omit selection state and hovered element changes as valid viewModel changes
+          _.omit(prev, ['hoveredElement', 'selectedNodes', 'selectedEdges']),
           _.omit(next, ['hoveredElement', 'selectedNodes', 'selectedEdges']),
         )
 
       // primitve compare fn that does not take into account the selection/hover state
       // this leads to the network having a 'modified' state even though nothing was modified
-      // const viewModelChanged = prev !== undefined && next !== undefined // assume view model changed when prev and next are defined
+      // const viewModelChanged = prev !== undefined && next !== undefined
       const { networkModified } = workspace
       const currentNetworkIsNotModified =
         networkModified[currentNetworkId] === undefined ??

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Suspense, useContext, useEffect, useState } from 'react'
 import { Allotment } from 'allotment'
-// import _ from 'lodash'
+import _ from 'lodash'
 import { Box, Tabs, Tab, Typography } from '@mui/material'
 import ShareIcon from '@mui/icons-material/Share'
 import PaletteIcon from '@mui/icons-material/Palette'
@@ -64,8 +64,17 @@ const WorkSpaceEditor: React.FC = () => {
   useViewModelStore.subscribe(
     (state) => state.viewModels[currentNetworkId],
     (prev: NetworkView, next: NetworkView) => {
-      // const viewModelChanged = !_.isEqual(prev, next)
-      const viewModelChanged = prev !== undefined && next !== undefined // assume view model changed when prev and next are defined
+      const viewModelChanged =
+        prev !== undefined &&
+        next !== undefined &&
+        !_.isEqual(
+          _.omit(prev, ['hoveredElement', 'selectedNodes', 'selectedEdges']), //omit selection state and hovered element changes as valid viewModel changes
+          _.omit(next, ['hoveredElement', 'selectedNodes', 'selectedEdges']),
+        )
+
+      // primitve compare fn that does not take into account the selection/hover state
+      // this leads to the network having a 'modified' state even though nothing was modified
+      // const viewModelChanged = prev !== undefined && next !== undefined // assume view model changed when prev and next are defined
       const { networkModified } = workspace
       const currentNetworkIsNotModified =
         networkModified[currentNetworkId] === undefined ??

--- a/src/store/NetworkStore.ts
+++ b/src/store/NetworkStore.ts
@@ -1,9 +1,9 @@
 import { IdType } from '../models/IdType'
 import NetworkFn, { Network } from '../models/NetworkModel'
-import { create } from 'zustand'
+import { create, StateCreator, StoreApi } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
-import { deleteNetworkFromDb } from './persist/db'
-
+import { deleteNetworkFromDb, putNetworkToDb } from './persist/db'
+import { useWorkspaceStore } from './WorkspaceStore'
 /**
  * Network State manager based on zustand
  */
@@ -27,76 +27,101 @@ interface NetworkActions {
   deleteAll: () => void
 }
 
+type NetworkStore = NetworkState & NetworkActions & UpdateActions
+
+const persist =
+  (config: StateCreator<NetworkStore>) =>
+  (
+    set: StoreApi<NetworkStore>['setState'],
+    get: StoreApi<NetworkStore>['getState'],
+    api: StoreApi<NetworkStore>,
+  ) =>
+    config(
+      async (args) => {
+        const currentNetworkId =
+          useWorkspaceStore.getState().workspace.currentNetworkId
+        console.log('persist middleware updating network store')
+        set(args)
+        const updated = get().networks.get(currentNetworkId)
+        console.log('new network store:', updated)
+        const deleted = updated === undefined
+        if (!deleted) {
+          await putNetworkToDb(updated).then(() => {})
+        }
+      },
+      get,
+      api,
+    )
+
 export const useNetworkStore = create(
-  immer<NetworkState & NetworkActions & UpdateActions>((set) => ({
-    networks: new Map<IdType, Network>(),
+  immer<NetworkStore>(
+    persist((set) => ({
+      networks: new Map<IdType, Network>(),
 
-    addNode: (networkId: IdType, nodeId: IdType) => {
-      set((state) => {
-        const network = state.networks.get(networkId)
-        if (network !== undefined) {
-          NetworkFn.addNode(network, nodeId)
-        }
-        return {
-          networks: { ...state.networks },
-        }
-      })
-    },
-
-    addNodes: (networkId: IdType, nodeIds: IdType[]) => {
-      set((state) => {
-        const network = state.networks.get(networkId)
-        if (network !== undefined) {
-          NetworkFn.addNodes(network, nodeIds)
-        }
-        return {
-          networks: { ...state.networks },
-        }
-      })
-    },
-
-    deleteNode: (networkId: IdType, nodeId: IdType) => {
-      set((state) => {
-        const network = state.networks.get(networkId)
-        if (network !== undefined) {
-          NetworkFn.deleteNode(network, nodeId)
-        }
-        return {
-          networks: { ...state.networks },
-        }
-      })
-    },
-
-    addEdge: (networkId: IdType, id: IdType, s: IdType, t: IdType) => {
-      set((state) => {
-        const network = state.networks.get(networkId)
-        if (network !== undefined) {
-          NetworkFn.addEdge(network, { id, s, t })
-        }
-        return {
-          networks: { ...state.networks },
-        }
-      })
-    },
-
-    add: (network: Network) =>
-      set((state) => {
-        const newNetworkMap = new Map(state.networks).set(network.id, network)
-        return {
-          networks: newNetworkMap,
-        }
-      }),
-    delete: (networkId: IdType) =>
-      set((state) => {
-        const newNetworkMap = new Map(state.networks)
-        newNetworkMap.delete(networkId)
-        void deleteNetworkFromDb(networkId).then(() => {
-          console.log('Network from db', networkId)
+      addNode: (networkId: IdType, nodeId: IdType) => {
+        set((state) => {
+          const network = state.networks.get(networkId)
+          if (network !== undefined) {
+            NetworkFn.addNode(network, nodeId)
+          }
+          return {
+            networks: { ...state.networks },
+          }
         })
-        return {
-          networks: newNetworkMap,
-        }
-      }),
-    deleteAll: () => set({ networks: new Map<IdType, Network>() }),
-  })),
+      },
+
+      addNodes: (networkId: IdType, nodeIds: IdType[]) => {
+        set((state) => {
+          const network = state.networks.get(networkId)
+          if (network !== undefined) {
+            NetworkFn.addNodes(network, nodeIds)
+          }
+          return {
+            networks: { ...state.networks },
+          }
+        })
+      },
+
+      deleteNode: (networkId: IdType, nodeId: IdType) => {
+        set((state) => {
+          const network = state.networks.get(networkId)
+          if (network !== undefined) {
+            NetworkFn.deleteNode(network, nodeId)
+          }
+          return {
+            networks: { ...state.networks },
+          }
+        })
+      },
+
+      addEdge: (networkId: IdType, id: IdType, s: IdType, t: IdType) => {
+        set((state) => {
+          const network = state.networks.get(networkId)
+          if (network !== undefined) {
+            NetworkFn.addEdge(network, { id, s, t })
+          }
+          return {
+            networks: { ...state.networks },
+          }
+        })
+      },
+
+      add: (network: Network) =>
+        set((state) => {
+          const newNetworkMap = new Map(state.networks).set(network.id, network)
+          return {
+            networks: newNetworkMap,
+          }
+        }),
+      delete: (networkId: IdType) =>
+        set((state) => {
+          state.networks.delete(networkId)
+          void deleteNetworkFromDb(networkId).then(() => {
+            console.log('Deleted network from db', networkId)
+          })
+          return state
+        }),
+      deleteAll: () => set({ networks: new Map<IdType, Network>() }),
+    })),
+  ),
 )

--- a/src/store/NetworkSummaryStore.ts
+++ b/src/store/NetworkSummaryStore.ts
@@ -163,6 +163,7 @@ export const useNetworkSummaryStore = create(
       if (summary === undefined) {
         return
       }
+      void putNetworkSummaryToDb({ ...summary, ...summaryUpdate })
       set((state) => {
         const newSummary = { ...summary, ...summaryUpdate }
         const newSummaries = { ...state.summaries, [networkId]: newSummary }
@@ -180,7 +181,7 @@ export const useNetworkSummaryStore = create(
             newSummaries[key] = summaries[key]
           }
         })
-        deleteNetworkSummaryFromDb(networkId)
+        void deleteNetworkSummaryFromDb(networkId)
           .then((val) => {
             console.log('Summary deleted', networkId, val)
           })

--- a/src/store/NetworkSummaryStore.ts
+++ b/src/store/NetworkSummaryStore.ts
@@ -2,161 +2,35 @@ import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 import { IdType } from '../models/IdType'
 import { NdexNetworkSummary } from '../models/NetworkSummaryModel'
-import {
-  deleteNetworkSummaryFromDb,
-  getNetworkSummariesFromDb,
-  getNetworkSummaryFromDb,
-  putNetworkSummaryToDb,
-} from './persist/db'
-// @ts-expect-error-next-line
-import { NDEx } from '@js4cytoscape/ndex-client'
+import { deleteNetworkSummaryFromDb, putNetworkSummaryToDb } from './persist/db'
 
 interface NetworkSummaryStore {
   summaries: Record<IdType, NdexNetworkSummary>
 }
 
 interface NetworkSummaryActions {
-  fetch: (
-    networkId: IdType,
-    url: string,
-    accessToken?: string,
-  ) => Promise<NdexNetworkSummary>
-  fetchAll: (
-    networkIds: IdType[],
-    url: string,
-    accessToken?: string,
-  ) => Promise<void>
+  set: (networkId: IdType, summary: NdexNetworkSummary) => void
+  setMultiple: (summaries: Record<IdType, NdexNetworkSummary>) => void
   update: (id: IdType, summary: Partial<NdexNetworkSummary>) => void
   delete: (networkId: IdType) => void
-}
-
-const networkSummaryFetcher = async (
-  id: IdType | IdType[],
-  url: string,
-  accessToken?: string,
-): Promise<NdexNetworkSummary | NdexNetworkSummary[]> => {
-  const ndexClient = new NDEx(`${url}/v2`)
-
-  if (accessToken !== undefined && accessToken !== '') {
-    ndexClient.setAuthToken(accessToken)
-  }
-
-  if (Array.isArray(id)) {
-    try {
-      const summaries: Promise<NdexNetworkSummary[]> =
-        await ndexClient.getNetworkSummariesByUUIDs(id)
-
-      return await summaries
-    } catch (error) {
-      console.error('Failed to fetch summary', error)
-      throw error
-    }
-  } else {
-    // Try local DB first
-    const cachedSummary = await getNetworkSummaryFromDb(id)
-    if (cachedSummary !== undefined) {
-      return cachedSummary
-    }
-    const summary: Promise<NdexNetworkSummary> =
-      ndexClient.getNetworkSummary(id)
-    return await summary
-  }
 }
 
 export const useNetworkSummaryStore = create(
   immer<NetworkSummaryStore & NetworkSummaryActions>((set, get) => ({
     summaries: {},
-    fetch: async (networkId: IdType, url: string, accessToken?: string) => {
-      const localData: NdexNetworkSummary | undefined =
-        await getNetworkSummaryFromDb(networkId)
-      if (localData !== undefined) {
-        return localData
-      }
-
-      const newSummary = (await networkSummaryFetcher(
-        networkId,
-        url,
-        accessToken,
-      )) as NdexNetworkSummary
-
+    set: (networkId: IdType, summary: NdexNetworkSummary) => {
       set((state) => {
-        // const newSummaries = new Map(state.summaries).set(networkId, newSummary)
-        return {
-          summaries: { ...state.summaries, newSummary },
-        }
-      })
+        state.summaries[networkId] = summary
 
-      return newSummary
+        return state
+      })
     },
-    fetchAll: async (
-      networkIds: IdType[],
-      url: string,
-      accessToken?: string,
-    ) => {
-      // Check local database first
-      const localData: NdexNetworkSummary[] = await getNetworkSummariesFromDb(
-        networkIds,
-      )
-
-      // "localdata" contains undefined if the list contains new network IDs
-
-      const results: NdexNetworkSummary[] = []
-
-      localData.forEach((summary) => {
-        if (summary !== undefined) {
-          results.push(summary)
-        }
-      })
-
-      const newIds: IdType[] = networkIds.filter(
-        (id) => !results.map((s) => s.externalId).includes(id),
-      )
-
-      let newSummaries: NdexNetworkSummary[] = []
-      if (results.length !== 0) {
-        const cached: NdexNetworkSummary[] = results
-        newSummaries = (await networkSummaryFetcher(
-          newIds,
-          url,
-          accessToken,
-        )) as NdexNetworkSummary[]
-
-        newSummaries = [...cached, ...newSummaries]
-        // Put those to DB
-      } else {
-        // NDEx server URL
-        newSummaries = (await networkSummaryFetcher(
-          networkIds,
-          url,
-          accessToken,
-        )) as NdexNetworkSummary[]
-      }
-      newSummaries.forEach(async (summary: NdexNetworkSummary) => {
-        await putNetworkSummaryToDb(summary)
-      })
-
-      const newSummaryRecord: Record<IdType, NdexNetworkSummary> =
-        newSummaries.reduce(
-          (summary, entry) => ({
-            ...summary,
-            [entry.externalId]: entry,
-          }),
-          {},
-        )
-
+    setMultiple: (summaries: Record<IdType, NdexNetworkSummary>) => {
       set((state) => {
-        if (newSummaries.length === 0) {
-          return state
-        }
+        state.summaries = { ...state.summaries, ...summaries }
 
-        const newRecord = { ...state.summaries, ...newSummaryRecord }
-
-        return {
-          summaries: newRecord,
-        }
+        return state
       })
-
-      // return newSummaries
     },
     update: (networkId: IdType, summaryUpdate: Partial<NdexNetworkSummary>) => {
       const summary = get().summaries[networkId]
@@ -165,22 +39,13 @@ export const useNetworkSummaryStore = create(
       }
       void putNetworkSummaryToDb({ ...summary, ...summaryUpdate })
       set((state) => {
-        const newSummary = { ...summary, ...summaryUpdate }
-        const newSummaries = { ...state.summaries, [networkId]: newSummary }
-        return {
-          summaries: newSummaries,
-        }
+        state.summaries[networkId] = { ...summary, ...summaryUpdate }
+        return state
       })
     },
     delete: (networkId: IdType) => {
       set((state) => {
-        const { summaries } = state
-        const newSummaries: Record<IdType, NdexNetworkSummary> = {}
-        Object.keys(summaries).forEach((key: IdType) => {
-          if (key !== networkId) {
-            newSummaries[key] = summaries[key]
-          }
-        })
+        delete state.summaries[networkId]
         void deleteNetworkSummaryFromDb(networkId)
           .then((val) => {
             console.log('Summary deleted', networkId, val)
@@ -189,9 +54,7 @@ export const useNetworkSummaryStore = create(
             console.error('', err)
           })
 
-        return {
-          summaries: { ...newSummaries },
-        }
+        return state
       })
     },
   })),

--- a/src/store/TableStore.ts
+++ b/src/store/TableStore.ts
@@ -1,11 +1,12 @@
 import { IdType } from '../models/IdType'
 import { AttributeName, Table, ValueType } from '../models/TableModel'
 
-import { create } from 'zustand'
+import { create, StateCreator, StoreApi } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 import { columnValueSet } from '../models/TableModel/impl/InMemoryTable'
 import { VisualPropertyGroup } from '../models/VisualStyleModel/VisualPropertyGroup'
-
+import { useWorkspaceStore } from './WorkspaceStore'
+import { deleteTablesFromDb, putTablesToDb } from './persist/db'
 /** */
 interface TableRecord {
   nodeTable: Table
@@ -42,94 +43,136 @@ interface TableAction {
   deleteAll: () => void
 }
 
+type TableStore = TableState & TableAction
+
+const persist =
+  (config: StateCreator<TableStore>) =>
+  (
+    set: StoreApi<TableStore>['setState'],
+    get: StoreApi<TableStore>['getState'],
+    api: StoreApi<TableStore>,
+  ) =>
+    config(
+      async (args) => {
+        const currentNetworkId =
+          useWorkspaceStore.getState().workspace.currentNetworkId
+        console.log('persist middleware updating table store')
+        set(args)
+        const updated = get().tables[currentNetworkId]
+        console.log('updated table: ', updated)
+        const deleted = updated === undefined
+        if (!deleted) {
+          await putTablesToDb(
+            currentNetworkId,
+            updated.nodeTable,
+            updated.edgeTable,
+          ).then(() => {})
+        }
+      },
+      get,
+      api,
+    )
+
 export const useTableStore = create(
-  immer<TableState & TableAction>((set, get) => ({
-    tables: {},
+  immer<TableStore>(
+    persist((set, get) => ({
+      tables: {},
 
-    setTables: (networkId: IdType, nodeTable: Table, edgeTable: Table) => {
-      set((state) => {
-        state.tables[networkId] = { nodeTable, edgeTable }
-      })
-    },
+      setTables: (networkId: IdType, nodeTable: Table, edgeTable: Table) => {
+        set((state) => {
+          state.tables[networkId] = { nodeTable, edgeTable }
+          return state
+        })
+      },
 
-    // Note:  The only code that calls this function makes sure the
-    // type of the column is the same as the type of the value
-    // TODO add type checking validation to this function
-    setValue: (
-      networkId: IdType,
-      tableType: 'node' | 'edge',
-      rowId: IdType,
-      column: AttributeName,
-      value: ValueType,
-    ) => {
-      set((state) => {
-        const table = state.tables[networkId]
-        const tableToUpdate =
-          tableType === VisualPropertyGroup.Node ? 'nodeTable' : 'edgeTable'
-        const row = table[tableToUpdate]?.rows.get(rowId)
-        if (row != null) {
-          row[column] = value
-        }
-      })
-    },
-    columnValues: (
-      networkId: IdType,
-      tableType: 'node' | 'edge',
-      column: AttributeName,
-    ): Set<ValueType> => {
-      const tables = get().tables
-      const nodeTable = tables[networkId]?.nodeTable
-      const edgeTable = tables[networkId]?.edgeTable
-      const table =
-        tableType === VisualPropertyGroup.Node ? nodeTable : edgeTable
-
-      return columnValueSet(table, column)
-    },
-    duplicateColumn(
-      networkId: IdType,
-      tableType: 'node' | 'edge',
-      column: AttributeName,
-    ) {
-      set((state) => {
-        const table = state.tables
-        const nodeTable = table[networkId]?.nodeTable
-        const edgeTable = table[networkId]?.edgeTable
-        const tableToUpdate =
+      // Note:  The only code that calls this function makes sure the
+      // type of the column is the same as the type of the value
+      // TODO add type checking validation to this function
+      setValue: (
+        networkId: IdType,
+        tableType: 'node' | 'edge',
+        rowId: IdType,
+        column: AttributeName,
+        value: ValueType,
+      ) => {
+        set((state) => {
+          const table = state.tables[networkId]
+          const tableToUpdate =
+            tableType === VisualPropertyGroup.Node ? 'nodeTable' : 'edgeTable'
+          const row = table[tableToUpdate]?.rows.get(rowId)
+          if (row != null) {
+            row[column] = value
+          }
+          return state
+        })
+      },
+      columnValues: (
+        networkId: IdType,
+        tableType: 'node' | 'edge',
+        column: AttributeName,
+      ): Set<ValueType> => {
+        const tables = get().tables
+        const nodeTable = tables[networkId]?.nodeTable
+        const edgeTable = tables[networkId]?.edgeTable
+        const table =
           tableType === VisualPropertyGroup.Node ? nodeTable : edgeTable
-        const columnToDuplicate = tableToUpdate?.columns.get(column)
-        if (columnToDuplicate != null) {
-          const newColumn = {
-            ...columnToDuplicate,
-            name: `${columnToDuplicate.name}_copy_${Date.now()}`,
-          }
-          tableToUpdate?.columns.set(newColumn.name, newColumn)
 
-          Array.from((tableToUpdate?.rows ?? new Map()).entries()).forEach(
-            ([nodeId, nodeAttr]) => {
-              nodeAttr[newColumn.name] = nodeAttr[column]
-              tableToUpdate.rows.set(nodeId, nodeAttr)
-            },
-          )
-        }
-      })
-    },
-    delete(networkId: IdType) {
-      set((state) => {
-        const filtered: Record<IdType, TableRecord> = Object.keys(
-          state.tables,
-        ).reduce((acc: Record<IdType, TableRecord>, id) => {
-          if (id !== networkId) {
-            acc[id] = state.tables[id]
+        return columnValueSet(table, column)
+      },
+      duplicateColumn(
+        networkId: IdType,
+        tableType: 'node' | 'edge',
+        column: AttributeName,
+      ) {
+        set((state) => {
+          const table = state.tables
+          const nodeTable = table[networkId]?.nodeTable
+          const edgeTable = table[networkId]?.edgeTable
+          const tableToUpdate =
+            tableType === VisualPropertyGroup.Node ? nodeTable : edgeTable
+          const columnToDuplicate = tableToUpdate?.columns.get(column)
+          if (columnToDuplicate != null) {
+            const newColumn = {
+              ...columnToDuplicate,
+              name: `${columnToDuplicate.name}_copy_${Date.now()}`,
+            }
+            tableToUpdate?.columns.set(newColumn.name, newColumn)
+
+            Array.from((tableToUpdate?.rows ?? new Map()).entries()).forEach(
+              ([nodeId, nodeAttr]) => {
+                nodeAttr[newColumn.name] = nodeAttr[column]
+                tableToUpdate.rows.set(nodeId, nodeAttr)
+              },
+            )
           }
-          return acc
-        }, {})
-        state.tables = filtered
-      })
-    },
-    deleteAll() {
-      set((state) => {
-        state.tables = {}
-      })
-    },
-  })),
+
+          return state
+        })
+      },
+      delete(networkId: IdType) {
+        set((state) => {
+          const filtered: Record<IdType, TableRecord> = Object.keys(
+            state.tables,
+          ).reduce((acc: Record<IdType, TableRecord>, id) => {
+            if (id !== networkId) {
+              acc[id] = state.tables[id]
+            }
+            return acc
+          }, {})
+          state.tables = filtered
+
+          void deleteTablesFromDb(networkId).then(() => {
+            console.log('Deleted network table from db', networkId)
+          })
+          return state
+        })
+      },
+      deleteAll() {
+        set((state) => {
+          state.tables = {}
+          return state
+        })
+      },
+    })),
+  ),
 )

--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -106,10 +106,17 @@ const persist =
       async (args) => {
         const currentNetworkId =
           useWorkspaceStore.getState().workspace.currentNetworkId
+        console.log('persist middleware updating visual style store')
+
         set(args)
         const updated = get().visualStyles[currentNetworkId]
-        console.log('updated', updated)
-        await putVisualStyleToDb(currentNetworkId, updated).then(() => {})
+        console.log('updated visual style: ', updated)
+
+        const deleted = updated === undefined
+
+        if (!deleted) {
+          await putVisualStyleToDb(currentNetworkId, updated).then(() => {})
+        }
       },
       get,
       api,
@@ -374,7 +381,7 @@ export const useVisualStyleStore = create(
             return acc
           }, {})
           void deleteVisualStyleFromDb(networkId).then(() => {
-            console.log('# deleted visual style from db')
+            console.log('Deleted visual style from db', networkId)
           })
           return {
             ...state,

--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -208,7 +208,6 @@ export const useVisualStyleStore = create(
             mapping.min = min
             mapping.max = max
             mapping.controlPoints = controlPoints
-            console.log('continuous mapping called')
           }
           return state
         })

--- a/src/store/WorkspaceStore.ts
+++ b/src/store/WorkspaceStore.ts
@@ -1,16 +1,16 @@
-import { create } from 'zustand'
+import { create, StateCreator, StoreApi } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 import { IdType } from '../models/IdType'
 import { Workspace } from '../models/WorkspaceModel'
-import { getWorkspaceFromDb, updateWorkspaceDb } from './persist/db'
+import { putWorkspaceToDb } from './persist/db'
 
-interface WorkspaceStore {
+interface WorkspaceState {
   workspace: Workspace
 }
 
 interface WorkspaceActions {
-  init: () => void
+  set: (workspace: Workspace) => void
   setId: (id: IdType) => void
   setName: (name: string) => void
   setCurrentNetworkId: (id: IdType) => void
@@ -37,132 +37,99 @@ const EMPTY_WORKSPACE: Workspace = {
   currentNetworkId: '',
 }
 
+type WorkspaceStore = WorkspaceState & WorkspaceActions
+
+const persist =
+  (config: StateCreator<WorkspaceStore>) =>
+  (
+    set: StoreApi<WorkspaceStore>['setState'],
+    get: StoreApi<WorkspaceStore>['getState'],
+    api: StoreApi<WorkspaceStore>,
+  ) =>
+    config(
+      async (args) => {
+        console.log('persist middleware updating workspace store')
+        set(args)
+        const updated = get().workspace
+        console.log('updated workspace: ', updated)
+
+        const deleted = updated === undefined
+
+        if (!deleted) {
+          await putWorkspaceToDb(updated).then(() => {})
+        }
+      },
+      get,
+      api,
+    )
+
 export const useWorkspaceStore = create(
   subscribeWithSelector(
-    immer<WorkspaceStore & WorkspaceActions>((set) => ({
-      workspace: EMPTY_WORKSPACE,
-      init: async () => {
-        // This always return a workspace (existing or new)
-        const newWs: Workspace = await getWorkspaceFromDb()
-        set((state) => {
-          return { workspace: newWs }
-        })
-      },
-      setId: (id: IdType) => {
-        set((state) => {
-          return { workspace: { ...state.workspace, id } }
-        })
-      },
-      setCurrentNetworkId: (newId: IdType) => {
-        set((state) => {
-          return {
-            workspace: { ...state.workspace, currentNetworkId: newId },
-          }
-        })
-      },
+    immer<WorkspaceStore & WorkspaceActions>(
+      persist((set) => ({
+        workspace: EMPTY_WORKSPACE,
+        set: (workspace: Workspace) => {
+          set((state) => {
+            state.workspace = workspace
+            return state
+          })
+        },
+        setId: (id: IdType) => {
+          set((state) => {
+            state.workspace.id = id
+            return state
+          })
+        },
+        setCurrentNetworkId: (newId: IdType) => {
+          set((state) => {
+            state.workspace.currentNetworkId = newId
+            return state
+          })
+        },
 
-      setName: (name: string) => {
-        set((state) => {
-          return {
-            workspace: { ...state.workspace, name },
-          }
-        })
-      },
-      addNetworkIds: (ids: IdType | IdType[]) => {
-        set((state) => {
-          if (Array.isArray(ids)) {
-            // Add only new network IDs
-            const newIds: IdType[] = ids.filter(
-              (id) => !state.workspace.networkIds.includes(id),
+        setName: (name: string) => {
+          set((state) => {
+            state.workspace.name = name
+            return state
+          })
+        },
+        addNetworkIds: (ids: IdType | IdType[]) => {
+          set((state) => {
+            const idsList = Array.isArray(ids) ? ids : [ids]
+            const uniqueIds = Array.from(
+              new Set([...idsList, ...state.workspace.networkIds]),
             )
-            const allIds = [...state.workspace.networkIds, ...newIds]
-            const newWs = {
-              workspace: {
-                ...state.workspace,
-                networkIds: allIds,
-                networkModified: allIds.reduce(
-                  (all, id) => ({
-                    ...all,
-                    [id]: false,
-                  }),
-                  {},
-                ),
-              },
-            }
-            void updateWorkspaceDb(newWs.workspace.id, {
-              networkIds: newWs.workspace.networkIds,
-            }).then()
-            return newWs
-          } else {
-            const allIds = [...state.workspace.networkIds, ids]
-            const newWs = {
-              workspace: {
-                ...state.workspace,
-                networkIds: allIds,
-                networkModified: allIds.reduce(
-                  (all, id) => ({
-                    ...all,
-                    [id]: false,
-                  }),
-                  {},
-                ),
-              },
-            }
 
-            void updateWorkspaceDb(newWs.workspace.id, {
-              networkIds: newWs.workspace.networkIds,
-            }).then()
-            return newWs
-          }
-        })
-      },
-      deleteCurrentNetwork: () => {
-        set((state) => {
-          const newWs = {
-            workspace: {
-              ...state.workspace,
-              networkIds: state.workspace.networkIds.filter(
+            state.workspace.networkIds = uniqueIds
+
+            return state
+          })
+        },
+        deleteCurrentNetwork: () => {
+          set((state) => {
+            const idsWithoutCurrentNetworkId =
+              state.workspace.networkIds.filter(
                 (id) => id !== state.workspace.currentNetworkId,
-              ),
-            },
-          }
-          void updateWorkspaceDb(newWs.workspace.id, {
-            networkIds: newWs.workspace.networkIds,
-          }).then()
-          return newWs
-        })
-      },
-      deleteAllNetworks: () => {
-        set((state) => {
-          const newWs = {
-            workspace: {
-              ...state.workspace,
-              networkIds: [],
-              networkModified: {},
-            },
-          }
-          void updateWorkspaceDb(newWs.workspace.id, {
-            networkIds: [],
-          }).then()
-          return newWs
-        })
-      },
+              )
+            state.workspace.networkIds = idsWithoutCurrentNetworkId
+            return state
+          })
+        },
+        deleteAllNetworks: () => {
+          set((state) => {
+            state.workspace.networkIds = []
+            state.workspace.networkModified = {}
+            return state
+          })
+        },
 
-      setNetworkModified: (networkId: IdType, isModified: boolean) => {
-        set((state) => {
-          const newWs = {
-            workspace: {
-              ...state.workspace,
-              networkModified: {
-                ...state.workspace.networkModified,
-                [networkId]: isModified,
-              },
-            },
-          }
-          // void updateWorkspaceDb(newWs.workspace.id, newWs).then()
-          return newWs
-        })
-      },
-    })),
+        setNetworkModified: (networkId: IdType, isModified: boolean) => {
+          set((state) => {
+            state.workspace.networkModified[networkId] = isModified
+            return state
+          })
+        },
+      })),
+    ),
   ),
 )

--- a/src/store/useNdexNetworkSummary.ts
+++ b/src/store/useNdexNetworkSummary.ts
@@ -1,0 +1,79 @@
+// @ts-expect-error-next-line
+import { NDEx } from '@js4cytoscape/ndex-client'
+import { NdexNetworkSummary } from '../models/NetworkSummaryModel'
+import { IdType } from '../models/IdType'
+import { getNetworkSummariesFromDb, putNetworkSummaryToDb } from './persist/db'
+
+// check the local cache for ndex network summaries and fetch from NDEx if not found
+export const getNdexNetworkSummary = async (
+  ndexNetworkId: IdType | IdType[],
+  url: string,
+  accessToken?: string,
+): Promise<Record<IdType, NdexNetworkSummary>> => {
+  try {
+    const uniqueIds = Array.from(
+      new Set(Array.isArray(ndexNetworkId) ? ndexNetworkId : [ndexNetworkId]),
+    )
+
+    // check cache to see if we have the summaries
+    const cachedSummaries = await getNetworkSummariesFromDb(uniqueIds)
+
+    // get the ids that are not in the cache
+    const nonCachedIds = new Set(uniqueIds)
+    cachedSummaries.forEach((s) => {
+      const summaryFound = s !== undefined
+      if (summaryFound) {
+        nonCachedIds.delete(s.externalId)
+      }
+    })
+
+    // fetch summaries not found in the cache in NDEx
+    // and then save them to the cache
+    const newSummaries = await networkSummaryFetcher(
+      Array.from(nonCachedIds),
+      url,
+      accessToken,
+    )
+    newSummaries.forEach(async (summary: NdexNetworkSummary) => {
+      await putNetworkSummaryToDb(summary)
+    })
+
+    const summaryResults: Record<IdType, NdexNetworkSummary> = [
+      ...cachedSummaries,
+      ...newSummaries,
+    ].reduce((acc: Record<IdType, NdexNetworkSummary>, s) => {
+      acc[s.externalId] = s
+      return acc
+    }, {})
+
+    return summaryResults
+  } catch (error) {
+    console.error('Failed to get network summary', error)
+    throw error
+  }
+}
+
+// fetch network summaries from NDEx
+const networkSummaryFetcher = async (
+  id: IdType | IdType[],
+  url: string,
+  accessToken?: string,
+): Promise<NdexNetworkSummary[]> => {
+  const ndexClient = new NDEx(`${url}/v2`)
+
+  if (accessToken !== undefined && accessToken !== '') {
+    ndexClient.setAuthToken(accessToken)
+  }
+
+  const ids = Array.isArray(id) ? id : [id]
+
+  try {
+    const summaries: Promise<NdexNetworkSummary[]> =
+      await ndexClient.getNetworkSummariesByUUIDs(ids)
+
+    return await summaries
+  } catch (error) {
+    console.error('Failed to fetch summary', error)
+    throw error
+  }
+}


### PR DESCRIPTION
- fix bug related to hoveredElement being undefined in the `applyHoverUpdate()` function
- rework the network summary ui to be a popover instead of a accordion
- network modified indicator appears when the visual style/table/network model changes
- subscribe to the viewModelStore and diff the computed views to determine if they have changed using lodash `isEqual()`
- refactor stores to use a persist middleware function that saves the model to the cache every time a store function is called.
- refactor network summary store to make it's api more consistent with the other store.  Move caching/network request logic into the `useNdexNetworkSummary` module
   -  code that gets ndex network summaries and ndex networks now follow the same code pattern (check cache for the object, if it is not found get it from ndex)
   - 