### PR TITLE
ui feedback

### DIFF
--- a/src/components/Vizmapper/Forms/BypassForm.tsx
+++ b/src/components/Vizmapper/Forms/BypassForm.tsx
@@ -55,7 +55,6 @@ function BypassFormContent(props: {
 
   const setBypass = useVisualStyleStore((state) => state.setBypass)
   const deleteBypass = useVisualStyleStore((state) => state.deleteBypass)
-  const setHovered = useViewModelStore((state) => state.setHovered)
   const toggleSelected = useViewModelStore((state) => state.toggleSelected)
   const additiveSelect = useViewModelStore((state) => state.additiveSelect)
   const additiveUnselect = useViewModelStore((state) => state.additiveUnselect)
@@ -175,13 +174,7 @@ function BypassFormContent(props: {
               const bypassValue = visualProperty.bypassMap?.get(id) ?? null
 
               return (
-                <TableRow
-                  onMouseEnter={() => setHovered(props.currentNetworkId, id)}
-                  onMouseLeave={() => setHovered(props.currentNetworkId, '')}
-                  key={id}
-                  hover={true}
-                  selected={selected}
-                >
+                <TableRow key={id} hover={true} selected={selected}>
                   <TableCell padding="checkbox">
                     <Checkbox
                       onClick={() => toggleSelected(currentNetworkId, [id])}
@@ -212,7 +205,6 @@ function BypassFormContent(props: {
                         deleteBypass(currentNetworkId, visualProperty.name, [
                           id,
                         ])
-                        setHovered(currentNetworkId, '')
                       }}
                       disabled={!hasBypass}
                     >
@@ -294,8 +286,6 @@ function BypassFormContent(props: {
         pl: 1,
         pr: 1,
       }}
-      // make sure there is no hovered component when the mouse leaves the bypass form
-      onMouseLeave={() => setHovered(props.currentNetworkId, '')}
     >
       <Typography
         sx={{ m: 1 }}
@@ -314,8 +304,6 @@ export function BypassForm(props: {
   sx?: SxProps
 }): React.ReactElement {
   const [formAnchorEl, setFormAnchorEl] = React.useState<Element | null>(null)
-
-  const setHovered = useViewModelStore((state) => state.setHovered)
 
   const showForm = (value: Element | null): void => {
     setFormAnchorEl(value)
@@ -354,7 +342,6 @@ export function BypassForm(props: {
         anchorEl={formAnchorEl}
         onClose={() => {
           showForm(null)
-          setHovered(props.currentNetworkId, '')
         }}
         anchorOrigin={{ vertical: 'top', horizontal: 55 }}
       >

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -346,22 +346,36 @@ export function ContinuousColorMappingForm(props: {
                         zIndex: lastDraggedHandleId === h.id ? 3 : 1,
                       }}
                     >
-                      <IconButton
-                        sx={{ position: 'absolute', top: -20, right: -16 }}
+                      <Delete
                         onClick={() => {
                           deleteHandle(h.id)
                         }}
-                      >
-                        <Delete sx={{ color: '#03082d' }} />
-                      </IconButton>
-
-                      <VisualPropertyValueForm
-                        currentValue={h.vpValue ?? null}
-                        visualProperty={props.visualProperty}
-                        onValueChange={(newValue) => {
-                          setHandle(h.id, h.value as number, newValue as string)
+                        sx={{
+                          position: 'absolute',
+                          top: -10,
+                          right: -10,
+                          color: '#03082d',
+                          fontSize: 22,
+                          '&:hover': {
+                            cursor: 'pointer',
+                            color: '#3d0303',
+                          },
                         }}
                       />
+
+                      <Box sx={{ pl: 1.8, pr: 1.8 }}>
+                        <VisualPropertyValueForm
+                          currentValue={h.vpValue ?? null}
+                          visualProperty={props.visualProperty}
+                          onValueChange={(newValue) => {
+                            setHandle(
+                              h.id,
+                              h.value as number,
+                              newValue as string,
+                            )
+                          }}
+                        />
+                      </Box>
                       <TextField
                         sx={{ width: 50, mt: 1 }}
                         inputProps={{

--- a/src/components/Vizmapper/Forms/MappingForm/index.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/index.tsx
@@ -370,14 +370,14 @@ export function MappingForm(props: {
   }
   const viewBox =
     props.visualProperty.mapping?.type == null ? (
-      <EmptyVisualPropertyViewBox onClick={(e) => showForm(e.currentTarget)}>
-        {'+'}
-      </EmptyVisualPropertyViewBox>
+      <EmptyVisualPropertyViewBox
+        onClick={(e) => showForm(e.currentTarget)}
+      ></EmptyVisualPropertyViewBox>
     ) : (
       <VisualPropertyViewBox onClick={(e) => showForm(e.currentTarget)}>
         {props.visualProperty.mapping?.type != null
           ? mappingFnIconMap[props.visualProperty.mapping?.type]
-          : '+'}{' '}
+          : ''}
       </VisualPropertyViewBox>
     )
 


### PR DESCRIPTION
Addresses some of the feedback received by Dexter/Rudi.

1. remove the '+' symbol for empty mapping visual properties to be consistent with the rest of the vizmapper forms/elements
2. make it less likely that the user will accidentally click the delete button in a continuous mapping color picker handle when they wanted to instead click on the color picker
3. filter the table rows based on the selected nodes/edges in the network
4. remove the feature that highlighted the node/edge when hovering over a table row or a element in the bypass map