### PR TITLE
Table browser features

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -23,9 +23,8 @@ import {
   Rectangle,
   CellClickedEventArgs,
   DataEditorRef,
-  HeaderClickedEventArgs
+  HeaderClickedEventArgs,
 } from '@glideapps/glide-data-grid'
-
 
 import {
   deserializeValueList,
@@ -43,9 +42,9 @@ interface TabPanelProps {
 }
 
 export interface TableColumn {
-  id: string,
-  title: string,
-  type: ValueTypeName,
+  id: string
+  title: string
+  type: ValueTypeName
   index: number
 }
 
@@ -87,10 +86,15 @@ export default function TableBrowser(props: {
   width: number // current width of the panel that contains the table browser -- needed to sync to the dataeditor
 }): React.ReactElement {
   const [currentTabIndex, setCurrentTabIndex] = React.useState(0)
-  const [showColumnForm, setShowColumnForm] = React.useState(false);
-  const [columnFormError, setColumnFormError] = React.useState<string | undefined>(undefined)
+  // const [showCreateColumnForm, setShowCreateColumnForm] = React.useState(false)
+  const [showColumnForm, setShowColumnForm] = React.useState(false)
+  const [columnFormError, setColumnFormError] = React.useState<
+    string | undefined
+  >(undefined)
 
-  const [selectedColumnIndex, setSelectedColumnIndex] = React.useState<number | undefined>(undefined)
+  const [selectedColumnIndex, setSelectedColumnIndex] = React.useState<
+    number | undefined
+  >(undefined)
 
   const nodeDataEditorRef = React.useRef<DataEditorRef>(null)
   const edgeDataEditorRef = React.useRef<DataEditorRef>(null)
@@ -102,7 +106,6 @@ export default function TableBrowser(props: {
     direction: undefined,
     valueType: undefined,
   })
-
 
   const networkId = props.currentNetworkId
   const visualStyle = useVisualStyleStore(
@@ -149,15 +152,14 @@ export default function TableBrowser(props: {
   React.useEffect(() => {
     // scroll to the first result anytime someone changes the filtered rows
     // e.g. when the user selects nodes in the network view, scroll to the top of the list in the table
-    nodeDataEditorRef.current?.scrollTo(0, 0, "both", 0, 0, {
+    nodeDataEditorRef.current?.scrollTo(0, 0, 'both', 0, 0, {
       vAlign: 'start',
       hAlign: 'start',
-    });
-    edgeDataEditorRef.current?.scrollTo(0, 0, "both", 0, 0, {
+    })
+    edgeDataEditorRef.current?.scrollTo(0, 0, 'both', 0, 0, {
       vAlign: 'start',
       hAlign: 'start',
-    });
-
+    })
   }, [rows])
 
   if (sort.column != null && sort.direction != null && sort.valueType != null) {
@@ -169,7 +171,6 @@ export default function TableBrowser(props: {
       return sortFn(aVal, bVal, sort.direction as SortDirection)
     })
   }
-
 
   const handleChange = (
     event: React.SyntheticEvent,
@@ -241,11 +242,14 @@ export default function TableBrowser(props: {
     [props.currentNetworkId, currentTable, tables],
   )
 
-  const onCellContextMenu = React.useCallback((cell: Item, event: CellClickedEventArgs): void => {
-    console.log(event)
+  const onCellContextMenu = React.useCallback(
+    (cell: Item, event: CellClickedEventArgs): void => {
+      console.log(event)
 
-    event.preventDefault()
-  }, [props.currentNetworkId, currentTable, tables])
+      event.preventDefault()
+    },
+    [props.currentNetworkId, currentTable, tables],
+  )
 
   const onCellEdited = React.useCallback(
     (cell: Item, newValue: EditableGridCell) => {
@@ -256,7 +260,8 @@ export default function TableBrowser(props: {
       const columnKey = column.id
       let data = newValue.data
 
-      if (rowData == null || cxId == null || column == null || data == null) return
+      if (rowData == null || cxId == null || column == null || data == null)
+        return
 
       if (isListType(column.type)) {
         data = deserializeValueList(column.type, data as string)
@@ -281,34 +286,45 @@ export default function TableBrowser(props: {
   )
 
   const onHeaderMenuClick = React.useCallback(
-    (col: number, bounds: Rectangle): void => {
+    (col: number, bounds: Rectangle): void => {},
+    [],
+  )
+
+  const onHeaderClicked = React.useCallback(
+    (col: number, event: HeaderClickedEventArgs): void => {
+      setSelectedColumnIndex(col)
+      console.log(selectedColumnIndex)
     },
     [],
   )
 
-  const onHeaderClicked = React.useCallback((col: number, event: HeaderClickedEventArgs): void => {
-    setSelectedColumnIndex(col)
-    console.log(selectedColumnIndex)
-  }, [])
-
-  const selectedColumn = selectedColumnIndex != null ? columns?.[selectedColumnIndex] : null
+  const selectedColumn =
+    selectedColumnIndex != null ? columns?.[selectedColumnIndex] : null
   // scan the visual properties to see if the selected column name is used in any mappings
-  const visualPropertiesDependentOnSelectedColumn = Object.values(visualStyle ?? {}).filter((vpValue) =>
-    selectedColumn?.id != null && vpValue?.mapping?.attribute === selectedColumn.id).map(vp => vp.displayName)
+  const visualPropertiesDependentOnSelectedColumn = Object.values(
+    visualStyle ?? {},
+  )
+    .filter(
+      (vpValue) =>
+        selectedColumn?.id != null &&
+        vpValue?.mapping?.attribute === selectedColumn.id,
+    )
+    .map((vp) => vp.displayName)
   const selectedColumnToolbar = (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <Button sx={{ mr: 1 }} onClick={() => setShowSearch(!showSearch)}>
         Toggle Search
       </Button>
-      {
-        selectedColumn != null && (
-          <>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-              <Box sx={{ mr: 1 }}>
-                Selected Column: {selectedColumn.id}
-              </Box>
-              <ButtonGroup size="small">
-                <Button onClick={() => {
+      {/* <Button sx={{ mr: 1 }} onClick={() => setShowCreateColumnForm(true)}>
+        Create Column
+      </Button> */}
+      {selectedColumn != null && (
+        <>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Box sx={{ mr: 1 }}>Selected Column: {selectedColumn.id}</Box>
+            <ButtonGroup size="small">
+              <Button
+                onClick={() => {
                   if (selectedColumn != null) {
                     const columnKey = selectedColumn.id
                     const columnType = selectedColumn.type
@@ -319,8 +335,12 @@ export default function TableBrowser(props: {
                       valueType: columnType,
                     })
                   }
-                }}>Sort Asc.</Button>
-                <Button onClick={() => {
+                }}
+              >
+                Sort Asc.
+              </Button>
+              <Button
+                onClick={() => {
                   if (selectedColumn != null) {
                     const columnKey = selectedColumn.id
                     const columnType = selectedColumn.type
@@ -330,8 +350,13 @@ export default function TableBrowser(props: {
                       valueType: columnType,
                     })
                   }
-                }}> Sort Desc.</Button>
-                <Button onClick={() => {
+                }}
+              >
+                {' '}
+                Sort Desc.
+              </Button>
+              <Button
+                onClick={() => {
                   if (selectedColumn != null) {
                     const columnKey = selectedColumn.id
                     duplicateColumn(
@@ -340,27 +365,50 @@ export default function TableBrowser(props: {
                       columnKey,
                     )
                   }
-                }}>Duplicate Column</Button>
-                <Button onClick={() => setShowColumnForm(true)}>Edit Column</Button>
-              </ButtonGroup>
-            </Box>
-            <TableColumnForm error={columnFormError} dependentVisualProperties={visualPropertiesDependentOnSelectedColumn} open={showColumnForm} column={selectedColumn} onClose={() => setShowColumnForm(false)} onSubmit={(newColumnName: string) => {
-              // const nextTable = editColumnName(currentTable, selectedColumn.id, newColumnName)
-              const columnNameSet = new Set(columns?.map(c => c.id))
+                }}
+              >
+                Duplicate Column
+              </Button>
+              <Button onClick={() => setShowColumnForm(true)}>
+                Edit Column
+              </Button>
+              <Button color="error" onClick={() => {}}>
+                Delete Column
+              </Button>
+            </ButtonGroup>
+          </Box>
+          <TableColumnForm
+            error={columnFormError}
+            dependentVisualProperties={
+              visualPropertiesDependentOnSelectedColumn
+            }
+            open={showColumnForm}
+            column={selectedColumn}
+            onClose={() => {
+              setShowColumnForm(false)
+              setColumnFormError(undefined)
+            }}
+            onSubmit={(newColumnName: string) => {
+              const columnNameSet = new Set(columns?.map((c) => c.id))
               if (columnNameSet.has(newColumnName)) {
-                setColumnFormError(`${newColumnName} already exists.  Please enter a new unique column name`)
+                setColumnFormError(
+                  `${newColumnName} already exists.  Please enter a new unique column name`,
+                )
               } else {
-                setColumnName(props.currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', selectedColumn.id, newColumnName)
+                setColumnName(
+                  props.currentNetworkId,
+                  currentTable === nodeTable ? 'node' : 'edge',
+                  selectedColumn.id,
+                  newColumnName,
+                )
                 setColumnFormError(undefined)
                 setSelectedColumnIndex(undefined)
               }
-            }} />
-
-          </>
-
-        )
-      }
-    </Box >
+            }}
+          />
+        </>
+      )}
+    </Box>
   )
 
   return (
@@ -419,10 +467,9 @@ export default function TableBrowser(props: {
             getCellContent={getContent}
             onCellEdited={onCellEdited}
             columns={columns}
-            rows={(maxNodeId - minNodeId) + 1}
+            rows={maxNodeId - minNodeId + 1}
           />
         </Box>
-
       </TabPanel>
       <TabPanel value={currentTabIndex} index={1}>
         {selectedColumnToolbar}
@@ -446,10 +493,10 @@ export default function TableBrowser(props: {
             getCellContent={getContent}
             onCellEdited={onCellEdited}
             columns={columns}
-            rows={(maxEdgeId - minEdgeId) + 1}
+            rows={maxEdgeId - minEdgeId + 1}
           />
         </Box>
-      </TabPanel >
-    </Box >
+      </TabPanel>
+    </Box>
   )
 }

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -4,16 +4,31 @@ import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
-import { TextField, Button, Alert } from '@mui/material'
+import { TextField, Button, Alert, FormControl, InputLabel, MenuItem, Box, Select } from '@mui/material'
 
-export default function TableColumnForm(props: {
+import { ValueTypeName } from '../../models/TableModel'
+
+interface TableFormProps {
   column: TableColumn
   open: boolean
   error: string | undefined
   onClose: () => void
   onSubmit: (newColumnName: string) => void
   dependentVisualProperties: string[]
-}): React.ReactElement {
+}
+
+interface DeleteTableColumnFormProps extends TableFormProps {
+  onSubmit: () => void
+}
+
+interface CreateTableColumnFormProps {
+  open: boolean
+  error: string | undefined
+  onClose: () => void
+  onSubmit: (newColumnName: string, dataType: ValueTypeName) => void
+
+}
+export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
 
   const [value, setValue] = React.useState(props.column.id)
 
@@ -37,6 +52,69 @@ export default function TableColumnForm(props: {
       </DialogContent>
       <DialogActions>
         <Button onClick={() => props.onSubmit(value)}>Confirm</Button>
+        <Button color="error" onClick={props.onClose}>Cancel</Button>
+      </DialogActions>
+    </Dialog>)
+}
+
+export function DeleteTableColumnForm(props: DeleteTableColumnFormProps): React.ReactElement {
+  return (
+    <Dialog
+      maxWidth="sm"
+      fullWidth={true}
+      open={props.open}
+      onClose={props.onClose}
+    >
+      <DialogTitle>Delete Column</DialogTitle>
+      <DialogContent>
+        <Box>Are you sure you want to delete column {props.column.id}?</Box>
+        {props.dependentVisualProperties.length > 0 ? <Alert severity="warning">{`Warning, the following visual properties have mappings that are dependent on column ${props.column.id}.  Changes to the following visual properties may be needed: ${props.dependentVisualProperties.join(', ')}`}</Alert>
+          : null}
+        {props.error != null ? <Alert severity="error">{`${props.error}`}</Alert>
+          : null}
+
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => props.onSubmit()}>Confirm</Button>
+        <Button color="error" onClick={props.onClose}>Cancel</Button>
+      </DialogActions>
+    </Dialog>)
+}
+
+
+export function CreateTableColumnForm(props: CreateTableColumnFormProps): React.ReactElement {
+  const [columnName, setColumnName] = React.useState('')
+  const [valueTypeName, setValueTypeName] = React.useState<ValueTypeName>(ValueTypeName.String)
+
+  return (
+    <Dialog
+      maxWidth="sm"
+      fullWidth={true}
+      open={props.open}
+      onClose={props.onClose}
+    >
+      <DialogTitle>Create New Column</DialogTitle>
+      <DialogContent>
+        <TextField size="small" sx={{ mt: 1, mb: 1 }} onChange={e => setColumnName(e.target.value)} value={columnName} label={'Column Name'} />
+        <FormControl fullWidth>
+          <InputLabel id="data-type-select">Data type</InputLabel>
+          <Select
+            labelId="data-type-select"
+            value={valueTypeName}
+            label="Age"
+            onChange={(e) => setValueTypeName(e.target.value as ValueTypeName)}
+          >
+            {Object.values(ValueTypeName).map(v => {
+              return <MenuItem key={v} value={v}>{v}</MenuItem>
+            })}
+          </Select>
+        </FormControl>
+        {props.error != null ? <Alert severity="error">{`${props.error}`}</Alert>
+          : null}
+
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => props.onSubmit(columnName, valueTypeName)}>Confirm</Button>
         <Button color="error" onClick={props.onClose}>Cancel</Button>
       </DialogActions>
     </Dialog>)

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -25,7 +25,7 @@ interface CreateTableColumnFormProps {
   open: boolean
   error: string | undefined
   onClose: () => void
-  onSubmit: (newColumnName: string, dataType: ValueTypeName) => void
+  onSubmit: (newColumnName: string, dataType: ValueTypeName, value: string) => void
 
 }
 export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
@@ -85,6 +85,7 @@ export function DeleteTableColumnForm(props: DeleteTableColumnFormProps): React.
 export function CreateTableColumnForm(props: CreateTableColumnFormProps): React.ReactElement {
   const [columnName, setColumnName] = React.useState('')
   const [valueTypeName, setValueTypeName] = React.useState<ValueTypeName>(ValueTypeName.String)
+  const [defaultValue, setDefaultValue] = React.useState('')
 
   return (
     <Dialog
@@ -94,14 +95,14 @@ export function CreateTableColumnForm(props: CreateTableColumnFormProps): React.
       onClose={props.onClose}
     >
       <DialogTitle>Create New Column</DialogTitle>
-      <DialogContent>
+      <DialogContent sx={{ display: 'flex', flexDirection: 'column' }}>
         <TextField size="small" sx={{ mt: 1, mb: 1 }} onChange={e => setColumnName(e.target.value)} value={columnName} label={'Column Name'} />
-        <FormControl fullWidth>
+        <FormControl>
           <InputLabel id="data-type-select">Data type</InputLabel>
           <Select
+            size="small"
             labelId="data-type-select"
             value={valueTypeName}
-            label="Age"
             onChange={(e) => setValueTypeName(e.target.value as ValueTypeName)}
           >
             {Object.values(ValueTypeName).map(v => {
@@ -109,12 +110,14 @@ export function CreateTableColumnForm(props: CreateTableColumnFormProps): React.
             })}
           </Select>
         </FormControl>
+        <TextField size="small" sx={{ mt: 1, mb: 1 }} onChange={e => setDefaultValue(e.target.value)} value={defaultValue} label={'Default value'} />
         {props.error != null ? <Alert severity="error">{`${props.error}`}</Alert>
           : null}
 
       </DialogContent>
+
       <DialogActions>
-        <Button onClick={() => props.onSubmit(columnName, valueTypeName)}>Confirm</Button>
+        <Button onClick={() => props.onSubmit(columnName, valueTypeName, defaultValue)}>Confirm</Button>
         <Button color="error" onClick={props.onClose}>Cancel</Button>
       </DialogActions>
     </Dialog>)

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import { TableColumn } from './TableBrowser'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import { TextField, Button, Alert } from '@mui/material'
+
+export default function TableColumnForm(props: {
+  column: TableColumn
+  open: boolean
+  error: string | undefined
+  onClose: () => void
+  onSubmit: (newColumnName: string) => void
+  dependentVisualProperties: string[]
+}): React.ReactElement {
+
+  const [value, setValue] = React.useState(props.column.id)
+
+  React.useEffect(() => setValue(props.column.id), [props.column])
+
+  return (
+    <Dialog
+      maxWidth="sm"
+      fullWidth={true}
+      open={props.open}
+      onClose={props.onClose}
+    >
+      <DialogTitle>Edit Column</DialogTitle>
+      <DialogContent>
+        <TextField size="small" sx={{ mt: 1, mb: 1 }} onChange={e => setValue(e.target.value)} value={value} label={'Column Name'} />
+        {props.dependentVisualProperties.length > 0 ? <Alert severity="warning">{`Warning, the following visual properties have mappings that are dependent on column ${props.column.id}.  Changes to the following visual properties may be needed: ${props.dependentVisualProperties.join(', ')}`}</Alert>
+          : null}
+        {props.error != null ? <Alert severity="error">{`${props.error}`}</Alert>
+          : null}
+
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => props.onSubmit(value)}>Confirm</Button>
+        <Button color="error" onClick={props.onClose}>Cancel</Button>
+      </DialogActions>
+    </Dialog>)
+}

--- a/src/components/Vizmapper/Forms/MappingForm/index.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/index.tsx
@@ -196,9 +196,9 @@ function MappingFormContent(props: {
 
   const validColumns =
     mappingType !== ''
-      ? columns.filter((c) =>
-          typesCanBeMapped(mappingType, c.type, props.visualProperty.type),
-        )
+      ? columns.filter((c) => {
+        return typesCanBeMapped(mappingType, c.type, props.visualProperty.type)
+      })
       : columns
   const validColumnNames = validColumns.map((c) => c.name)
 
@@ -221,12 +221,12 @@ function MappingFormContent(props: {
   )
 
   const mappingDimensions: Record<MappingFunctionType | '', [string, string]> =
-    {
-      [MappingFunctionType.Discrete]: ['400px', '600px'],
-      [MappingFunctionType.Continuous]: ['650px', 'auto'],
-      [MappingFunctionType.Passthrough]: ['400px', 'auto'],
-      '': ['400px', '200px'],
-    }
+  {
+    [MappingFunctionType.Discrete]: ['400px', '600px'],
+    [MappingFunctionType.Continuous]: ['650px', 'auto'],
+    [MappingFunctionType.Passthrough]: ['400px', 'auto'],
+    '': ['400px', '200px'],
+  }
   return (
     <Box
       sx={{
@@ -294,11 +294,9 @@ function MappingFormContent(props: {
                 if (validColumnNames.includes(c.name)) {
                   return columnMenuItem
                 } else {
-                  const invalidColumnTooltipStr = `${mappingType} mapping functions${
-                    c.name !== '' ? ` on column '${c.name}' ` : ' '
-                  }cannot be applied to property ${
-                    props.visualProperty.displayName
-                  }`
+                  const invalidColumnTooltipStr = `${mappingType} mapping functions${c.name !== '' ? ` on column '${c.name}' ` : ' '
+                    }cannot be applied to property ${props.visualProperty.displayName
+                    }`
 
                   return (
                     <Tooltip key={c.name} title={invalidColumnTooltipStr}>
@@ -334,11 +332,9 @@ function MappingFormContent(props: {
                 if (validMappings.includes(mappingFnType)) {
                   return mappingFnMenuItem
                 } else {
-                  const invalidMappingTooltipStr = `${mappingFnType} mapping functions${
-                    column !== '' ? ` on column '${column}' ` : ' '
-                  }cannot be applied to property ${
-                    props.visualProperty.displayName
-                  }`
+                  const invalidMappingTooltipStr = `${mappingFnType} mapping functions${column !== '' ? ` on column '${column}' ` : ' '
+                    }cannot be applied to property ${props.visualProperty.displayName
+                    }`
                   return (
                     <Tooltip
                       key={mappingFnType}

--- a/src/components/Vizmapper/Forms/VisualPropertyValueForm.tsx
+++ b/src/components/Vizmapper/Forms/VisualPropertyValueForm.tsx
@@ -16,7 +16,7 @@ import {
 import { NumberInput, NumberRender } from '../VisualPropertyRender/Number'
 import { Font, FontPicker } from '../VisualPropertyRender/Font'
 import {
-  HoritzontalAlignPicker,
+  HorizontalAlignPicker,
   HorizontalAlign,
 } from '../VisualPropertyRender/HorizontalAlign'
 import {
@@ -85,7 +85,7 @@ const vpType2RenderMap: Record<
     valueRender: Font,
   },
   horizontalAlign: {
-    pickerRender: HoritzontalAlignPicker,
+    pickerRender: HorizontalAlignPicker,
     valueRender: HorizontalAlign,
   },
   verticalAlign: {
@@ -241,7 +241,7 @@ export function VisualPropertyValueForm(
             {(
               vpName2RenderMap[props.visualProperty.name]?.pickerRender ??
               vpType2RenderMap[props.visualProperty.type].pickerRender ??
-              (() => {})
+              (() => { })
             )({
               onValueChange: (value: VisualPropertyValueType) =>
                 props.onValueChange(value),

--- a/src/components/Vizmapper/VisualPropertyRender/HorizontalAlign.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/HorizontalAlign.tsx
@@ -1,7 +1,7 @@
 import { HorizontalAlignType } from '../../../models/VisualStyleModel/VisualPropertyValue'
 import { Box, Typography } from '@mui/material'
 
-export function HoritzontalAlignPicker(props: {
+export function HorizontalAlignPicker(props: {
   currentValue: HorizontalAlignType | null
   onValueChange: (horizontalAlign: HorizontalAlignType) => void
 }): React.ReactElement {

--- a/src/models/TableModel/impl/InMemoryTable.ts
+++ b/src/models/TableModel/impl/InMemoryTable.ts
@@ -8,6 +8,7 @@ import { ValueTypeName } from '../ValueTypeName'
 import { CxValue } from '../../CxModel/Cx2/CxValue'
 import { AttributeDeclaration } from '../../CxModel/Cx2/CoreAspects/AttributeDeclarations'
 import { translateCXEdgeId } from '../../NetworkModel/impl/CyNetwork'
+import { cloneDeep } from 'lodash'
 export const createTable = (id: IdType): Table => ({
   id,
   columns: new Map<AttributeName, Column>(),
@@ -153,20 +154,21 @@ export const editColumnName = (
   oldName: string,
   newName: string,
 ): Table => {
-  const column = table.columns.get(oldName)
+  const newTable = cloneDeep(table)
+  const column = newTable.columns.get(oldName)
   if (column != null) {
-    table.columns.delete(oldName)
-    table.columns.set(newName, column)
+    newTable.columns.delete(oldName)
+    newTable.columns.set(newName, column)
   }
 
-  Array.from(table.rows.values()).forEach((row) => {
+  Array.from(newTable.rows.values()).forEach((row) => {
     const value = row[oldName]
     if (value != null) {
       delete row[oldName]
       row[newName] = value
     }
   })
-  return table
+  return newTable
 }
 
 export const deleteTableColumn = (table: Table, columnName: AttributeName): Table => {

--- a/src/models/VisualStyleModel/VisualPropertyValueTypeName.ts
+++ b/src/models/VisualStyleModel/VisualPropertyValueTypeName.ts
@@ -6,7 +6,7 @@ export const VisualPropertyValueTypeName = {
   EdgeLine: 'edgeLine',
   EdgeArrowShape: 'edgeArrowShape',
   Font: 'font',
-  HoritzontalAlign: 'horitzontalAlign',
+  HorizontalAlign: 'HorizontalAlign',
   VerticalAlign: 'verticalAlign',
   NodeBorderLine: 'nodeBorderLine',
   Visibility: 'visibility',

--- a/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
+++ b/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
@@ -2,7 +2,7 @@ import { ValueTypeName } from '../../TableModel'
 import { SingleValueType } from '../../TableModel/ValueType'
 import { MappingFunctionType, VisualPropertyValueTypeName } from '..'
 
-const valueType2BaseType: Record<ValueTypeName, SingleValueType | null> = {
+const valueType2BaseType: Record<ValueTypeName | VisualPropertyValueTypeName, SingleValueType | null> = {
   [ValueTypeName.String]: 'string',
   [ValueTypeName.Long]: 'number',
   [ValueTypeName.Integer]: 'number',
@@ -13,6 +13,17 @@ const valueType2BaseType: Record<ValueTypeName, SingleValueType | null> = {
   [ValueTypeName.ListDouble]: null,
   [ValueTypeName.ListInteger]: null,
   [ValueTypeName.ListString]: null,
+  [VisualPropertyValueTypeName.NodeShape]: 'string',
+  [VisualPropertyValueTypeName.EdgeLine]: 'string',
+  [VisualPropertyValueTypeName.EdgeArrowShape]: 'string',
+  [VisualPropertyValueTypeName.Font]: 'string',
+  [VisualPropertyValueTypeName.HorizontalAlign]: 'string',
+  [VisualPropertyValueTypeName.VerticalAlign]: 'string',
+  [VisualPropertyValueTypeName.NodeBorderLine]: 'string',
+  [VisualPropertyValueTypeName.Visibility]: 'string',
+  [VisualPropertyValueTypeName.Number]: 'number',
+  [VisualPropertyValueTypeName.Boolean]: 'string',
+  [VisualPropertyValueTypeName.String]: 'string',
 }
 
 // This function will be redundant once continuous discrete mapping ui is available
@@ -41,13 +52,15 @@ export const typesCanBeMapped = (
   mappingType: MappingFunctionType,
   valueTypeName: ValueTypeName,
   vpValueTypeName: VisualPropertyValueTypeName,
+  columnName?: string
 ): boolean => {
   if (mappingType === MappingFunctionType.Passthrough) {
     const vtBaseType = valueType2BaseType[valueTypeName]
     const isSingleValue = vtBaseType != null
+    const typesMatch = valueTypeName === vpValueTypeName
+    const singleStringType = isSingleValue && valueType2BaseType[vpValueTypeName] === VisualPropertyValueTypeName.String /// any single value type can be mapped to a string
     return (
-      valueTypeName === vpValueTypeName ||
-      (isSingleValue && vpValueTypeName === VisualPropertyValueTypeName.String) // any single value type can be mapped to a string
+      typesMatch || singleStringType
     )
   }
 

--- a/src/store/TableStore.ts
+++ b/src/store/TableStore.ts
@@ -41,6 +41,14 @@ interface TableAction {
     tableType: 'node' | 'edge',
     columnName: string
   ) => void
+
+  applyValueToElements: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    columnName: string,
+    value: ValueType,
+    elementIds: IdType[] | undefined
+  ) => void
   createColumn: (
     networkId: IdType,
     tableType: 'node' | 'edge',
@@ -156,6 +164,37 @@ export const useTableStore = create(
           // })
           return state
 
+        })
+      },
+
+      applyValueToElements: (
+        networkId: IdType,
+        tableType: 'node' | 'edge',
+        columnName: string,
+        value: ValueType,
+        elementIds: IdType[] | undefined
+      ) => {
+        set((state) => {
+
+          const table = state.tables[networkId]
+          const tableToUpdate =
+            table[tableType === VisualPropertyGroup.Node ? 'nodeTable' : 'edgeTable']
+
+          if (elementIds != null) {
+            elementIds.forEach(id => {
+              const row = tableToUpdate.rows.get(id)
+              if (row != null) {
+                row[columnName] = value
+
+              }
+            })
+
+          } else {
+            Array.from(tableToUpdate.rows.values()).forEach(row => {
+              row[columnName] = value
+            })
+          }
+          return state
         })
       },
 

--- a/src/store/TableStore.ts
+++ b/src/store/TableStore.ts
@@ -53,7 +53,8 @@ interface TableAction {
     networkId: IdType,
     tableType: 'node' | 'edge',
     columnName: string,
-    dataType: ValueTypeName
+    dataType: ValueTypeName,
+    value: ValueType
   ) => void
   setColumnName: (
     networkId: IdType,
@@ -228,7 +229,8 @@ export const useTableStore = create(
         networkId: IdType,
         tableType: 'node' | 'edge',
         columnName: string,
-        dataType: ValueTypeName
+        dataType: ValueTypeName,
+        value: ValueType
       ) => {
         set((state) => {
           const table = state.tables[networkId]
@@ -240,9 +242,10 @@ export const useTableStore = create(
             type: dataType
           })
 
-          // const rows = tableToUpdate.rows.values()
-          // Array.from(rows).forEach(row => {
-          // })
+          const rows = tableToUpdate.rows.values()
+          Array.from(rows).forEach(row => {
+            row[columnName] = value
+          })
 
 
           return state

--- a/src/store/TableStore.ts
+++ b/src/store/TableStore.ts
@@ -1,5 +1,5 @@
 import { IdType } from '../models/IdType'
-import { AttributeName, Table, ValueType } from '../models/TableModel'
+import { AttributeName, Table, ValueType, ValueTypeName } from '../models/TableModel'
 
 import { create, StateCreator, StoreApi } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
@@ -36,6 +36,17 @@ interface TableAction {
   add: (networkId: IdType, nodeTable: Table, edgeTable: Table) => void
 
 
+  deleteColumn: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    columnName: string
+  ) => void
+  createColumn: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    columnName: string,
+    dataType: ValueTypeName
+  ) => void
   setColumnName: (
     networkId: IdType,
     tableType: 'node' | 'edge',
@@ -147,6 +158,58 @@ export const useTableStore = create(
 
         })
       },
+
+      deleteColumn: (
+        networkId: IdType,
+        tableType: 'node' | 'edge',
+        columnName: string
+      ) => {
+        set((state) => {
+          const table = state.tables[networkId]
+          const tableToUpdate =
+            table[tableType === VisualPropertyGroup.Node ? 'nodeTable' : 'edgeTable']
+          const column = tableToUpdate.columns.get(columnName)
+          if (column != null) {
+            tableToUpdate.columns.delete(columnName)
+          }
+
+          const rows = tableToUpdate.rows.values()
+          Array.from(rows).forEach(row => {
+
+            delete row[columnName]
+          })
+
+
+          return state
+        })
+      },
+
+
+      createColumn: (
+        networkId: IdType,
+        tableType: 'node' | 'edge',
+        columnName: string,
+        dataType: ValueTypeName
+      ) => {
+        set((state) => {
+          const table = state.tables[networkId]
+          const tableToUpdate =
+            table[tableType === VisualPropertyGroup.Node ? 'nodeTable' : 'edgeTable']
+
+          tableToUpdate.columns.set(columnName, {
+            name: columnName,
+            type: dataType
+          })
+
+          // const rows = tableToUpdate.rows.values()
+          // Array.from(rows).forEach(row => {
+          // })
+
+
+          return state
+        })
+      },
+
 
       // Note:  The only code that calls this function makes sure the
       // type of the column is the same as the type of the value


### PR DESCRIPTION
- Add table browser functions in the table store to create/edit/delete columns
- Show a button group of actions that can be performed by the user when they click a cell or a header
- Specific functions added: create/edit/delete column, apply value to column, apply value to selected nodes

In another PR I will try to make these menus show in a context menu via right click.  I was not able to get it working at the moment.