### PR TITLE
fix bug that broke the app when a network with an empty summary was loaded

### DIFF
--- a/src/features/HierarchyViewer/utils/hierarcy-util.ts
+++ b/src/features/HierarchyViewer/utils/hierarcy-util.ts
@@ -9,7 +9,8 @@ export const getHcxProps = (
   const keys: string[] = Object.keys(summaryObject)
 
   if (keys.length === 0) {
-    throw new Error('No summary object found')
+    // in the future, hcx will have more validation/error handling
+    return undefined
   }
 
   if (keys.includes(HcxMetaTag.interactionNetworkUUID)) {
@@ -27,8 +28,11 @@ export const getHcxProps = (
 }
 
 export const createDummySummary = (
-  uuid: string, name: string, nodeCount: number, edgeCount: number)
-    : NdexNetworkSummary => {
+  uuid: string,
+  name: string,
+  nodeCount: number,
+  edgeCount: number,
+): NdexNetworkSummary => {
   const time: Date = new Date(Date.now())
   const summary: NdexNetworkSummary = {
     ownerUUID: '',
@@ -55,8 +59,7 @@ export const createDummySummary = (
     creationTime: time,
     externalId: uuid,
     isDeleted: false,
-    modificationTime: time
+    modificationTime: time,
   }
   return summary
-
 }


### PR DESCRIPTION
- return undefined if the summary object is empty in the hcx utils

refs #CW-95