### PR TITLE
Column edit choices

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -128,6 +128,7 @@ export default function TableBrowser(props: {
   const visualStyle = useVisualStyleStore(
     (state) => state.visualStyles[props.currentNetworkId],
   )
+  const setMapping = useVisualStyleStore((state) => state.setMapping)
 
   const { selectedNodes, selectedEdges } =
     useViewModelStore((state) => state.viewModels[networkId]) ?? {}
@@ -329,13 +330,11 @@ export default function TableBrowser(props: {
   // scan the visual properties to see if the selected column name is used in any mappings
   const visualPropertiesDependentOnSelectedColumn = Object.values(
     visualStyle ?? {},
+  ).filter(
+    (vpValue) =>
+      selectedColumn?.id != null &&
+      vpValue?.mapping?.attribute === selectedColumn.id,
   )
-    .filter(
-      (vpValue) =>
-        selectedColumn?.id != null &&
-        vpValue?.mapping?.attribute === selectedColumn.id,
-    )
-    .map((vp) => vp.displayName)
   const selectedColumnToolbar =
     selectedColumn != null ? (
       <>
@@ -413,7 +412,7 @@ export default function TableBrowser(props: {
             setShowEditColumnForm(false)
             setColumnFormError(undefined)
           }}
-          onSubmit={(newColumnName: string) => {
+          onSubmit={(newColumnName: string, mappingUpdateType) => {
             const columnNameSet = new Set(columns?.map((c) => c.id))
             if (columnNameSet.has(newColumnName)) {
               setColumnFormError(
@@ -426,6 +425,21 @@ export default function TableBrowser(props: {
                 selectedColumn.id,
                 newColumnName,
               )
+
+              if (mappingUpdateType === 'rename') {
+                visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
+                  if (vp.mapping != null) {
+                    setMapping(props.currentNetworkId, vp.name, {
+                      ...vp.mapping,
+                      attribute: newColumnName,
+                    })
+                  }
+                })
+              } else if (mappingUpdateType === 'delete') {
+                visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
+                  setMapping(props.currentNetworkId, vp.name, undefined)
+                })
+              }
               setColumnFormError(undefined)
               setSelectedColumnIndex(undefined)
             }
@@ -440,12 +454,17 @@ export default function TableBrowser(props: {
             setShowDeleteColumnForm(false)
             setDeleteColumnFormError(undefined)
           }}
-          onSubmit={() => {
+          onSubmit={(mappingUpdateType) => {
             deleteColumn(
               props.currentNetworkId,
               currentTable === nodeTable ? 'node' : 'edge',
               selectedColumn.id,
             )
+            if (mappingUpdateType === 'delete') {
+              visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
+                setMapping(props.currentNetworkId, vp.name, undefined)
+              })
+            }
             setDeleteColumnFormError(undefined)
             setSelectedColumnIndex(undefined)
           }}

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -6,6 +6,7 @@ import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Radio from '@mui/material/Radio'
+import Tooltip from '@mui/material/Tooltip'
 import {
   TextField,
   Button,
@@ -112,6 +113,18 @@ export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
               }
               label="Delete the style mapping"
             />
+            <Tooltip title="Warning: You will not be able to save a network that contains invalid mappings to NDEx">
+              <FormControlLabel
+                value="delete"
+                control={
+                  <Radio
+                    checked={mappingSyncSetting === undefined}
+                    onChange={() => setMappingSyncSetting(undefined)}
+                  />
+                }
+                label="Leave the mapping as is"
+              />
+            </Tooltip>
           </>
         ) : null}
       </DialogContent>
@@ -160,6 +173,32 @@ export function DeleteTableColumnForm(
         ) : null}
         {props.error != null ? (
           <Alert severity="error">{`${props.error}`}</Alert>
+        ) : null}
+        {columnHasDependentProperties ? (
+          <>
+            <FormControlLabel
+              value="delete"
+              control={
+                <Radio
+                  checked={mappingSyncSetting === 'delete'}
+                  onChange={() => setMappingSyncSetting('delete')}
+                />
+              }
+              label="Delete the style mapping"
+            />
+            <Tooltip title="Warning: You will not be able to save a network that contains invalid mappings to NDEx">
+              <FormControlLabel
+                value="delete"
+                control={
+                  <Radio
+                    checked={mappingSyncSetting === undefined}
+                    onChange={() => setMappingSyncSetting(undefined)}
+                  />
+                }
+                label="Leave the mapping as is"
+              />
+            </Tooltip>
+          </>
         ) : null}
       </DialogContent>
       <DialogActions>

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -90,7 +90,11 @@ export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
           label={'Column Name'}
         />
         {columnHasDependentProperties ? (
-          <Alert severity="warning">{`The column ${props.column.id} is used in one or more visual style mappings`}</Alert>
+          <Alert severity="warning">{`Warning, the following visual properties have mappings that are dependent on column ${
+            props.column.id
+          }. Changes to the following visual properties may be needed: ${props.dependentVisualProperties
+            .map((vp) => vp.displayName)
+            .join(', ')}`}</Alert>
         ) : null}
         {props.error != null ? (
           <Alert severity="error">{`${props.error}`}</Alert>
@@ -111,7 +115,7 @@ export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
                   onChange={() => setMappingSyncSetting('delete')}
                 />
               }
-              label="Delete the style mapping"
+              label="Delete the style mapping(s)"
             />
             <Tooltip title="Warning: You will not be able to save a network that contains invalid mappings to NDEx">
               <FormControlLabel
@@ -122,7 +126,7 @@ export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
                     onChange={() => setMappingSyncSetting(undefined)}
                   />
                 }
-                label="Leave the mapping as is"
+                label="Leave the mapping(s) as is"
               />
             </Tooltip>
           </>
@@ -169,7 +173,11 @@ export function DeleteTableColumnForm(
       <DialogContent>
         <Box>Are you sure you want to delete column {props.column.id}?</Box>
         {columnHasDependentProperties ? (
-          <Alert severity="warning">{`The column ${props.column.id} is used in one or more visual style mappings.  The associated style mappings will be deleted with the column.`}</Alert>
+          <Alert severity="warning">{`Warning, the following visual properties have mappings that are dependent on column ${
+            props.column.id
+          }. Changes to the following visual properties may be needed: ${props.dependentVisualProperties
+            .map((vp) => vp.displayName)
+            .join(', ')}`}</Alert>
         ) : null}
         {props.error != null ? (
           <Alert severity="error">{`${props.error}`}</Alert>
@@ -184,7 +192,7 @@ export function DeleteTableColumnForm(
                   onChange={() => setMappingSyncSetting('delete')}
                 />
               }
-              label="Delete the style mapping"
+              label="Delete the style mapping(s)"
             />
             <Tooltip title="Warning: You will not be able to save a network that contains invalid mappings to NDEx">
               <FormControlLabel
@@ -195,7 +203,7 @@ export function DeleteTableColumnForm(
                     onChange={() => setMappingSyncSetting(undefined)}
                   />
                 }
-                label="Leave the mapping as is"
+                label="Leave the mapping(s) as is"
               />
             </Tooltip>
           </>

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -27,11 +27,11 @@ import {
 interface TableFormProps {
   column: TableColumn
   open: boolean
-  error: string | undefined
+  error?: string
   onClose: () => void
   onSubmit: (
     newColumnName: string,
-    mappingUpdateType: 'rename' | 'delete' | undefined,
+    mappingUpdateType?: 'rename' | 'delete',
   ) => void
   dependentVisualProperties: Array<VisualProperty<VisualPropertyValueType>>
 }
@@ -39,15 +39,15 @@ interface TableFormProps {
 interface DeleteTableColumnFormProps {
   column: TableColumn
   open: boolean
-  error: string | undefined
+  error?: string
   onClose: () => void
-  onSubmit: (mappingUpdateType: 'delete' | undefined) => void
+  onSubmit: (mappingUpdateType?: 'delete') => void
   dependentVisualProperties: Array<VisualProperty<VisualPropertyValueType>>
 }
 
 interface CreateTableColumnFormProps {
   open: boolean
-  error: string | undefined
+  error?: string
   onClose: () => void
   onSubmit: (
     newColumnName: string,

--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -68,6 +68,15 @@ interface UpdateVisualStyleAction {
     max: ContinuousFunctionControlPoint,
     controlPoints: ContinuousFunctionControlPoint[],
   ) => void
+  setMapping: (
+    networkId: IdType,
+    vpName: VisualPropertyName,
+    mapping:
+      | DiscreteMappingFunction
+      | ContinuousMappingFunction
+      | PassthroughMappingFunction
+      | undefined,
+  ) => void
   createContinuousMapping: (
     networkId: IdType,
     vpName: VisualPropertyName,
@@ -370,6 +379,13 @@ export const useVisualStyleStore = create(
         set((state) => {
           const vp = state.visualStyles[networkId][vpName]
           delete vp.mapping
+          return state
+        })
+      },
+      setMapping(networkId, vpName, mapping) {
+        set((state) => {
+          const vp = state.visualStyles[networkId][vpName]
+          vp.mapping = mapping
           return state
         })
       },

--- a/src/utils/is-url.ts
+++ b/src/utils/is-url.ts
@@ -1,0 +1,8 @@
+export function isValidUrl(input: string): boolean {
+  try {
+    const url = new URL(input)
+    return url != null
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
When a user renames or deletes a column, provide a radio button group that gives them option on how to handle columns that are used in visual style mappings.  

The options are:
1. delete the mapping
2. update the mapping with newly renamed column
3. do nothing (with a warning saying that invalid vizmapper state will produce errors when saving to NDEx)