### PR TITLE
Fixes for CW 122 and 123

### DIFF
--- a/src/features/HierarchyViewer/components/MainPanel.tsx
+++ b/src/features/HierarchyViewer/components/MainPanel.tsx
@@ -148,6 +148,7 @@ export const MainPanel = (): JSX.Element => {
       <Allotment vertical minSize={100}>
         <Allotment.Pane>
           <SubNetworkPanel
+            hierarchyId={currentNetworkId}
             subNetworkName={subNetworkName}
             rootNetworkId={rootNetworkId}
             subsystemNodeId={targetNode}

--- a/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
+++ b/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
@@ -25,6 +25,9 @@ import { LayoutAlgorithm, LayoutEngine } from '../../../models/LayoutModel'
 import { useLayoutStore } from '../../../store/LayoutStore'
 
 interface SubNetworkPanelProps {
+  // Hierarchy ID
+  hierarchyId: IdType
+
   // Name of the network visualized here
   subNetworkName: string
 
@@ -45,6 +48,7 @@ interface SubNetworkPanelProps {
  *
  */
 export const SubNetworkPanel = ({
+  hierarchyId,
   subNetworkName,
   rootNetworkId,
   subsystemNodeId,
@@ -96,7 +100,14 @@ export const SubNetworkPanel = ({
 
   const { ndexBaseUrl } = useContext(AppConfigContext)
   const { data, error, isLoading } = useSWR<NetworkWithView>(
-    [ndexBaseUrl, rootNetworkId, subsystemNodeId, query, interactionNetworkId],
+    [
+      hierarchyId,
+      ndexBaseUrl,
+      rootNetworkId,
+      subsystemNodeId,
+      query,
+      interactionNetworkId,
+    ],
     ndexQueryFetcher,
     {
       revalidateOnFocus: false,

--- a/src/features/HierarchyViewer/store/ndexQueryFetcher.ts
+++ b/src/features/HierarchyViewer/store/ndexQueryFetcher.ts
@@ -27,11 +27,15 @@ export const ndexQueryFetcher = async (
     throw new Error('Missing parameters')
   }
 
+  // Use Hierarchy ID and selected node ID as the new network ID
+  const interactionNetworkId: string = `${rootNetworkUuid}_${subsystemId}`
+
   const ndexClient = getNdexClient(url, accessToken)
 
   try {
     // First, check the local cache
-    const cache: CachedData = await getCachedData(subsystemId)
+    const cache: CachedData = await getCachedData(interactionNetworkId)
+    // const cache: CachedData = await getCachedData(subsystemId)
 
     // This is necessary only when data is not in the cache
     if (
@@ -49,7 +53,7 @@ export const ndexQueryFetcher = async (
         const cx2Network: Cx2 = await ndexClient.getCX2Network(
           interactionNetworkUuid,
         )
-        return await createDataFromCx(subsystemId, cx2Network)
+        return await createDataFromCx(interactionNetworkId, cx2Network)
       } else {
         // Case 2: Just run the interconnect query if UUID is not provided
         const cx2QueryResult: Cx2 = await ndexClient.interConnectQuery(
@@ -59,7 +63,7 @@ export const ndexQueryFetcher = async (
           query,
           true,
         )
-        return await createDataFromCx(subsystemId, cx2QueryResult)
+        return await createDataFromCx(interactionNetworkId, cx2QueryResult)
       }
     } else {
       return {

--- a/src/features/HierarchyViewer/store/ndexQueryFetcher.ts
+++ b/src/features/HierarchyViewer/store/ndexQueryFetcher.ts
@@ -11,6 +11,7 @@ export const ndexQueryFetcher = async (
   params: string[],
 ): Promise<NetworkWithView> => {
   const [
+    hierarchyId,
     url,
     rootNetworkUuid,
     subsystemId,
@@ -19,6 +20,7 @@ export const ndexQueryFetcher = async (
     accessToken,
   ] = params
   if (
+    hierarchyId === undefined ||
     url === undefined ||
     rootNetworkUuid === undefined ||
     subsystemId === undefined ||
@@ -28,7 +30,7 @@ export const ndexQueryFetcher = async (
   }
 
   // Use Hierarchy ID and selected node ID as the new network ID
-  const interactionNetworkId: string = `${rootNetworkUuid}_${subsystemId}`
+  const interactionNetworkId: string = `${hierarchyId}_${subsystemId}`
 
   const ndexClient = getNdexClient(url, accessToken)
 

--- a/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
+++ b/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 import {
   NdexNetworkProperty,
@@ -12,11 +12,39 @@ import { Panel } from '../../../models/UiModel/Panel'
 import { ValueType } from '../../../models/TableModel'
 import { HcxMetaData } from '../model/HcxMetaData'
 import { getHcxProps } from '../utils/hierarcy-util'
+import _ from 'lodash'
+import { getAllNetworkKeys } from '../../../store/persist/db'
 
 /**
  *  Switch the panel state based on the network meta data
  */
 export const useHierarchyViewerManager = (): void => {
+  // Keep track of last network list and check the diff
+  const [lastIds, setLastIds] = useState<IdType[]>([])
+
+  // For watching deletion of networks in the workspace
+  const networkIds: IdType[] = useWorkspaceStore(
+    (state) => state.workspace.networkIds,
+  )
+
+  useEffect(() => {
+    // Check the diff
+    const diff2 = _.difference(lastIds, networkIds)
+    setLastIds(networkIds)
+
+    void getAllNetworkKeys().then((keys) => {
+      console.log(
+        '3!!!!!!!!!!!!!!!!!!MainPanel: old, new, diff',
+        lastIds,
+        networkIds,
+        diff2,
+      )
+      setTimeout(() => {
+        console.log('keys', keys)
+      }, 2000)
+    })
+  }, [networkIds])
+
   const uiState = useUiStateStore((state) => state.ui)
   const setPanelState = useUiStateStore((state) => state.setPanelState)
 
@@ -45,7 +73,7 @@ export const useHierarchyViewerManager = (): void => {
       acc[prop.predicateString] = prop.value
       return acc
     }, {})
-    if(Object.keys(networkPropObj).length === 0) {
+    if (Object.keys(networkPropObj).length === 0) {
       enablePopup(false)
       return
     }

--- a/src/store/persist/db.ts
+++ b/src/store/persist/db.ts
@@ -57,7 +57,9 @@ export const deleteDb = async (): Promise<void> => {
   await Dexie.delete(DB_NAME)
   db = new CyDB(DB_NAME)
 }
-
+export const getAllNetworkKeys = async (): Promise<IdType[]> => {
+  return (await db.cyNetworks.toCollection().primaryKeys()) as IdType[]
+}
 /**
  *
  * Persist network to indexedDB


### PR DESCRIPTION
This change addresses the possibility of ID conflicts within interaction networks in the database, and it also solves the issue of cleaning up when the parent network is deleted.