### PR TITLE
Network sharing route has been updated to use dummy WS ID.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import {
 import { enableMapSet } from 'immer'
 import { MessagePanel } from './components/Messages'
 import appConfig from './assets/config.json'
-import { ExternalNetworkLoadingPanel } from './components/ExternalLoading'
 import { KeycloakContext } from '.'
 import { useCredentialStore } from './store/CredentialStore'
 
@@ -54,15 +53,6 @@ const router = createBrowserRouter(
       }
       errorElement={<Error />}
     >
-      <Route
-        // Special endpoint for loading external networks
-        path="network/:networkId"
-        element={
-          <ExternalNetworkLoadingPanel
-            message={'Loading External Network...'}
-          />
-        }
-      />
       <Route
         path=":workspaceId"
         element={

--- a/src/components/FloatingToolBar/ShareNetworkButtton.tsx
+++ b/src/components/FloatingToolBar/ShareNetworkButtton.tsx
@@ -120,7 +120,8 @@ export const ShareNetworkButton = (): JSX.Element => {
     const query = getQueryString()
 
     void copyTextToClipboard(
-      `${baseUrl}network/${currentNetworkId}?${query}`,
+      // Here, "0" means dummy workspace ID only for the purpose of generating sharable URL
+      `${baseUrl}0/networks/${currentNetworkId}?${query}`,
     ).then(() => {
       // Notify user that the sharable URL has been copied to clipboard
       setOpen(true)


### PR DESCRIPTION
The /network endpoint has been removed. Now "0" will be used as a dummy workspace ID.