### PR TITLE
fix bugs related to loading networks from  url

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -187,6 +187,7 @@ const AppShell = (): ReactElement => {
               )
             }
           } else {
+            addNetworkIds(networkId)
             setCurrentNetworkId(networkId)
             navigate(
               `/${id}/networks/${networkId}${location.search.toString()}`,


### PR DESCRIPTION
- routing logic used to assume that the network id exists in the workspace.  changed it to always add the network id to the workspace