### PR TITLE
only show update network dialog when user is logged in

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -56,7 +56,9 @@ const AppShell = (): ReactElement => {
   const deleteNetworkModifiedStatus = useWorkspaceStore(
     (state) => state.deleteNetworkModifiedStatus,
   )
+  const client = useCredentialStore((state) => state.client)
 
+  const authenticated = client?.authenticated ?? false
   const { id, currentNetworkId, networkIds, networkModified } = workspace
 
   const parsed = parsePathName(location.pathname)
@@ -167,8 +169,8 @@ const AppShell = (): ReactElement => {
 
           const localNetworkModified = networkModified[networkId] ?? false
           if (localNetworkOutdated) {
-            if (localNetworkModified) {
-              // local network and ndex network have been modified
+            if (localNetworkModified && authenticated) {
+              // local network and ndex network have been modified and the user is authenticated
               // ask the user what they want to do
               setShowDialog(true)
             } else {

--- a/src/components/UpdateNetworkDialog.tsx
+++ b/src/components/UpdateNetworkDialog.tsx
@@ -55,9 +55,7 @@ export const UpdateNetworkDialog = (props: {
       <DialogTitle>Networks out of sync</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {`There is a newer version of the network '${
-            summary?.name ?? ''
-          }' with changes on NDEx.  Would you like to update your network with the latest version?`}
+          {`The network: ${summary?.name} in your local cache is outdated.  Would you like to update it from NDEx?`}
         </DialogContentText>
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
Based on Jing's requests:
- if user is not logged in just update the network instead of showing the dialog
- make update network dialog text clearer i.e. use words like 'cache'
