### PR TITLE
reset active network view when networks are deleted

### DIFF
--- a/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
+++ b/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
@@ -33,12 +33,24 @@ export const useHierarchyViewerManager = (): void => {
     (state) => state.workspace.networkIds,
   )
 
+  const setActiveNetworkView = useUiStateStore(
+    (state) => state.setActiveNetworkView,
+  )
+  const activeNetworkView = useUiStateStore(
+    (state) => state.ui.activeNetworkView,
+  )
+
   useEffect(() => {
     const deleteChildren = async (parentId: IdType): Promise<void> => {
       const keys = await getAllNetworkKeys()
 
       for (let i = 0; i < keys.length; i++) {
         const key: IdType = keys[i]
+
+        if (key === activeNetworkView) {
+          setActiveNetworkView('')
+        }
+
         if (key.startsWith(parentId)) {
           await deleteNetworkFromDb(key)
           await deleteNetworkViewFromDb(key)
@@ -61,6 +73,7 @@ export const useHierarchyViewerManager = (): void => {
     }
 
     const removed = diff[0]
+
     void deleteChildren(removed).catch((error) => {
       console.error('## Error deleting interaction networks:', error)
     })

--- a/src/store/hooks/useWorkspaceManager.ts
+++ b/src/store/hooks/useWorkspaceManager.ts
@@ -6,6 +6,7 @@ import { useTableStore } from '../TableStore'
 import { useViewModelStore } from '../ViewModelStore'
 import { useVisualStyleStore } from '../VisualStyleStore'
 import { useWorkspaceStore } from '../WorkspaceStore'
+import { useUiStateStore } from '../UiStateStore'
 
 /**
  * Based on the changes in the workspace store, this hook will
@@ -33,6 +34,13 @@ export const useWorkspaceManager = (): void => {
     (state) => state.deleteAllNetworkModifiedStatuses,
   )
 
+  const setActiveNetworkView = useUiStateStore(
+    (state) => state.setActiveNetworkView,
+  )
+  const activeNetworkView = useUiStateStore(
+    (state) => state.ui.activeNetworkView,
+  )
+
   const handleDeleteNetwork = (deleted: IdType): void => {
     deleteNetwork(deleted)
     deleteSummary(deleted)
@@ -40,6 +48,10 @@ export const useWorkspaceManager = (): void => {
     deleteVisualStyle(deleted)
     deleteTables(deleted)
     deleteNetworkModifiedStatus(deleted)
+
+    if (activeNetworkView === deleted) {
+      setActiveNetworkView('')
+    }
   }
 
   const handleDeleteAll = (): void => {
@@ -49,6 +61,7 @@ export const useWorkspaceManager = (): void => {
     deleteAllVisualStyles()
     deleteAllTables()
     deleteAllNetworkModifiedStatuses()
+    setActiveNetworkView('')
   }
 
   useEffect(() => {


### PR DESCRIPTION
- reset active network view if the active network view id in the ui state store matches any hierarchy children to be deleted
- reset active network view id in the ui state store if it matches any of the networks to be deleted