### PR TITLE
Llm empty query

### DIFF
--- a/src/features/LLMQuery/components/LLMQueryOptionsMenuItem.tsx
+++ b/src/features/LLMQuery/components/LLMQueryOptionsMenuItem.tsx
@@ -29,13 +29,12 @@ export const LLMQueryOptionsMenuItem = (props: BaseMenuProps): ReactElement => {
   const setLLMModel = useLLMQueryStore((state) => state.setLLMModel)
   const setLLMApiKey = useLLMQueryStore((state) => state.setLLMApiKey)
   const LLMModel = useLLMQueryStore((state) => state.LLMModel)
-  const LLMApiKey = useLLMQueryStore((state) => state.LLMApiKey)
   const LLMTemplate = useLLMQueryStore((state) => state.LLMTemplate)
   const setLLMTemplate = useLLMQueryStore((state) => state.setLLMTemplate)
 
   const [showDialog, setShowDialog] = useState(false)
   const [localLLMModel, setLocalLLMModel] = useState<LLMModel>(LLMModel)
-  const [localLLMApiKey, setLocalLLMApiKey] = useState<string>(LLMApiKey)
+  const [localLLMApiKey, setLocalLLMApiKey] = useState<string>('')
   const [localLLMTemplate, setLocalLLMTemplate] =
     useState<LLMTemplate>(LLMTemplate)
 

--- a/src/features/LLMQuery/components/LLMQueryOptionsMenuItem.tsx
+++ b/src/features/LLMQuery/components/LLMQueryOptionsMenuItem.tsx
@@ -160,8 +160,10 @@ export const LLMQueryOptionsMenuItem = (props: BaseMenuProps): ReactElement => {
           onClick={() => {
             setShowDialog(false)
             setLLMModel(localLLMModel)
-            setLLMApiKey(localLLMApiKey)
             setLLMTemplate(localLLMTemplate)
+            if (localLLMApiKey !== '') {
+              setLLMApiKey(localLLMApiKey)
+            }
             props.handleClose()
           }}
         >

--- a/src/features/LLMQuery/components/LLMQueryResultPanel.tsx
+++ b/src/features/LLMQuery/components/LLMQueryResultPanel.tsx
@@ -40,6 +40,16 @@ export const LLMQueryResultPanel = (): ReactElement => {
     setLoading(true)
     setPanelState('left', 'open')
     setActiveNetworkBrowserPanelIndex(2)
+
+    if (localQueryValue === '') {
+      addMessage({
+        message: `Unable to send query to the LLM model.  The query string is empty.`,
+        duration: 8000,
+      })
+      setLLMResult('')
+      setLoading(false)
+      return
+    }
     try {
       addMessage({
         message: `Running LLM query...`,
@@ -65,7 +75,7 @@ export const LLMQueryResultPanel = (): ReactElement => {
     setLoading(false)
   }
 
-  const disabled = loading || LLMApiKey === ''
+  const disabled = loading || LLMApiKey === '' || localQueryValue === ''
 
   const regenerateResponseButton = disabled ? (
     <Tooltip

--- a/src/features/LLMQuery/components/RunLLMQueryMenuItem.tsx
+++ b/src/features/LLMQuery/components/RunLLMQueryMenuItem.tsx
@@ -130,6 +130,16 @@ export const RunLLMQueryMenuItem = (props: BaseMenuProps): ReactElement => {
       return
     }
 
+    if (geneNames.length === 0) {
+      addMessage({
+        message: `No gene symbols found for the selected subsystem nodes.  Make sure the ${SubsystemTag.members} or ${SubsystemTag.memberNames} attribute is defined for the selected nodes.`,
+        duration: 8000,
+      })
+      setLoading(false)
+      setLLMResult('')
+      return
+    }
+
     setGeneQuery(serializeValueList(geneNames))
 
     addMessage({

--- a/src/features/LLMQuery/components/RunLLMQueryMenuItem.tsx
+++ b/src/features/LLMQuery/components/RunLLMQueryMenuItem.tsx
@@ -132,7 +132,7 @@ export const RunLLMQueryMenuItem = (props: BaseMenuProps): ReactElement => {
 
     if (geneNames.length === 0) {
       addMessage({
-        message: `No gene symbols found for the selected subsystem nodes.  Make sure the ${SubsystemTag.members} or ${SubsystemTag.memberNames} attribute is defined for the selected nodes.`,
+        message: `No gene symbols found for the selected subsystem nodes.  Make sure the ${SubsystemTag.members} or ${SubsystemTag.memberNames} column is defined for the selected nodes.`,
         duration: 8000,
       })
       setLoading(false)


### PR DESCRIPTION
- dont show default llm keys in the textfield
- llm key field only changes the key when the user enters input, it does nothing if it is empty
- disable regenerate response button when the gene query string is empty
- show warning message when genes were not found in the hcx related columns (members/memberNames)
