### PR TITLE
Fix for duplicate view models bug

### DIFF
--- a/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
+++ b/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
@@ -120,6 +120,9 @@ export const SubNetworkPanel = ({
       revalidateOnFocus: false,
     },
   )
+  if(error !== undefined) {
+    console.error('Failed to get network via SWR', error)
+  }
 
   // A local state to keep track of the current query network id.
   // This is different from the current network id in the workspace.
@@ -146,7 +149,6 @@ export const SubNetworkPanel = ({
       prevQueryNetworkIdRef.current = queryNetworkId
     })
   }, [queryNetworkId])
-  // }, [viewModels[queryNetworkId]])
 
   const saveLastQueryNetworkId = async (id: string): Promise<void> => {
     // const network: Network | undefined = networks.get(id)
@@ -159,15 +161,15 @@ export const SubNetworkPanel = ({
     }
   }
 
-  useEffect(() => {
-    if (isLoading) {
-      return
-    }
+  // useEffect(() => {
+  //   if (isLoading) {
+  //     return
+  //   }
 
-    if (!isLoading && data !== undefined && error === undefined) {
-      updateNetworkView()
-    }
-  }, [isLoading])
+  //   if (!isLoading && data !== undefined && error === undefined) {
+  //     updateNetworkView()
+  //   }
+  // }, [isLoading])
 
   const updateNetworkView = (): string => {
     if (data === undefined) {

--- a/src/models/ViewModel/NetworkView.ts
+++ b/src/models/ViewModel/NetworkView.ts
@@ -17,6 +17,18 @@ export interface NetworkView extends View {
   selectedNodes: IdType[]
   selectedEdges: IdType[]
 
-  // Visualization type (e.g., node-link diagram, circle packing, etc.)
+  /**
+   * Visualization type (e.g., node-link diagram, circle packing, etc.)
+   * nodeLink is the default and will be assigned if not given
+   */
   type?: string
+
+  /**
+   * ID of the view. Syntax: <networkId>-<type>-<index>
+   * e.g., 12345-nodeLink-1
+   *
+   * This will be generated in the store if not given
+   * This will be used to manage the multiple views of the same network
+   */
+  viewId?: IdType
 }

--- a/src/store/ViewModelStore.ts
+++ b/src/store/ViewModelStore.ts
@@ -21,7 +21,7 @@ const DEF_VIEW_TYPE = 'nodeLink'
  * @param views
  * @returns
  */
-const getNetworkViewId = (
+export const getNetworkViewId = (
   newView: NetworkView,
   views: NetworkView[],
 ): IdType => {

--- a/src/store/persist/db.ts
+++ b/src/store/persist/db.ts
@@ -380,14 +380,11 @@ export const putNetworkViewToDb = async (
     if (networkViews !== undefined) {
       const viewList: NetworkView[] = networkViews.views
       // Add only if the view does not exist
-      // const found = viewList.find((v) => v.id + '-' + v.type === view.id + '-' + view.type)
 
       let found = false
       viewList.forEach((v: NetworkView, idx: number) => {
-        const type1: string = v.type ?? 'default'
-        const type2: string = view.type ?? 'default'
-        const key1 = v.id + '-' + type1
-        const key2 = view.id + '-' + type2
+        const key1 = v.viewId
+        const key2 = view.viewId
         if (key1 === key2) {
           viewList[idx] = view
           found = true

--- a/src/store/persist/db.ts
+++ b/src/store/persist/db.ts
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { NetworkView } from '../../models/ViewModel'
 import { Ui } from '../../models/UiModel'
 import { applyMigrations } from './migrations'
+import { getNetworkViewId } from '../ViewModelStore'
 
 const DB_NAME = 'cyweb-db'
 
@@ -391,6 +392,9 @@ export const putNetworkViewToDb = async (
         }
       })
       if (!found) {
+        if(view.viewId === undefined) {
+          view.viewId = getNetworkViewId(view, viewList)
+        }
         viewList.push(view)
       }
       await db.cyNetworkViews.put({
@@ -398,6 +402,10 @@ export const putNetworkViewToDb = async (
         views: viewList,
       })
     } else {
+      if(view.viewId === undefined) {
+        // Add ID if not given
+        view.viewId = getNetworkViewId(view, [])
+      }
       await db.cyNetworkViews.put({ id, views: [view] })
     }
   })

--- a/unittest/store/ViewModelStore.test.ts
+++ b/unittest/store/ViewModelStore.test.ts
@@ -9,13 +9,13 @@ enableMapSet()
 describe('useViewModelStore', () => {
   let mockNetworkView: NetworkView
   let mockNetworkView2: NetworkView
+  let mockNetworkView3: NetworkView
   let networkModelId: IdType
 
   beforeEach(() => {
-    networkModelId = 'networkModelId'
+    networkModelId = 'networkModelId1'
     mockNetworkView = {
       id: networkModelId,
-      type: `${networkModelId}-nodeLink`,
       values: new Map(),
       nodeViews: {
         node1: { id: 'node1', x: 0, y: 0, values: new Map() },
@@ -45,7 +45,7 @@ describe('useViewModelStore', () => {
 
     mockNetworkView2 = {
       id: networkModelId,
-      type: `${networkModelId}-circlePacking`,
+      type: 'circlePacking',
       values: new Map(),
       nodeViews: {
         node6: { id: 'node6', x: 500, y: 501, values: new Map() },
@@ -53,6 +53,23 @@ describe('useViewModelStore', () => {
         node8: { id: 'node8', x: 700, y: 701, values: new Map() },
         node9: { id: 'node9', x: 800, y: 801, values: new Map() },
         node10: { id: 'node10', x: 900, y: 901, values: new Map() },
+      },
+      edgeViews: {
+        edge3: { id: 'edge3', values: new Map() },
+        edge4: { id: 'edge4', values: new Map() },
+      },
+      selectedNodes: [],
+      selectedEdges: [],
+    }
+    
+    mockNetworkView3 = {
+      id: networkModelId,
+      type: 'nodeLink',
+      values: new Map(),
+      nodeViews: {
+        node6: { id: 'node6', x: 500, y: 501, values: new Map() },
+        node7: { id: 'node7', x: 600, y: 601, values: new Map() },
+        node8: { id: 'node8', x: 700, y: 701, values: new Map() },
       },
       edgeViews: {
         edge3: { id: 'edge3', values: new Map() },
@@ -88,17 +105,24 @@ describe('useViewModelStore', () => {
     act(() => {
       result.current.add(networkModelId, mockNetworkView)
       result.current.add(networkModelId, mockNetworkView2)
+      result.current.add(networkModelId, mockNetworkView3)
       primaryView = result.current.getViewModel(networkModelId)
     })
 
     const viewList: NetworkView[] = result.current.viewModels[networkModelId]
-    expect(viewList.length).toEqual(2)
+    expect(viewList.length).toEqual(3)
     const firstView = viewList[0]
     expect(firstView).toEqual(primaryView)
     expect(primaryView).toEqual(mockNetworkView)
+    expect(primaryView?.viewId).toEqual(`${networkModelId}-nodeLink-1`)
 
     const secondView = viewList[1]
     expect(secondView).toEqual(mockNetworkView2)
+    expect(secondView?.viewId).toEqual(`${networkModelId}-circlePacking-1`)
+    
+    const lastView = viewList[2]
+    expect(lastView).toEqual(mockNetworkView3)
+    expect(lastView?.viewId).toEqual(`${networkModelId}-nodeLink-2`)
   })
 
   it('should update selected nodes and edges', async () => {


### PR DESCRIPTION
From this version, _viewId_ will be assigned to the view models in the NetworkView array in the store.

This resolves the bug generating duplicate network view models in the store