### PR TITLE
0 will be used as a valid dummy workspace ID

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -31,6 +31,9 @@ import { PanelState } from '../models/UiModel/PanelState'
 import { Panel } from '../models/UiModel/Panel'
 import { Workspace } from '../models/WorkspaceModel'
 
+// This is a valid workspace ID for sharing
+const DUMMY_WS_ID = '0'
+
 /**
  *
  * Empty application shell only with a toolbar
@@ -39,7 +42,6 @@ import { Workspace } from '../models/WorkspaceModel'
  *
  */
 const AppShell = (): ReactElement => {
-
   const [initializationError, setInitializationError] = useState<string>('')
 
   // This is necessary to prevent creating a new workspace on every render
@@ -115,7 +117,11 @@ const AppShell = (): ReactElement => {
         targetWorkspaceId === '' ? undefined : targetWorkspaceId,
       ).then((workspace: Workspace) => {
         // Add error message if the new workspace ID is not same as the one in URL
-        if (targetWorkspaceId !== workspace.id && targetWorkspaceId !== '') {
+        if (
+          targetWorkspaceId !== workspace.id &&
+          targetWorkspaceId !== '' &&
+          targetWorkspaceId !== DUMMY_WS_ID
+        ) {
           setErrorMessage(
             `An invalid workspace ID was entered (${targetWorkspaceId}). 
             Your workspace has now been initialized with the last cache.`,
@@ -300,7 +306,7 @@ const AppShell = (): ReactElement => {
       />
       <WarningDialog
         title="Initialization Error"
-        subtitle='Problems during initialization:'
+        subtitle="Problems during initialization:"
         message={initializationError}
         open={initializationError !== ''}
         handleClose={() => {


### PR DESCRIPTION
Simple fix to avoid unnecessary warning dialog for the workspace ID for sharing ('0').