### PR TITLE
fix bug where active network view would persist across current network id changes

### DIFF
--- a/src/store/hooks/useWorkspaceManager.ts
+++ b/src/store/hooks/useWorkspaceManager.ts
@@ -81,7 +81,7 @@ export const useWorkspaceManager = (): void => {
   }
 
   useEffect(() => {
-    const sub = useWorkspaceStore.subscribe(
+    const handleNetworkIdDeletion = useWorkspaceStore.subscribe(
       (state) => state.workspace.networkIds,
       (ids, lastIds) => {
         if (ids.length === 0 && lastIds.length !== 0) {
@@ -97,8 +97,23 @@ export const useWorkspaceManager = (): void => {
         }
       },
     )
+
+    // when current network id changes, update the active network view
+    const handleCurrentNetworkIdChange = useWorkspaceStore.subscribe(
+      (state) => state.workspace.currentNetworkId,
+      (id, lastId) => {
+        if (id !== lastId) {
+          if (id === '') {
+            setActiveNetworkView('')
+          } else {
+            setActiveNetworkView(id)
+          }
+        }
+      },
+    )
     return () => {
-      sub() // Unsubscribe
+      handleNetworkIdDeletion() // Unsubscribe
+      handleCurrentNetworkIdChange()
     }
   }, [])
 }


### PR DESCRIPTION
Listen to current network id changes and update the active network view accordingly.