### PR TITLE
Update cytoscape import

### DIFF
--- a/src/models/NetworkModel/impl/CyNetwork.ts
+++ b/src/models/NetworkModel/impl/CyNetwork.ts
@@ -57,10 +57,6 @@ class CyNetwork implements Network {
  * @returns Initialized Cytoscape.js Core object
  */
 const createCyDataStore = (): Core => {
-  window.cytoscape = cytoscape
-  
-  console.log("INITTED CYTOSCAPE")
-
   return cytoscape({
     headless: true,
     styleEnabled: false,

--- a/src/models/NetworkModel/impl/CyNetwork.ts
+++ b/src/models/NetworkModel/impl/CyNetwork.ts
@@ -9,7 +9,7 @@ import { Edge as CxEdge } from '../../CxModel/Cx2/CoreAspects/Edge'
 import * as cxUtil from '../../CxModel/cx2-util'
 
 import { Core, EdgeSingular, NodeSingular } from 'cytoscape'
-import * as cytoscape from 'cytoscape'
+import cytoscape from 'cytoscape'
 
 const GroupType = { Nodes: 'nodes', Edges: 'edges' } as const
 type GroupType = (typeof GroupType)[keyof typeof GroupType]
@@ -56,11 +56,16 @@ class CyNetwork implements Network {
  *
  * @returns Initialized Cytoscape.js Core object
  */
-const createCyDataStore = (): Core =>
-  cytoscape({
+const createCyDataStore = (): Core => {
+  window.cytoscape = cytoscape
+  
+  console.log("INITTED CYTOSCAPE")
+
+  return cytoscape({
     headless: true,
     styleEnabled: false,
   })
+}
 
 /**
  *


### PR DESCRIPTION
This updates the `cytoscape` import to use the default exports of the `cytoscape` package.

It was only luck that it worked before.

Before (bad):

```
import * as cytoscape from 'cytoscape'
```

After (good):

```
import cytoscape from 'cytoscape'
```

See https://github.com/cytoscape/cytoscape.js/issues/3217#issuecomment-1981627469

@GAOChengzhan @d2fong @keiono 