### PR TITLE
CW-164: unregistered networks can be opened in the Cytoscape Desktop

### DIFF
--- a/src/components/FloatingToolBar/FloatingToolBar.tsx
+++ b/src/components/FloatingToolBar/FloatingToolBar.tsx
@@ -6,10 +6,14 @@ import { ShareNetworkButton } from './ShareNetworkButtton'
 interface FloatingToolBarProps {
   // All actions to be performed on the target network if provided
   targetNetworkId?: string
+
+  // Label for the network to be used if the network has no summary
+  networkLabel?: string
 }
 
 export const FloatingToolBar = ({
   targetNetworkId,
+  networkLabel,
 }: FloatingToolBarProps): JSX.Element => {
   return (
     <Box
@@ -28,7 +32,7 @@ export const FloatingToolBar = ({
       <Divider orientation="vertical" flexItem />
       <ApplyLayoutButton targetNetworkId={targetNetworkId} />
       <FitButton />
-      <OpenInCytoscapeButton />
+      <OpenInCytoscapeButton networkLabel={networkLabel} />
       <ShareNetworkButton />
     </Box>
   )

--- a/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
+++ b/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
@@ -15,9 +15,14 @@ import { exportNetworkToCx2 } from '../../store/io/exportCX'
 import { Network } from '../../models/NetworkModel'
 import { useEffect, useState } from 'react'
 import { useUiStateStore } from '../../store/UiStateStore'
-import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
 
-export const OpenInCytoscapeButton = (): JSX.Element => {
+interface OpenInCytoscapeButtonProps {
+  networkLabel?: string
+}
+
+export const OpenInCytoscapeButton = ({
+  networkLabel,
+}: OpenInCytoscapeButtonProps): JSX.Element => {
   const [open, setOpen] = useState<boolean>(false)
   const [message, setMessage] = useState<string>('')
 
@@ -82,25 +87,23 @@ export const OpenInCytoscapeButton = (): JSX.Element => {
     let targetSummary: any = summary
     if (summary === undefined) {
       targetSummary = {
-        name: 'Interaction Network',
+        name: networkLabel ?? 'Interaction Network',
         properties: [],
         externalId: '',
         isReadOnly: false,
         isShowcase: false,
         owner: '',
-        // Add the remaining properties here
       }
     }
 
     const cx = exportNetworkToCx2(
       network,
       visualStyle,
-      // summary,
       targetSummary,
       table.nodeTable,
       table.edgeTable,
       viewModel,
-      `Copy of ${summary?.name}`,
+      targetSummary.name,
     )
     try {
       handleMessageOpen('Sending this network to Cytoscape Desktop...')

--- a/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
+++ b/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
@@ -25,6 +25,7 @@ import { LayoutAlgorithm, LayoutEngine } from '../../../models/LayoutModel'
 import { useLayoutStore } from '../../../store/LayoutStore'
 import { useCredentialStore } from '../../../store/CredentialStore'
 import { useSubNetworkStore } from '../store/SubNetworkStore'
+import { NdexNetworkSummary } from '../../../models/NetworkSummaryModel'
 
 interface SubNetworkPanelProps {
   // Hierarchy ID
@@ -60,6 +61,9 @@ export const SubNetworkPanel = ({
   // A local state to keep track of the current query network id.
   // This is different from the current network id in the workspace.
   const [queryNetworkId, setQueryNetworkId] = useState<string>('')
+
+  // Label of a new network to be created in the Desktop if the network does not have a summary
+  const [networkLabel, setNetworkLabel] = useState<string>('')
 
   const addNewNetwork = useNetworkStore((state) => state.add)
   const addVisualStyle = useVisualStyleStore((state) => state.add)
@@ -220,8 +224,29 @@ export const SubNetworkPanel = ({
     if (data === undefined) {
       return ''
     }
-    const { network, visualStyle, nodeTable, edgeTable, networkViews } = data
+    const {
+      network,
+      visualStyle,
+      nodeTable,
+      edgeTable,
+      networkViews,
+      networkAttributes,
+    } = data
     const newUuid: string = network.id.toString()
+
+    const minimalSummary: any = {
+      name: networkAttributes?.attributes.name ?? 'Interaction Network',
+      properties: [],
+      externalId: '',
+      isReadOnly: false,
+      isShowcase: false,
+      owner: '',
+    }
+
+    setNetworkLabel(
+      (networkAttributes?.attributes.name as string) ??
+        'Interaction Network: ' + newUuid,
+    )
 
     // Add parent network's style to the shared style store
     if (vs[rootNetworkId] === undefined && visualStyle !== undefined) {
@@ -326,7 +351,10 @@ export const SubNetworkPanel = ({
         Subsystem: {subNetworkName}
       </Typography>
       <CyjsRenderer network={queryNetwork} />
-      <FloatingToolBar targetNetworkId={queryNetworkId ?? undefined} />
+      <FloatingToolBar
+        targetNetworkId={queryNetworkId ?? undefined}
+        networkLabel={networkLabel}
+      />
     </Box>
   )
 }


### PR DESCRIPTION
In hierarchy viewer mode, "Open in Cytoscape" button will open the active network, instead of main network.