### PR TITLE
Cw 161

### DIFF
--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -116,6 +116,7 @@ export default function VizmapperView(props: {
   return (
     <Box
       sx={{
+        borderBottom: 1,
         width: '100%',
       }}
     >
@@ -160,7 +161,7 @@ export default function VizmapperView(props: {
               ml: 1,
               mb: 1,
               pt: 1,
-              // overflow: 'scroll',
+              overflow: 'scroll',
               height: props.height - 135, // we want to only scroll the vp list instead of the whole allotment
               // height has to be computed based on allotment size to allow overflow scroll
               // height is passed as a prop but this could be pulled from a uiState store instead in the future

--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -116,7 +116,6 @@ export default function VizmapperView(props: {
   return (
     <Box
       sx={{
-        borderBottom: 1,
         width: '100%',
       }}
     >


### PR DESCRIPTION
Solved the [bug](https://cytoscape.atlassian.net/browse/CW-161) setting `overflow: 'scroll'`.
Now the black line is at the bottom:
| Original Case | Current Case |
|-|-|
|![image](https://github.com/cytoscape/cytoscape-web/assets/39005000/5c566d78-e8ee-48b0-87d1-fb1426899ccc)| <img width="453" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/90dc94a9-6fde-4217-af8b-a0f38997f3c8">|

But actually I suggest we may just delete the bottom line, it might look better without it.
<img width="1470" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/1355b500-1663-4d48-8d70-85ef9e167ce9">
