### PR TITLE
Changed the code to call add to DB function only from the stores

### DIFF
--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -191,7 +191,7 @@ const CyjsRenderer = ({
 
       // single selection listener
       cy.on('tap', (e: EventObject) => {
-        console.log('handling TAP event: ', e)
+        console.debug('handling TAP event: ', e)
         // Check for background click
 
         // This is necessary to access the latest value from closure

--- a/src/components/ToolBar/DataMenu/UploadNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/UploadNetworkMenuItem.tsx
@@ -17,13 +17,7 @@ import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 import { useVisualStyleStore } from '../../../store/VisualStyleStore'
 import { useNetworkStore } from '../../../store/NetworkStore'
 import { useViewModelStore } from '../../../store/ViewModelStore'
-import {
-  putNetworkToDb,
-  putTablesToDb,
-  putVisualStyleToDb,
-  putNetworkViewToDb,
-  putNetworkSummaryToDb,
-} from '../../../store/persist/db'
+import { putNetworkSummaryToDb } from '../../../store/persist/db'
 import { NdexNetworkProperty } from '../../../models/NetworkSummaryModel'
 import {
   getAttributeDeclarations,
@@ -61,23 +55,19 @@ export const UploadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
       LocalNetworkId,
       cxData,
     )
-    await putNetworkToDb(network)
 
     const [nodeTable, edgeTable]: [Table, Table] = TableFn.createTablesFromCx(
       LocalNetworkId,
       cxData,
     )
-    await putTablesToDb(LocalNetworkId, nodeTable, edgeTable)
 
     const visualStyle: VisualStyle =
       VisualStyleFn.createVisualStyleFromCx(cxData)
-    await putVisualStyleToDb(LocalNetworkId, visualStyle)
 
     const networkView: NetworkView = ViewModelFn.createViewModelFromCX(
       LocalNetworkId,
       cxData,
     )
-    await putNetworkViewToDb(LocalNetworkId, networkView)
 
     return { network, nodeTable, edgeTable, visualStyle, networkView }
   }

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -22,7 +22,6 @@ import { useNetworkSummaryStore } from '../../store/NetworkSummaryStore'
 import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
 import { AppConfigContext } from '../../AppConfigContext'
 import { Workspace } from '../../models/WorkspaceModel'
-import { putNetworkViewToDb } from '../../store/persist/db'
 import { NetworkView } from '../../models/ViewModel'
 import { useWorkspaceManager } from '../../store/hooks/useWorkspaceManager'
 
@@ -379,26 +378,16 @@ const WorkSpaceEditor = (): JSX.Element => {
           isLoadingRef.current = false
         })
     } else {
-      putNetworkViewToDb(currentNetworkId, currentNetworkView)
+      loadCurrentNetworkById(currentNetworkId)
         .then(() => {
-          loadCurrentNetworkById(currentNetworkId)
-            .then(() => {
-              // restoreSelectionStates()
-              restoreTableBrowserTabState()
-              navigate(
-                `/${
-                  workspace.id
-                }/networks/${currentNetworkId}${location.search.toString()}`,
-              )
-            })
-            .catch((err) => console.error('Failed to load a network:', err))
+          restoreTableBrowserTabState()
+          navigate(
+            `/${
+              workspace.id
+            }/networks/${currentNetworkId}${location.search.toString()}`,
+          )
         })
-        .catch((err) => {
-          console.error('Failed to save network view to DB:', err)
-        })
-        .finally(() => {
-          isLoadingRef.current = false
-        })
+        .catch((err) => console.error('Failed to load a network:', err))
     }
   }, [currentNetworkId])
 

--- a/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
+++ b/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
@@ -12,7 +12,6 @@ import { Query } from './MainPanel'
 import { useNetworkStore } from '../../../store/NetworkStore'
 import { useVisualStyleStore } from '../../../store/VisualStyleStore'
 import { useUiStateStore } from '../../../store/UiStateStore'
-import { putVisualStyleToDb } from '../../../store/persist/db'
 import { VisualStyle } from '../../../models/VisualStyleModel'
 import { NetworkView } from '../../../models/ViewModel'
 import { useTableStore } from '../../../store/TableStore'
@@ -83,7 +82,6 @@ export const SubNetworkPanel = ({
   const addVisualStyle = useVisualStyleStore((state) => state.add)
   const addTable = useTableStore((state) => state.add)
   const addViewModel = useViewModelStore((state) => state.add)
-  const viewModels = useViewModelStore((state) => state.viewModels)
   const setActiveNetworkView: (id: IdType) => void = useUiStateStore(
     (state) => state.setActiveNetworkView,
   )
@@ -207,7 +205,7 @@ export const SubNetworkPanel = ({
   // The query network to be rendered
   const queryNetwork: Network | undefined = networks.get(queryNetworkId)
 
-  const handleClick = (e: any): void => {
+  const handleClick = (): void => {
     setActiveNetworkView(queryNetworkId)
   }
 
@@ -216,21 +214,8 @@ export const SubNetworkPanel = ({
     if (viewModel === undefined) {
       return
     }
-    void saveLastQueryNetworkId(queryNetworkId).then(() => {
-      prevQueryNetworkIdRef.current = queryNetworkId
-    })
+    prevQueryNetworkIdRef.current = queryNetworkId
   }, [queryNetworkId])
-
-  const saveLastQueryNetworkId = async (id: string): Promise<void> => {
-    // const network: Network | undefined = networks.get(id)
-    const visualStyle: VisualStyle | undefined = vs[id]
-    await putVisualStyleToDb(id, visualStyle)
-
-    const viewModel: NetworkView | undefined = getViewModel(id)
-    if (viewModel !== undefined) {
-      // await putNetworkViewToDb(id, viewModel)
-    }
-  }
 
   const updateNetworkView = (): string => {
     if (data === undefined) {

--- a/src/store/TableStore.ts
+++ b/src/store/TableStore.ts
@@ -113,10 +113,8 @@ const persist =
       async (args) => {
         const currentNetworkId =
           useWorkspaceStore.getState().workspace.currentNetworkId
-        console.log('persist middleware updating table store')
         set(args)
         const updated = get().tables[currentNetworkId]
-        console.log('updated table: ', updated)
         const deleted = updated === undefined
         if (!deleted) {
           await putTablesToDb(
@@ -137,7 +135,18 @@ export const useTableStore = create(
 
       add: (networkId: IdType, nodeTable: Table, edgeTable: Table) => {
         set((state) => {
+          if (state.tables[networkId] !== undefined) {
+            console.warn('Table already exists for network', networkId)
+            return state
+          }
           state.tables[networkId] = { nodeTable, edgeTable }
+          void putTablesToDb(networkId, nodeTable, edgeTable)
+            .then(() => {
+              console.debug('Added tables to DB', networkId)
+            })
+            .catch((err) => {
+              console.error('Error adding tables to DB', err)
+            })
           return state
         })
       },

--- a/src/store/ViewModelStore.ts
+++ b/src/store/ViewModelStore.ts
@@ -282,7 +282,7 @@ export const useViewModelStore = create(
             if (viewType !== 'circlePacking') {
               // Store only default view type (node-link diagram) only.
               void putNetworkViewToDb(networkId, networkView).then(() => {
-                // console.info('Network view model added to the DB.', networkId)
+                console.debug('Network view model added to the DB.', networkId)
               })
             }
             return state

--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -139,7 +139,18 @@ export const useVisualStyleStore = create(
 
       add: (networkId: IdType, visualStyle: VisualStyle) => {
         set((state) => {
+          if (state.visualStyles[networkId] !== undefined) {
+            console.warn(`Visual Style already exists for network ${networkId}`)
+            return state
+          }
           state.visualStyles[networkId] = visualStyle
+          void putVisualStyleToDb(networkId, visualStyle)
+            .then(() => {
+              console.debug('Added visual style to DB', networkId)
+            })
+            .catch((err) => {
+              console.error('Error adding visual style to DB', err)
+            })
           return state
         })
       },
@@ -332,10 +343,10 @@ export const useVisualStyleStore = create(
               visualPropertyType: type,
               defaultValue,
             }
-            void putVisualStyleToDb(
-              networkId,
-              state.visualStyles[networkId],
-            ).then(() => {})
+            // void putVisualStyleToDb(
+            //   networkId,
+            //   state.visualStyles[networkId],
+            // ).then(() => {})
 
             state.visualStyles[networkId][vpName].mapping = continuousMapping
           } else if (vpType === VisualPropertyValueTypeName.Number) {

--- a/src/utils/cx-utils.ts
+++ b/src/utils/cx-utils.ts
@@ -9,9 +9,6 @@ import {
   getTablesFromDb,
   getNetworkViewsFromDb,
   getVisualStyleFromDb,
-  putNetworkToDb,
-  putTablesToDb,
-  putVisualStyleToDb,
 } from '../store/persist/db'
 import { CachedData } from './CachedData'
 import { createNetworkAttributesFromCx } from '../models/TableModel/impl/NetworkAttributesImpl'
@@ -87,22 +84,15 @@ export const createDataFromCx = async (
   cxData: Cx2,
 ): Promise<NetworkWithView> => {
   const network: Network = NetworkFn.createNetworkFromCx(ndexNetworkId, cxData)
-  await putNetworkToDb(network)
-
   const [nodeTable, edgeTable]: [Table, Table] = TableFn.createTablesFromCx(
     ndexNetworkId,
     cxData,
   )
-  await putTablesToDb(ndexNetworkId, nodeTable, edgeTable)
-
   const visualStyle: VisualStyle = VisualStyleFn.createVisualStyleFromCx(cxData)
-  await putVisualStyleToDb(ndexNetworkId, visualStyle)
-
   const networkView: NetworkView = ViewModelFn.createViewModelFromCX(
     ndexNetworkId,
     cxData,
   )
-
   const networkAttributes: NetworkAttributes = createNetworkAttributesFromCx(
     ndexNetworkId,
     cxData,


### PR DESCRIPTION
The new data objects (networks, tables, VS, and network views) should be added only from the data store's "add" method. In this version, I removed the scattered putXtoDB methods and moved those to the store.