### PR TITLE
ensure all nodes are initialized in the node table

### DIFF
--- a/src/models/TableModel/impl/InMemoryTable.ts
+++ b/src/models/TableModel/impl/InMemoryTable.ts
@@ -20,6 +20,7 @@ export const createTablesFromCx = (id: IdType, cx: Cx2): [Table, Table] => {
   const edgeTable = createTable(`${id}-edges`)
 
   const nodes = cxUtil.getNodes(cx)
+  const edges = cxUtil.getEdges(cx)
 
   const nodeAttr: Map<
     string,
@@ -118,6 +119,15 @@ export const createTablesFromCx = (id: IdType, cx: Cx2): [Table, Table] => {
       processedAttributes[translatedAttrName] = value
     })
     edgeTable.rows.set(translatedEdgeId, processedAttributes)
+  })
+
+  // some edges may not have a corresponding entry in the edgeAttr map
+  // initialize them in the table with an empty row
+  edges.forEach((e) => {
+    const translatedEdgeId = translateCXEdgeId(`${e.id}`)
+    if (!edgeTable.rows.has(translatedEdgeId)) {
+      edgeTable.rows.set(translatedEdgeId, {})
+    }
   })
 
   return [nodeTable, edgeTable]

--- a/src/models/TableModel/impl/InMemoryTable.ts
+++ b/src/models/TableModel/impl/InMemoryTable.ts
@@ -9,16 +9,17 @@ import { CxValue } from '../../CxModel/Cx2/CxValue'
 import { AttributeDeclaration } from '../../CxModel/Cx2/CoreAspects/AttributeDeclarations'
 import { translateCXEdgeId } from '../../NetworkModel/impl/CyNetwork'
 
-export const createTable = (id: IdType, cols: Column[] = []): Table => (
-  {
-    id,
-    columns: [...cols],
-    rows: new Map<IdType, Record<AttributeName, ValueType>>(),
-  })
+export const createTable = (id: IdType, cols: Column[] = []): Table => ({
+  id,
+  columns: [...cols],
+  rows: new Map<IdType, Record<AttributeName, ValueType>>(),
+})
 
 export const createTablesFromCx = (id: IdType, cx: Cx2): [Table, Table] => {
   const nodeTable = createTable(`${id}-nodes`)
   const edgeTable = createTable(`${id}-edges`)
+
+  const nodes = cxUtil.getNodes(cx)
 
   const nodeAttr: Map<
     string,
@@ -88,6 +89,14 @@ export const createTablesFromCx = (id: IdType, cx: Cx2): [Table, Table] => {
       processedAttributes[translatedAttrName] = value
     })
     nodeTable.rows.set(nodeId, processedAttributes)
+  })
+
+  // some nodes may not have a corresponding entry in the nodeAttr map
+  // initialize them in the table with an empty row
+  nodes.forEach((n) => {
+    if (!nodeTable.rows.has(`${n.id}`)) {
+      nodeTable.rows.set(`${n.id}`, {})
+    }
   })
 
   edgeAttr.forEach((attr, edgeId) => {


### PR DESCRIPTION
- sometimes nodes may be in the nodes aspect but not in the node attr aspect
- initialze all nodes into the node table when converting cx