### PR TITLE
dont allow a user to open a collection from ndex

### DIFF
--- a/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
@@ -232,6 +232,7 @@ export const LoadFromNdexDialog = (
   const emptyListMessageContent = <Typography>{emptyListMessage}</Typography>
   const networksToRender =
     currentTabIndex === 0 ? searchResultNetworks : myNetworks
+
   const networkListContent = (
     <Box>
       <TableContainer sx={{ height: 460 }}>
@@ -256,6 +257,7 @@ export const LoadFromNdexDialog = (
                 edgeCount,
                 modificationTime,
                 cx2FileSize,
+                subnetworkIds,
               } = network
               const selected = selectedNetworks.includes(externalId)
               const networkAlreadyLoaded = networkIds.includes(externalId)
@@ -263,7 +265,9 @@ export const LoadFromNdexDialog = (
                 +nodeCount + +edgeCount < maxNetworkElementsThreshold &&
                 cx2FileSize < maxNetworkFileSize
               const networkCanBeSelected =
-                !networkAlreadyLoaded && networkIsSmallEnough
+                !networkAlreadyLoaded &&
+                networkIsSmallEnough &&
+                subnetworkIds.length === 0
 
               const dateDisplay = dateFormatter(modificationTime)
 
@@ -353,9 +357,11 @@ export const LoadFromNdexDialog = (
               } else {
                 const tooltipMessage = networkAlreadyLoaded
                   ? 'Network already loaded in the workspace'
-                  : `Networks must be smaller than ${formatBytes(
-                      maxNetworkFileSize,
-                    )} and contain less than ${maxNetworkElementsThreshold} nodes/edges.`
+                  : subnetworkIds.length > 0
+                    ? 'Collections cannot be imported into Cytoscape Web'
+                    : `Networks must be smaller than ${formatBytes(
+                        maxNetworkFileSize,
+                      )} and contain less than ${maxNetworkElementsThreshold} nodes/edges.`
 
                 return (
                   <Tooltip key={externalId} title={tooltipMessage}>


### PR DESCRIPTION
- grey out the network summary in the ndex modal if it is a collection
- a network summary is a collection if the subnetworkIds field is a non empty list