### PR TITLE
potential fix for the passthrough mapping flashing crash bug

### DIFF
--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -12,7 +12,6 @@ import * as d3Scale from 'd3-scale'
 // import * as d3Color from 'd3-color'
 import { VisualPropertyValueTypeName } from '../VisualPropertyValueTypeName'
 
-
 const enumTypes: Set<VisualPropertyValueTypeName> = new Set([
   VisualPropertyValueTypeName.NodeShape,
   VisualPropertyValueTypeName.EdgeLine,
@@ -25,7 +24,23 @@ const enumTypes: Set<VisualPropertyValueTypeName> = new Set([
 ])
 
 // all enum value strings are in lower case
-const enumValueNormalizationFn = (value: string): string => value.toLowerCase()
+const enumValueNormalizationFn = (
+  pm: PassthroughMappingFunction,
+  value: VisualPropertyValueType,
+): VisualPropertyValueType => {
+  if (pm.visualPropertyType === VisualPropertyValueTypeName.Visibility) {
+    if (typeof value === 'string') {
+      const normalizedValue = value.toLowerCase()
+      if (normalizedValue === 'true' || normalizedValue === 'false') {
+        return JSON.parse(normalizedValue)
+      }
+    }
+    if (typeof value === 'boolean') {
+      return value
+    }
+  }
+  return value
+}
 /**
  * Derive the mapping function from given VMF object
  */
@@ -41,10 +56,9 @@ export const createPassthroughMapper = (
 ): Mapper => {
   return (value: ValueType): VisualPropertyValueType => {
     if (enumTypes.has(pm.visualPropertyType)) {
-      return enumValueNormalizationFn(value as string) as VisualPropertyValueType
+      return enumValueNormalizationFn(pm, value as VisualPropertyValueType)
     } else {
       return (value as VisualPropertyValueType) ?? pm.defaultValue
-
     }
   }
 }


### PR DESCRIPTION
### Context
- There exists a set of visual property values that are considered enums (node shape, edge line, visibility etc)
- All the current enum types except visibility are strings (visibility is a boolean)
- There is variation in how a user wants to passthrough map visibility:
   - 'TRUE', 'True', 'false', false 
 
This fixes a bug in the code that assumed that visibility would always be passed as a string (sometimes people pass a boolean column)

Just looking for comments to see if this is ok.  

There is another related bug to fix that stops the flickering from happening when each passthrough value throws an error.  Or whenever multiple values throw the same error again and again.

It may be more proper to not consider visibility as an enum type and then just have specific logic for visibility to be accepting of strings and booleans.

### Test Case:
1. Go to cytoscape web configured for dev
2. Load the network G2PT_Reactome
3. The network should no longer throw the error flashing screen