### PR TITLE
Solved the CW-242 bug

### DIFF
--- a/src/components/Util/ConfirmationDialog.tsx
+++ b/src/components/Util/ConfirmationDialog.tsx
@@ -18,10 +18,12 @@ export const ConfirmationDialog = (
 ): JSX.Element => {
   const { open, setOpen, message, title, buttonTitle, onConfirm } = props
 
-  const handleCancel = (): void => {
+  const handleCancel = (e: React.MouseEvent<HTMLButtonElement>): void => {
+    e.stopPropagation()
     setOpen(false)
   }
-  const handleConfirm = (): void => {
+  const handleConfirm = (e: React.MouseEvent<HTMLButtonElement>): void => {
+    e.stopPropagation()
     setOpen(false)
     onConfirm()
   }


### PR DESCRIPTION
Ticket: [CW-242](https://cytoscape.atlassian.net/browse/CW-242)
The root of the bug is that the click on the delete icon or the confirmation window would also further trigger the click on the network panel. This can be resolved by adding e.stopPropagation() to stop the event propagation.
Previously e.stopPropagation was only added to the delete icon. After adding the confirmation window, the click on the confirmation window (either _confirm_ or _cancel_) would also trigger the click on the network panel and further set the currentNetwork ID. 

[CW-242]: https://cytoscape.atlassian.net/browse/CW-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ