### PR TITLE
fix bug where the search ndex input could not be focused

### DIFF
--- a/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
@@ -387,6 +387,10 @@ export const LoadFromNdexDialog = (
   const { open, handleClose } = props
   return (
     <Dialog
+      onKeyDown={(e) => {
+        e.stopPropagation()
+        e.preventDefault()
+      }}
       onClick={(e) => {
         e.stopPropagation()
         e.preventDefault()

--- a/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
@@ -68,10 +68,6 @@ export const NetworkSeachField = (props: {
         type="text"
         fullWidth
         variant="standard"
-        onFocus={(e) => {
-          e.stopPropagation()
-          e.preventDefault()
-        }}
         onChange={(e) => setSearchValue(e.target.value)}
         value={searchValue}
         onKeyDown={handleKeyDown}

--- a/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
@@ -68,6 +68,10 @@ export const NetworkSeachField = (props: {
         type="text"
         fullWidth
         variant="standard"
+        onFocus={(e) => {
+          e.stopPropagation()
+          e.preventDefault()
+        }}
         onChange={(e) => setSearchValue(e.target.value)}
         value={searchValue}
         onKeyDown={handleKeyDown}
@@ -387,6 +391,10 @@ export const LoadFromNdexDialog = (
   const { open, handleClose } = props
   return (
     <Dialog
+      onClick={(e) => {
+        e.stopPropagation()
+        e.preventDefault()
+      }}
       PaperProps={{
         sx: {
           minHeight: 600,


### PR DESCRIPTION
Add event handler in the parent modal element to prevent event propagation and prevent default.  When the user would click on the input it would trigger the menu items event handlers, overriding the input field event handler, preventing it from being focused.