### PR TITLE
Make the Worksapce and LLM Query Tab stick to the top

### DIFF
--- a/src/components/SummaryPanel/Summaries.tsx
+++ b/src/components/SummaryPanel/Summaries.tsx
@@ -3,6 +3,7 @@ import { IdType } from '../../models/IdType'
 import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
 import { NetworkPropertyPanel } from './NetworkPropertyPanel'
 import { MessagePanel } from '../Messages'
+import { Box } from '@mui/material'
 
 interface SummariesProps {
   summaries: Record<IdType, NdexNetworkSummary>
@@ -10,17 +11,23 @@ interface SummariesProps {
 
 export const Summaries = ({ summaries }: SummariesProps): ReactElement => {
   const summaryData = Object.values(summaries)
-
   if (summaryData.length === 0) {
     return <MessagePanel message="No network in workspace" />
   }
+
   return (
-    <>
+    <Box
+      sx={{
+        overflow: 'auto',
+        width: '100%',
+        height: '100%',
+      }}
+    >
       {summaryData.map((summary: NdexNetworkSummary) => {
         return (
           <NetworkPropertyPanel key={summary.externalId} summary={summary} />
         )
       })}
-    </>
+    </Box>
   )
 }

--- a/src/components/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
+++ b/src/components/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
@@ -166,7 +166,13 @@ export const NetworkBrowserPanel = ({
       </div>
       <div hidden={currentTabIndex !== 2}>
         {currentTabIndex === 2 && (
-          <Box>
+          <Box
+            sx={{
+              height: allotmentDimensions[0] - 96,
+              width: '100%',
+              padding: 0,
+              margin: 0,
+            }}>
             <LLMQueryResultPanel />
           </Box>
         )}

--- a/src/components/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
+++ b/src/components/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
@@ -141,11 +141,9 @@ export const NetworkBrowserPanel = ({
         {currentTabIndex === 0 && (
           <Box
             sx={{
-              overflow: 'auto',
-              // height: '100%',
-              // height: allotmentDimensions[0] - 48,
+              height: allotmentDimensions[0] - 96,
               // need to set a height to enable scroll in the network list
-              // 48 is the height of the tool bar
+              // 96 is the height of the tool bar
               width: '100%',
               padding: 0,
               margin: 0,

--- a/src/features/LLMQuery/components/LLMQueryResultPanel.tsx
+++ b/src/features/LLMQuery/components/LLMQueryResultPanel.tsx
@@ -103,7 +103,7 @@ export const LLMQueryResultPanel = (): ReactElement => {
   )
 
   return (
-    <Box sx={{ p: 1 }}>
+    <Box sx={{ overflow: 'auto', width: '100%', height: '100%', p: 1 }}>
       <Box>
         <Tooltip title="enter a comma space seperated list of gene names e.g. 'FOXA1, HNF1A, PDX1' ">
           <TextField
@@ -119,10 +119,12 @@ export const LLMQueryResultPanel = (): ReactElement => {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
+            mt: 1,
+            mb: 1
           }}
         >
           {regenerateResponseButton}
-          <Box>{`Model: ${LLMModel}`}</Box>
+          <Box sx={{ ml: 2 }}>{`Model: ${LLMModel}`}</Box>
         </Box>
       </Box>
       <Box>


### PR DESCRIPTION
Jira: [CW-234](https://cytoscape.atlassian.net/browse/CW-234)
|  Workspace |  LLM Query |
| -| -|
|<img height="350" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/f1a7eb51-7ea7-4e1f-90fe-230fd0b59773">| <img height="350" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/141de0ea-fedb-4ea9-89d0-fc40be3caea6">|

[CW-234]: https://cytoscape.atlassian.net/browse/CW-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ