### PR TITLE
Fix passthrough bugs

### DIFF
--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -1,5 +1,6 @@
 import { ValueType } from '../../TableModel'
 import { ColorType, VisualPropertyValueType } from '../VisualPropertyValue'
+import { VisibilityType } from '../../VisualStyleModel/VisualPropertyValue/VisibilityType'
 import {
   ContinuousFunctionControlPoint,
   ContinuousMappingFunction,
@@ -32,11 +33,13 @@ const enumValueNormalizationFn = (
     if (typeof value === 'string') {
       const normalizedValue = value.toLowerCase()
       if (normalizedValue === 'true' || normalizedValue === 'false') {
-        return JSON.parse(normalizedValue)
+        return normalizedValue === 'true'
+          ? VisibilityType.Element
+          : VisibilityType.None
       }
     }
     if (typeof value === 'boolean') {
-      return value
+      return value === true ? VisibilityType.Element : VisibilityType.None
     }
   }
   return value

--- a/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
+++ b/src/models/VisualStyleModel/impl/MappingFunctionImpl.ts
@@ -2,7 +2,10 @@ import { ValueTypeName } from '../../TableModel'
 import { SingleValueType } from '../../TableModel/ValueType'
 import { MappingFunctionType, VisualPropertyValueTypeName } from '..'
 
-const valueType2BaseType: Record<ValueTypeName | VisualPropertyValueTypeName, SingleValueType | null> = {
+const valueType2BaseType: Record<
+  ValueTypeName | VisualPropertyValueTypeName,
+  SingleValueType | null
+> = {
   [ValueTypeName.String]: 'string',
   [ValueTypeName.Long]: 'number',
   [ValueTypeName.Integer]: 'number',
@@ -52,16 +55,17 @@ export const typesCanBeMapped = (
   mappingType: MappingFunctionType,
   valueTypeName: ValueTypeName,
   vpValueTypeName: VisualPropertyValueTypeName,
-  columnName?: string
+  columnName?: string,
 ): boolean => {
   if (mappingType === MappingFunctionType.Passthrough) {
     const vtBaseType = valueType2BaseType[valueTypeName]
     const isSingleValue = vtBaseType != null
-    const typesMatch = valueTypeName === vpValueTypeName
-    const singleStringType = isSingleValue && valueType2BaseType[vpValueTypeName] === VisualPropertyValueTypeName.String /// any single value type can be mapped to a string
-    return (
-      typesMatch || singleStringType
-    )
+    const typesMatch =
+      valueTypeName === vpValueTypeName || vtBaseType === vpValueTypeName
+    const singleStringType =
+      isSingleValue &&
+      valueType2BaseType[vpValueTypeName] === VisualPropertyValueTypeName.String /// any single value type can be mapped to a string
+    return typesMatch || singleStringType
   }
 
   if (mappingType === MappingFunctionType.Continuous) {


### PR DESCRIPTION
- fix issue where users would passthrough map a boolean onto visibility (which is currently an enum of two string values) by converting booleans to their respective values (true => 'element', false => 'none')
- fix issue where passthrough mappings would not be populated correctly in the mapping form