### PR TITLE
Improved the behavior of delete button

### DIFF
--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -43,6 +43,7 @@ export const NetworkPropertyPanel = ({
   const currentNetworkId: IdType = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
+  const [lastOpenedNetworkId, setLastOpenedNetworkId] = useState<IdType>('')
   const setCurrentNetworkId: (id: IdType) => void = useWorkspaceStore(
     (state) => state.setCurrentNetworkId,
   )
@@ -69,7 +70,16 @@ export const NetworkPropertyPanel = ({
 
   const onClickDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
+    setLastOpenedNetworkId(currentNetworkId)
+    setCurrentNetworkId(id)
     setOpenConfirmation(true)
+  }
+
+  const onConfirmDelete = () => {
+    deleteNetwork(id);
+    if (lastOpenedNetworkId && lastOpenedNetworkId !== id) {
+      setCurrentNetworkId(lastOpenedNetworkId);
+    }
   }
 
   const backgroundColor: string =
@@ -168,7 +178,7 @@ export const NetworkPropertyPanel = ({
         <ConfirmationDialog
           title="Remove Network From Workspace"
           message={`Do you really want to delete the network, ${summary.name}?`}
-          onConfirm={() => { deleteNetwork(id); }}
+          onConfirm={onConfirmDelete}
           open={openConfirmation}
           setOpen={setOpenConfirmation}
           buttonTitle="Yes (cannot be undone)"

--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -82,6 +82,12 @@ export const NetworkPropertyPanel = ({
     }
   }
 
+  const onCancelDelete = () => {
+    if (lastOpenedNetworkId && lastOpenedNetworkId !== id) {
+      setCurrentNetworkId(lastOpenedNetworkId);
+    }
+  }
+
   const backgroundColor: string =
     currentNetworkId === id ? blueGrey[100] : '#FFFFFF'
 
@@ -178,6 +184,7 @@ export const NetworkPropertyPanel = ({
         <ConfirmationDialog
           title="Remove Network From Workspace"
           message={`Do you really want to delete the network, ${summary.name}?`}
+          onCancel={onCancelDelete}
           onConfirm={onConfirmDelete}
           open={openConfirmation}
           setOpen={setOpenConfirmation}

--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -69,7 +69,6 @@ export const NetworkPropertyPanel = ({
 
   const onClickDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
-    setCurrentNetworkId(id)
     setOpenConfirmation(true)
   }
 

--- a/src/components/Util/ConfirmationDialog.tsx
+++ b/src/components/Util/ConfirmationDialog.tsx
@@ -12,15 +12,19 @@ interface ConfirmationDialogProps {
   message: string
   buttonTitle?: string
   onConfirm: () => void
+  onCancel?: () => void
 }
 export const ConfirmationDialog = (
   props: ConfirmationDialogProps,
 ): JSX.Element => {
-  const { open, setOpen, message, title, buttonTitle, onConfirm } = props
+  const { open, setOpen, message, title, buttonTitle, onConfirm, onCancel } = props
 
   const handleCancel = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.stopPropagation()
     setOpen(false)
+    if (onCancel) {
+      onCancel()
+    }
   }
   const handleConfirm = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.stopPropagation()


### PR DESCRIPTION
If the user wants to delete a network that is not the currently selected network:
1. Firstly, it would set currentNetworkId in the workspace to the networkId to delete, so that the user knows what exactly the network he/she is going to delete.
2. Then it shows the confirmation window. If the user confirms, it will delete the network from the workspace and then set the currenNetworkId in the workspace back to the network just now opened.
