### PR TITLE
Solved A few issues in Network Merger

### DIFF
--- a/src/components/ToolBar/ToolsMenu/MergeNetwork.tsx
+++ b/src/components/ToolBar/ToolsMenu/MergeNetwork.tsx
@@ -29,7 +29,7 @@ export const MergeNetwork = ({ handleClose }: BaseMenuProps): ReactElement => {
     const workSpaceNetworks: Pair<string, string>[] = networkIds.map((networkId) => {
         const networkName = networkSummaries[networkId]?.name
         return [networkName, networkId]
-    })
+    }).filter((pair) => pair[0] !== undefined && pair[1] !== undefined) as Pair<string, string>[];
     const uniqueName = generateUniqueName(workSpaceNetworks.map(net => net[0]), 'Merged Network');
 
     const handleOpenDialog = (): void => {

--- a/src/features/MergeNetworks/components/MatchingTableComp.tsx
+++ b/src/features/MergeNetworks/components/MatchingTableComp.tsx
@@ -11,6 +11,7 @@ import { Column } from '../../../models/TableModel/Column';
 import useNodeMatchingTableStore from '../store/nodeMatchingTableStore';
 import useEdgeMatchingTableStore from '../store/edgeMatchingTableStore';
 import useNetMatchingTableStore from '../store/netMatchingTableStore';
+import useMergeToolTipStore from '../store/mergeToolTip';
 
 interface MatchingTableProps {
     networkRecords: Record<IdType, NetworkRecord>
@@ -29,8 +30,35 @@ export const MatchingTableComp = React.memo(({ networkRecords, netLst, type }: M
         const updatedRow = { ...tableData[rowIndex], mergedNetwork: e.target.value };
         setMatchingTable(rowIndex, updatedRow);
     };
+    const setMergeTooltipIsOpen = useMergeToolTipStore(state => state.setIsOpen)
+    const setMergeTooltipText = useMergeToolTipStore(state => state.setText)
+    const name2RowId = new Map<string, number[]>();
+    const emptyRowIds = new Set<number>();
+    tableData.forEach((row) => {
+        const name = row.mergedNetwork;
+        if (name.length > 0) {
+            if (name2RowId.has(row.mergedNetwork)) {
+                name2RowId.get(row.mergedNetwork)?.push(row.id);
+            } else {
+                name2RowId.set(row.mergedNetwork, [row.id]);
+            }
+        } else {
+            emptyRowIds.add(row.id);
+        }
+    });
+    //get rows that have duplicated name
+    const duplicatedNamesIds = new Set((Array.from(name2RowId.values()).filter((ids) => ids.length > 1)).reduce((acc, val) => acc.concat(val), []));
+    if (duplicatedNamesIds.size > 0) {
+        setMergeTooltipIsOpen(true);
+        setMergeTooltipText('Some rows have duplicated names. Please make sure each row has a unique name.');
+    } else if (emptyRowIds.size > 0) {
+        setMergeTooltipIsOpen(true);
+        setMergeTooltipText('Merged network attribute name cannot be empty.');
+    } else {
+        setMergeTooltipIsOpen(false);
+    }
     return (
-        <TableContainer component={Paper} sx={{ maxHeight: 500, overflow: 'auto' }}>
+        <TableContainer key={`${type}-tablecontainer`} component={Paper} sx={{ maxHeight: 500, overflow: 'auto' }}>
             <Table sx={{ minWidth: 400 }} aria-label="simple table">
                 <TableHead>
                     <TableRow>
@@ -43,18 +71,31 @@ export const MatchingTableComp = React.memo(({ networkRecords, netLst, type }: M
                 </TableHead>
                 <TableBody>
                     {tableData.map((row, rowIndex) => (
-                        <TableRow key={row.id}>
-                            {netLst.map((net) => (
-                                <TableCell key={`${row.id}-${net[1]}`} component="th" scope="row">
-                                    <NetAttDropDownTemplate
-                                        networkRecords={networkRecords} rowData={row}
-                                        column={net[1]} type={type} netLst={netLst}
-                                    />
-                                </TableCell>
-                            ))}
-                            <TableCell key={`${row.id}-mergedNetwork`}>
-                                {(row.id === 0 && type === TableView.node) ?
-                                    <Tooltip title={'This attribute is used to match nodes between networks.'} placement="top" arrow>
+                        <Tooltip key={`${row.id}-row-tooltip`} title={row.hasConflicts ? 'This row has type conflict' :
+                            (duplicatedNamesIds.has(row.id) ? 'This row has duplicated merged network attribute name' :
+                                (emptyRowIds.has(row.id) ? 'This row\'s merged network attribute name is empty' : ''))} placement="top" arrow>
+                            <TableRow key={`${row.id}-row`} style={{ backgroundColor: (row.hasConflicts || duplicatedNamesIds.has(row.id) || emptyRowIds.has(row.id)) ? '#e27070' : 'transparent' }}>
+                                {netLst.map((net) => (
+                                    <TableCell key={`${row.id}-${net[1]}`} component="th" scope="row">
+                                        <NetAttDropDownTemplate
+                                            networkRecords={networkRecords} rowData={row}
+                                            column={net[1]} type={type} netLst={netLst}
+                                        />
+                                    </TableCell>
+                                ))}
+                                <TableCell key={`${row.id}-mergedNetwork`}>
+                                    {(row.id === 0 && type === TableView.node) ?
+                                        <Tooltip key={`${row.id}-mergedNetwork-tooltip`} title={'This attribute is used to match nodes between networks.'} placement="top" arrow>
+                                            <TextField
+                                                key={`${row.id}-matchingAttribute-textField`}
+                                                fullWidth
+                                                variant="outlined"
+                                                value={row.mergedNetwork}
+                                                onChange={(e) => onMergedNetworkChange(e, row.id)}
+                                                style={{ minWidth: 100 }}
+                                                InputProps={{ style: { color: 'red' } }}
+                                            />
+                                        </Tooltip> :
                                         <TextField
                                             key={`${row.id}-textField`}
                                             fullWidth
@@ -62,27 +103,14 @@ export const MatchingTableComp = React.memo(({ networkRecords, netLst, type }: M
                                             value={row.mergedNetwork}
                                             onChange={(e) => onMergedNetworkChange(e, row.id)}
                                             style={{ minWidth: 100 }}
-                                            InputProps={{ style: { color: 'red' } }}
-                                        />
-                                    </Tooltip> :
-                                    <TextField
-                                        key={`${row.id}-textField`}
-                                        fullWidth
-                                        variant="outlined"
-                                        value={row.mergedNetwork}
-                                        onChange={(e) => onMergedNetworkChange(e, row.id)}
-                                        style={{ minWidth: 100 }}
-                                        disabled={type === TableView.network && rowIndex < 3}
-                                    />}
-                            </TableCell>
-                            <TableCell key={`${row.id}-type`}>
-                                <TypeDropDownTemplate type={type} rowData={row} netLst={netLst} />
-                                {row.hasConflicts ?
-                                    <Tooltip title={'Type coercion may be applied to this attribute.'} placement="top" arrow>
-                                        <PriorityHighIcon viewBox="0 -3.7 24 24" style={{ color: 'red' }} />
-                                    </Tooltip > : ''}
-                            </TableCell>
-                        </TableRow>
+                                            disabled={type === TableView.network && rowIndex < 3}
+                                        />}
+                                </TableCell>
+                                <TableCell key={`${row.id}-type`}>
+                                    <TypeDropDownTemplate type={type} rowData={row} netLst={netLst} />
+                                </TableCell>
+                            </TableRow>
+                        </Tooltip>
                     ))}
                 </TableBody>
             </Table>

--- a/src/features/MergeNetworks/components/MatchingTableComp.tsx
+++ b/src/features/MergeNetworks/components/MatchingTableComp.tsx
@@ -53,15 +53,27 @@ export const MatchingTableComp = React.memo(({ networkRecords, netLst, type }: M
                                 </TableCell>
                             ))}
                             <TableCell key={`${row.id}-mergedNetwork`}>
-                                <TextField
-                                    key={`${row.id}-textField`}
-                                    fullWidth
-                                    variant="outlined"
-                                    value={row.mergedNetwork}
-                                    onChange={(e) => onMergedNetworkChange(e, row.id)}
-                                    style={{ minWidth: 100 }}
-                                    disabled={type === TableView.network && rowIndex < 3}
-                                />
+                                {(row.id === 0 && type === TableView.node) ?
+                                    <Tooltip title={'This attribute is used to match nodes between networks.'} placement="top" arrow>
+                                        <TextField
+                                            key={`${row.id}-textField`}
+                                            fullWidth
+                                            variant="outlined"
+                                            value={row.mergedNetwork}
+                                            onChange={(e) => onMergedNetworkChange(e, row.id)}
+                                            style={{ minWidth: 100 }}
+                                            InputProps={{ style: { color: 'red' } }}
+                                        />
+                                    </Tooltip> :
+                                    <TextField
+                                        key={`${row.id}-textField`}
+                                        fullWidth
+                                        variant="outlined"
+                                        value={row.mergedNetwork}
+                                        onChange={(e) => onMergedNetworkChange(e, row.id)}
+                                        style={{ minWidth: 100 }}
+                                        disabled={type === TableView.network && rowIndex < 3}
+                                    />}
                             </TableCell>
                             <TableCell key={`${row.id}-type`}>
                                 <TypeDropDownTemplate type={type} rowData={row} netLst={netLst} />

--- a/src/features/MergeNetworks/components/MergeDialog.css
+++ b/src/features/MergeNetworks/components/MergeDialog.css
@@ -12,7 +12,7 @@
 
 .toggleButton.selected {
     color: white !important;
-    background-color: #227dd8 !important;
+    background-color: #217dd8 !important;
 }
 
 .toggleButton:hover {
@@ -21,10 +21,20 @@
 
 /* button */
 .arrowButton {
-    background-color: #227dd8;
+    background-color: #217dd8 !important;
+    color: white !important;
     margin-top: 8px !important;
     min-width: 36px !important;
     padding: 2px !important;
+}
+
+.arrowButton:disabled {
+    background: #e0e0e0 !important;
+    color: #A6A6A6 !important
+}
+
+.arrowButton:hover {
+    background-color: #337ab7 !important;
 }
 
 .arrowIcon {
@@ -34,4 +44,13 @@
 /* union difference and intersection icon */
 .iconify.iconify--gis {
     margin-right: 5px;
+}
+
+/* list header */
+.listSubheader {
+    font-size: 1.0em !important;
+    background-color: #217dd8 !important;
+    color: white !important;
+    padding-left: 17px !important;
+    border-radius: 4px !important
 }

--- a/src/features/MergeNetworks/components/MergeDialog.css
+++ b/src/features/MergeNetworks/components/MergeDialog.css
@@ -7,7 +7,15 @@
 }
 
 .toggleButton {
-    border: 1px solid #565656 !important;
+    border: 1.5px solid #565656 !important;
+}
+
+.toggleButton:first-child {
+    border-right: none !important;
+}
+
+.toggleButton:last-child {
+    border-left: none !important;
 }
 
 .toggleButton.selected {
@@ -52,5 +60,11 @@
     background-color: #217dd8 !important;
     color: white !important;
     padding-left: 17px !important;
-    border-radius: 4px !important
+    border-radius: 4px 4px 0 0 !important;
+    border-bottom: 2px solid #000000 !important;
+}
+
+.scrollableList {
+    overflow: auto;
+    max-height: 250px;
 }

--- a/src/features/MergeNetworks/components/MergeDialog.css
+++ b/src/features/MergeNetworks/components/MergeDialog.css
@@ -34,7 +34,7 @@
 }
 
 .arrowButton:hover {
-    background-color: #337ab7 !important;
+    background-color: #337AB7 !important;
 }
 
 .arrowIcon {

--- a/src/features/MergeNetworks/components/MergeDialog.css
+++ b/src/features/MergeNetworks/components/MergeDialog.css
@@ -62,6 +62,7 @@
     padding-left: 17px !important;
     border-radius: 4px 4px 0 0 !important;
     border-bottom: 2px solid #000000 !important;
+    position: relative !important;
 }
 
 .scrollableList {

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -524,8 +524,8 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                             }}
                         />
                         {isNameDuplicate && (
-                            <Typography color="error">
-                                This name already exists. Please choose a different name.
+                            <Typography color="orange">
+                                Warning: A network with this name already exists in your workspace.
                             </Typography>
                         )}
                         <Typography variant="h6" style={{ margin: '5px 0 10px 0' }}>

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -66,6 +66,8 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
     const [fullScreen, setFullScreen] = useState(false); // Full screen mode for the dialog
     const [tooltipOpen, setTooltipOpen] = useState(false); // Flag to indicate whether the tooltip is open
     const [strictRemoveMode, setStrictRemoveMode] = useState(false); // Flag to indicate the rules of difference merge
+    const [isNameDuplicate, setIsNameDuplicate] = useState(false);
+    const existingNetNames = new Set(workSpaceNetworks.map(pair => pair[0])); // Set of existing network names
     // confirmation window
     const [openConfirmation, setOpenConfirmation] = useState(false);
     const [confirmationTitle, setConfirmationTitle] = useState('');
@@ -266,7 +268,9 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
     };
     // Function to handle changes in the merged network name
     const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setMergedNetworkName(event.target.value);
+        const newName = event.target.value;
+        setMergedNetworkName(newName);
+        setIsNameDuplicate(existingNetNames.has(newName));
     };
     // Function to handle switch in the matching table view
     const handleTableViewChange = (event: React.MouseEvent<HTMLElement>, newTableView: TableView) => {
@@ -529,7 +533,15 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                             onChange={handleNameChange}
                             fullWidth
                             margin="normal"
+                            InputProps={{
+                                style: { color: isNameDuplicate ? 'orange' : 'inherit' }
+                            }}
                         />
+                        {isNameDuplicate && (
+                            <Typography color="error">
+                                This name already exists. Please choose a different name.
+                            </Typography>
+                        )}
                         <Typography variant="h6" style={{ margin: '5px 0 10px 0' }}>
                             Matching columns:
                         </Typography>

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -286,31 +286,6 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
         setFullScreen(!fullScreen);
         setTooltipOpen(false); // Close tooltip on toggle
     };
-    // Update the matching table when selectedNetworks changes
-    useEffect(() => {
-        // check whether it is ready to merge
-        if (toMergeNetworksList.length > 0) {
-            let isReady = true
-            toMergeNetworksList.forEach((net) => {
-                if (!networkRecords[net[1]]?.nodeTable?.columns.some(col => col.name === matchingCols[net[1]].name && col.type === matchingCols[net[1]].type)) {
-                    isReady = false
-                    setMergeTooltipText("The matching column for " + net[0] + " is not found in the node table.")
-                }
-            })
-            // Intersection Operation must take two or more networks while Difference Operation must take exactly two networks
-            if (mergeOpType === MergeType.intersection && toMergeNetworksList.length < 2) {
-                isReady = false
-                setMergeTooltipText("Intersection operation must take two or more networks")
-            } else if (mergeOpType === MergeType.difference && toMergeNetworksList.length !== 2) {
-                isReady = false
-                setMergeTooltipText("Difference operation must take exactly two networks")
-            }
-            setMergeTooltipIsOpen(!isReady);
-        } else {
-            setMergeTooltipIsOpen(true);
-            setMergeTooltipText("Please select networks to merge")
-        }
-    }, [toMergeNetworksList, matchingCols, mergeOpType, networkRecords]);
 
     // Set the initial state of the networkRecords
     useEffect(() => {
@@ -472,22 +447,22 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                 </Typography>
 
                 <Box display="flex" justifyContent="space-between" p={2}>
-                    <List
-                        subheader={<ListSubheader className="listSubheader" component="div" >Available Networks</ListSubheader>}
-                        component={Paper}
-                        style={{ width: '42.5%', maxHeight: 300, overflow: 'auto' }}
-                    >
-                        {availableNetworksList.map((network, index) => (
-                            <ListItem
-                                button
-                                selected={selectedAvailable.includes(network)}
-                                onClick={() => handleSelectAvailable(network[1])}
-                                key={index}
-                            >
-                                <ListItemText primary={network[0]} />
-                            </ListItem>
-                        ))}
-                    </List>
+                    <Paper style={{ width: '42.5%' }}>
+                        <ListSubheader className="listSubheader" component="div">Available Networks</ListSubheader>
+                        <List className="scrollableList" component="div">
+                            {availableNetworksList.map((network, index) => (
+                                <ListItem
+                                    button
+                                    selected={selectedAvailable.includes(network)}
+                                    onClick={() => handleSelectAvailable(network[1])}
+                                    key={index}
+                                >
+                                    <ListItemText primary={network[0]} />
+                                </ListItem>
+                            ))}
+                        </List>
+                    </Paper>
+
                     <Box display="flex" flexDirection="column" justifyContent="center" m={1}>
                         <Button className="arrowButton" variant="contained" onClick={handleAddNetwork} disabled={selectedAvailable.length === 0} size='small'>
                             <ArrowForwardIcon className="arrowIcon" fontSize="small" />
@@ -496,30 +471,29 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                             <ArrowBackIcon className="arrowIcon" fontSize="small" />
                         </Button>
                     </Box>
-                    <List
-                        subheader={<ListSubheader className="listSubheader" component="div" >Networks to Merge</ListSubheader>}
-                        component={Paper}
-                        style={{ width: '42.5%', maxHeight: 300, overflow: 'auto' }}
-                    >
-                        {toMergeNetworksList.map((network, index) => (
-                            <ListItem
-                                button
-                                selected={selectedToMerge.includes(network)}
-                                onClick={() => handleSelectToMerge(network[1])}
-                                key={index}
-                            >
-                                <ListItemText
-                                    primary={
-                                        <>
-                                            {network[0]}
-                                            {index === 0 && <Tooltip title={`This is the base network`} placement="top" arrow>
-                                                <StarIcon viewBox="0 -3.7 24 24" style={{ color: 'gold' }} />
-                                            </Tooltip>}
-                                        </>
-                                    } />
-                            </ListItem>
-                        ))}
-                    </List>
+                    <Paper style={{ width: '42.5%' }}>
+                        <ListSubheader className="listSubheader" component="div">Networks to Merge</ListSubheader>
+                        <List className="scrollableList" component="div">
+                            {toMergeNetworksList.map((network, index) => (
+                                <ListItem
+                                    button
+                                    selected={selectedToMerge.includes(network)}
+                                    onClick={() => handleSelectToMerge(network[1])}
+                                    key={index}
+                                >
+                                    <ListItemText
+                                        primary={
+                                            <>
+                                                {network[0]}
+                                                {index === 0 && <Tooltip title={`This is the base network`} placement="top" arrow>
+                                                    <StarIcon viewBox="0 -3.7 24 24" style={{ color: 'gold' }} />
+                                                </Tooltip>}
+                                            </>
+                                        } />
+                                </ListItem>
+                            ))}
+                        </List>
+                    </Paper>
                     <Box display="flex" flexDirection="column" justifyContent="center" m={1}>
                         <Button className="arrowButton" variant="contained" onClick={handleMoveUp} disabled={selectedToMerge.length === 0} size='small'>
                             <ArrowUpwardIcon className="arrowIcon" fontSize="small" />
@@ -568,8 +542,8 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                             <MatchingTableComp
                                 networkRecords={networkRecords}
                                 netLst={toMergeNetworksList}
-                                type={tableView}
-                                matchingCols={matchingCols}
+                                tableView={tableView}
+                                mergeOpType={mergeOpType}
                             />
                         )}
 

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -39,7 +39,7 @@ import { LayoutAlgorithm, LayoutEngine } from '../../../models/LayoutModel';
 import { MatchingTableComp } from './MatchingTableComp';
 import { MatchingColumnTable } from './MatchingColumnTable';
 import { NetworkWithView } from '../../../utils/cx-utils';
-import { findPairIndex, getNetTableFromSummary } from '../utils/helper-functions';
+import { findPairIndex, getNetTableFromSummary, sortListAlphabetically } from '../utils/helper-functions';
 import { ConfirmationDialog } from '../../../components/Util/ConfirmationDialog';
 import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore';
 import { NdexNetworkSummary } from '../../../models/NetworkSummaryModel';
@@ -93,7 +93,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
     const removeNetsFromNetTable = useNetMatchingTableStore(state => state.removeNetworksFromTable);
     const resetNetMatchingTable = useNetMatchingTableStore(state => state.resetStore);
     // Record the status of the available and selected networks lists
-    const [availableNetworksList, setAvailableNetworksList] = useState<Pair<string, IdType>[]>(workSpaceNetworks);
+    const [availableNetworksList, setAvailableNetworksList] = useState<Pair<string, IdType>[]>(sortListAlphabetically(workSpaceNetworks));
     const [toMergeNetworksList, setToMergeNetworksList] = useState<Pair<string, IdType>[]>([]);
     const [selectedAvailable, setSelectedAvailable] = useState<Pair<string, IdType>[]>([]);
     const [selectedToMerge, setSelectedToMerge] = useState<Pair<string, IdType>[]>([]);
@@ -211,7 +211,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
     };
     // Function to remove selected networks from the 'Networks to Merge' list
     const handleRemoveNetwork = () => {
-        setAvailableNetworksList([...availableNetworksList, ...selectedToMerge]);
+        setAvailableNetworksList(sortListAlphabetically([...availableNetworksList, ...selectedToMerge]));
         setToMergeNetworksList(toMergeNetworksList.filter(net => !selectedToMerge.includes(net)));
         //Todo: whether to delete all these information or not
         const newNetworkRecords = { ...networkRecords };

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -461,7 +461,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
 
                 <Box display="flex" justifyContent="space-between" p={2}>
                     <List
-                        subheader={<ListSubheader>Available Networks</ListSubheader>}
+                        subheader={<ListSubheader className="listSubheader" component="div" >Available Networks</ListSubheader>}
                         component={Paper}
                         style={{ width: '42.5%', maxHeight: 300, overflow: 'auto' }}
                     >
@@ -485,7 +485,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                         </Button>
                     </Box>
                     <List
-                        subheader={<ListSubheader>Networks to Merge</ListSubheader>}
+                        subheader={<ListSubheader className="listSubheader" component="div" >Networks to Merge</ListSubheader>}
                         component={Paper}
                         style={{ width: '42.5%', maxHeight: 300, overflow: 'auto' }}
                     >
@@ -609,7 +609,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
 
                     </AccordionDetails>
                 </Accordion>
-            </DialogContent>
+            </DialogContent >
             <ConfirmationDialog
                 open={showError} setOpen={setShowError} title="Error"
                 message={errorMessage} onConfirm={() => setShowError(false)}

--- a/src/features/MergeNetworks/components/NetAttDropDownTemplate.tsx
+++ b/src/features/MergeNetworks/components/NetAttDropDownTemplate.tsx
@@ -25,7 +25,7 @@ export const NetAttDropDownTemplate = React.memo(({ networkRecords, rowData, col
     const emptyOption = { label: 'None', value: 'None' };
     const tableType = type === TableView.node ? 'nodeTable' : (type === TableView.edge ? 'edgeTable' : 'netTable');
     const columns = networkRecords[column]?.[tableType]?.columns || [];
-    const networkOptions = (type === TableView.node && rowData.id === 0) ? columns.map(nc => ({ label: nc.name, value: nc.name })) : [...columns.map(nc => ({ label: nc.name, value: nc.name })), emptyOption];
+    const networkOptions = ((type === TableView.node && rowData.id === 0) || (type === TableView.network && rowData.id < 3)) ? columns.map(nc => ({ label: nc.name, value: nc.name })) : [...columns.map(nc => ({ label: nc.name, value: nc.name })), emptyOption];
     const currentValue = (rowData.nameRecord[column] && rowData.nameRecord[column] !== 'None') ? rowData.nameRecord[column] : '';
     const netIdLst = netLst.map(pair => pair[1]);
     const setMatchingCols = useMatchingColumnsStore(state => state.setMatchingCols);

--- a/src/features/MergeNetworks/models/Impl/CreateMergedNetworkWithView.ts
+++ b/src/features/MergeNetworks/models/Impl/CreateMergedNetworkWithView.ts
@@ -6,6 +6,7 @@ import { MatchingTable } from '../MatchingTable';
 import { IdType } from '../../../../models/IdType';
 import { mergeNetSummary } from './MergeNetSummary';
 import { NetworkWithView } from '../../../../utils/cx-utils';
+import { checkAttribute } from '../../utils/attributes-operations';
 import { Column } from '../../../../models/TableModel/Column';
 import { putNetworkSummaryToDb } from '../../../../store/persist/db'
 import { NetworkAttributes } from '../../../../models/NetworkModel';
@@ -13,7 +14,6 @@ import ViewModelFn, { NetworkView } from '../../../../models/ViewModel';
 import { MergeType, NetworkRecord, NetworktoMerge } from '../DataInterfaceForMerge';
 import { NdexNetworkSummary } from '../../../../models/NetworkSummaryModel';
 import { Visibility } from '../../../../models/NetworkSummaryModel/Visibility';
-import { getMatchingTableRows, getAttributeMapping } from './MatchingTableImpl';
 import VisualStyleFn, { VisualStyle } from '../../../../models/VisualStyleModel';
 
 export const createMergedNetworkWithView = async (fromNetworks: IdType[], toNetworkId: IdType, networkName: string,
@@ -21,22 +21,8 @@ export const createMergedNetworkWithView = async (fromNetworks: IdType[], toNetw
     networkAttributeMapping: MatchingTable, matchingAttribute: Record<IdType, Column>, netSummaries: Record<IdType, NdexNetworkSummary>,
     mergeOpType: MergeType = MergeType.union, mergeWithinNetwork: boolean = false, mergeOnlyNodes: boolean = false, strictRemoveMode: boolean = false
 ): Promise<NetworkWithView> => {
-    if (fromNetworks.length < 1) {
-        throw new Error("No networks to merge");
-    }
-    if (getMatchingTableRows(nodeAttributeMapping).length < 1) {
-        throw new Error("The length of node attribute mapping table must be greater than 0")
-    }
-    for (const netId of fromNetworks) {
-        if (!networkRecords[netId]) {
-            throw new Error(`Network with id ${netId} not found`);
-        }
-        if (!getAttributeMapping(nodeAttributeMapping, netId)) {
-            throw new Error(`Node Attribute mapping for network ${netId} not found`);
-        }
-        if (!matchingAttribute[netId]) {
-            throw new Error(`Matching attribute for network ${netId} not found`);
-        }
+    if (checkAttribute(nodeAttributeMapping, edgeAttributeMapping, networkRecords, fromNetworks)) {
+        throw new Error(`Attribute not found in the network`);
     }
     let mergedNetwork: NetworkRecord = {} as NetworkRecord
     if (mergeOpType === MergeType.union) {

--- a/src/features/MergeNetworks/models/Impl/MatchingTableImpl.ts
+++ b/src/features/MergeNetworks/models/Impl/MatchingTableImpl.ts
@@ -30,30 +30,6 @@ export function getMergedAttributes(matchingTable: MatchingTable): Column[] {
     return matchingTable.mergedAttributes
 }
 
-export function getReversedAttributeMapping(matchingTable: MatchingTable, netId: IdType, isNode: boolean = true): Map<string, Column> {
-    const attMap = new Map()
-    if (matchingTable.matchingTableRows.length > 0) {
-        for (const row of (isNode ? matchingTable.matchingTableRows.slice(1) : matchingTable.matchingTableRows)) {
-            if (row.nameRecord.hasOwnProperty(netId)) {
-                attMap.set(row.nameRecord[netId], { name: row.mergedNetwork, type: row.type } as Column)
-            }
-        }
-    }
-    return attMap
-}
-
-export function getAttributeMapping(matchingTable: MatchingTable, netId: IdType, isNode: boolean = true): Map<number, Column> {
-    const attMap = new Map()
-    if (matchingTable.matchingTableRows.length > 0) {
-        for (const row of (isNode ? matchingTable.matchingTableRows.slice(1) : matchingTable.matchingTableRows)) {
-            if (row.nameRecord.hasOwnProperty(netId) && row.nameRecord[netId] !== 'None') {
-                attMap.set(row.id, { name: row.nameRecord[netId], type: row.type } as Column)
-            }
-        }
-    }
-    return attMap
-}
-
 export function getReversedMergedAttMap(matchingTable: MatchingTable): Map<string, string> {
     const attMap = new Map()
     if (matchingTable.matchingTableRows.length > 0) {

--- a/src/features/MergeNetworks/store/edgeMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/edgeMatchingTableStore.ts
@@ -6,6 +6,7 @@ import { MatchingTableRow } from '../models/MatchingTable';
 import { filterRows, getMergedType } from '../utils/helper-functions';
 import { NetworkRecord } from '../models/DataInterfaceForMerge';
 import { getResonableCompatibleConvertionType } from '../utils/attributes-operations';
+import { generateUniqueName } from '../../../utils/network-utils';
 
 interface EdgeMatchingTableState {
     rows: MatchingTableRow[];
@@ -26,6 +27,7 @@ type EdgeMatchingTableStore = EdgeMatchingTableState & EdgeMatchingTableActions
 const addNetworks = (state: EdgeMatchingTableStore, networkIds: IdType[], networkRecords: Record<IdType, NetworkRecord>, matchingCols: Record<string, Column>) => {
     const sharedColsRecord: Record<IdType, Set<string>> = {};
     networkIds.forEach(netId => sharedColsRecord[netId] = new Set());
+    const mergedNetworkNames = new Set(state.rows.map(row => row.mergedNetwork));
     state.rows = state.rows.map((row, id) => {
         let typeCheck = false;
         for (const netId of networkIds) {
@@ -80,9 +82,11 @@ const addNetworks = (state: EdgeMatchingTableStore, networkIds: IdType[], networ
                         typeRecord[net2] = 'None';
                     }
                 });
+                const mergedNetworkName = generateUniqueName(mergedNetworkNames, col.name);
+                mergedNetworkNames.add(mergedNetworkName);
                 state.rows.push({
                     id: state.rows.length,
-                    mergedNetwork: col.name,
+                    mergedNetwork: mergedNetworkName,
                     type: getResonableCompatibleConvertionType(typeSet),
                     typeRecord: typeRecord,
                     nameRecord: matchCols,

--- a/src/features/MergeNetworks/store/edgeMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/edgeMatchingTableStore.ts
@@ -48,6 +48,7 @@ const addNetworks = (state: EdgeMatchingTableStore, networkIds: IdType[], networ
             row.hasConflicts = hasConflicts;
             row.type = mergedType;
         }
+        mergedNetworkNames.add(row.mergedNetwork);
         return row;
     });
 

--- a/src/features/MergeNetworks/store/mergeToolTip.ts
+++ b/src/features/MergeNetworks/store/mergeToolTip.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+interface MergeToolTipState {
+    text: string,
+    isOpen: boolean;
+}
+
+interface MergeToolTipAction {
+    setText: (toolTipText: string) => void
+    setIsOpen: (openToolTip: boolean) => void;
+}
+
+type MergeToolTipStore = MergeToolTipState & MergeToolTipAction
+
+const useMergeToolTipStore = create(immer<MergeToolTipStore>((set) => ({
+    text: 'Please select networks to merge',
+    isOpen: false,
+    setText: (toolTipText: string) => set(() => ({ text: toolTipText })),
+    setIsOpen: (openToolTip: boolean) => set(() => ({ isOpen: openToolTip }))
+})));
+
+export default useMergeToolTipStore;

--- a/src/features/MergeNetworks/store/netMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/netMatchingTableStore.ts
@@ -86,7 +86,7 @@ const addNetworks = (state: NetMatchingTableStore, networkIds: IdType[], network
                 mergedNetworkNames.add(mergedNetworkName);
                 state.rows.push({
                     id: state.rows.length,
-                    mergedNetwork: col.name,
+                    mergedNetwork: mergedNetworkName,
                     type: getResonableCompatibleConvertionType(typeSet),
                     typeRecord: typeRecord,
                     nameRecord: matchCols,

--- a/src/features/MergeNetworks/store/netMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/netMatchingTableStore.ts
@@ -6,6 +6,7 @@ import { MatchingTableRow } from '../models/MatchingTable';
 import { filterRows, getMergedType } from '../utils/helper-functions';
 import { NetworkRecord } from '../models/DataInterfaceForMerge';
 import { getResonableCompatibleConvertionType } from '../utils/attributes-operations';
+import { generateUniqueName } from '../../../utils/network-utils';
 
 interface NetMatchingTableState {
     rows: MatchingTableRow[];
@@ -26,6 +27,7 @@ type NetMatchingTableStore = NetMatchingTableState & NetMatchingTableActions
 const addNetworks = (state: NetMatchingTableStore, networkIds: IdType[], networkRecords: Record<IdType, NetworkRecord>, matchingCols: Record<string, Column>) => {
     const sharedColsRecord: Record<IdType, Set<string>> = {};
     networkIds.forEach(netId => sharedColsRecord[netId] = new Set());
+    const mergedNetworkNames = new Set(state.rows.map(row => row.mergedNetwork));
     state.rows = state.rows.map((row, id) => {
         let typeCheck = false;
         for (const netId of networkIds) {
@@ -80,6 +82,8 @@ const addNetworks = (state: NetMatchingTableStore, networkIds: IdType[], network
                         typeRecord[net2] = 'None';
                     }
                 });
+                const mergedNetworkName = generateUniqueName(mergedNetworkNames, col.name);
+                mergedNetworkNames.add(mergedNetworkName);
                 state.rows.push({
                     id: state.rows.length,
                     mergedNetwork: col.name,

--- a/src/features/MergeNetworks/store/netMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/netMatchingTableStore.ts
@@ -48,6 +48,7 @@ const addNetworks = (state: NetMatchingTableStore, networkIds: IdType[], network
             row.hasConflicts = hasConflicts;
             row.type = mergedType;
         }
+        mergedNetworkNames.add(row.mergedNetwork);
         return row;
     });
 

--- a/src/features/MergeNetworks/store/nodeMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/nodeMatchingTableStore.ts
@@ -60,6 +60,7 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
                 row.hasConflicts = hasConflicts;
                 row.type = mergedType;
             }
+            mergedNetworkNames.add(row.mergedNetwork);
             return row;
         });
     } else {

--- a/src/features/MergeNetworks/store/nodeMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/nodeMatchingTableStore.ts
@@ -29,6 +29,7 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
     const sharedColsRecord: Record<IdType, Set<string>> = {};
     networkIds.forEach(netId => sharedColsRecord[netId] = new Set());
     const mergedNetworkNames = new Set(state.rows.map(row => row.mergedNetwork));
+    let checkFirstRow = false;
     if (state.rows.length > 0) {
         state.rows = state.rows.map((row, id) => {
             let typeCheck = false;
@@ -82,7 +83,7 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
         matchingColRow.hasConflicts = typeSet.size > 1;
         matchingColRow.type = getResonableCompatibleConvertionType(typeSet);
         state.rows.push(matchingColRow);
-        mergedNetworkNames.add(defaultMatchingAttributeName);
+        checkFirstRow = true
     }
     const originalNetworkIds = Array.from(state.networkIds);
     networkIds.forEach((net1, index1) => {
@@ -128,6 +129,9 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
             }
         });
     });
+    if (checkFirstRow) {
+        state.rows[0].mergedNetwork = generateUniqueName(mergedNetworkNames, state.rows[0].mergedNetwork);
+    }
 }
 
 const removeNetworks = (state: NodeMatchingTableStore, networkIds: IdType[]) => {

--- a/src/features/MergeNetworks/store/nodeMatchingTableStore.ts
+++ b/src/features/MergeNetworks/store/nodeMatchingTableStore.ts
@@ -6,6 +6,7 @@ import { MatchingTableRow } from '../models/MatchingTable';
 import { filterRows, getMergedType } from '../utils/helper-functions';
 import { NetworkRecord } from '../models/DataInterfaceForMerge';
 import { getResonableCompatibleConvertionType } from '../utils/attributes-operations';
+import { generateUniqueName } from '../../../utils/network-utils';
 
 interface NodeMatchingTableState {
     rows: MatchingTableRow[];
@@ -18,72 +19,16 @@ interface NodeMatchingTableActions {
     addRow: (newRow: MatchingTableRow) => void
     updateRow: (rowIndex: number, netId: string, col: Column) => void;
     resetStore: () => void;
-    addNetworkToTable: (networkId: IdType, netRecord: NetworkRecord, matchingCol: Column) => void
     addNetworksToTable: (networkIds: IdType[], networkRecords: Record<IdType, NetworkRecord>, matchingCols: Record<string, Column>) => void
     removeNetworksFromTable: (networkIds: IdType[]) => void
 }
 
 type NodeMatchingTableStore = NodeMatchingTableState & NodeMatchingTableActions
 
-const addNetwork = (state: NodeMatchingTableStore, networkId: IdType, netRecord: NetworkRecord, matchingCol: Column) => {
-    const netCols = netRecord.nodeTable.columns;
-    const sharedCols = new Set<string>();
-    if (state.rows.length > 0) {
-        state.rows = state.rows.map((row, id) => {
-            let typeCheck = true
-            if (id === 0) {
-                row.nameRecord[networkId] = matchingCol.name || 'None';
-                row.typeRecord[networkId] = matchingCol.type || 'None';
-            }
-            else {
-                if (netCols.some(nc => nc.name === row.mergedNetwork)) {
-                    sharedCols.add(row.mergedNetwork);
-                    row.nameRecord[networkId] = row.mergedNetwork;
-                    row.typeRecord[networkId] = netCols.find(nc => nc.name === row.mergedNetwork)?.type || 'None';
-                } else {
-                    row.nameRecord[networkId] = 'None';
-                    row.typeRecord[networkId] = 'None';
-                    typeCheck = false;
-                }
-            }
-            if (typeCheck) {
-                const { hasConflicts, mergedType } = getMergedType(row.typeRecord);
-                row.hasConflicts = hasConflicts;
-                row.type = mergedType;
-            }
-            return row;
-        });
-    } else {
-        state.rows.push({
-            id: 0,
-            mergedNetwork: 'Matching.Attribute',
-            type: matchingCol.type || 'None',
-            nameRecord: { [networkId]: matchingCol.name || 'None' },
-            typeRecord: { [networkId]: matchingCol.type || 'None' },
-            hasConflicts: false
-        });
-    }
-
-    // Add new rows for columns not in sharedCols
-    netCols.forEach(col => {
-        if (!sharedCols.has(col.name)) {
-            state.rows.push({
-                id: state.rows.length,
-                mergedNetwork: col.name,
-                type: col.type,
-                nameRecord: { ...Array.from(state.networkIds).reduce((acc, key) => ({ ...acc, [key]: 'None' }), {}), [networkId]: col.name },
-                typeRecord: { ...Array.from(state.networkIds).reduce((acc, key) => ({ ...acc, [key]: 'None' }), {}), [networkId]: col.type },
-                hasConflicts: false
-            });
-        }
-    });
-    // Update network IDs
-    state.networkIds.add(networkId);
-};
-
 const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networkRecords: Record<IdType, NetworkRecord>, matchingCols: Record<string, Column>) => {
     const sharedColsRecord: Record<IdType, Set<string>> = {};
     networkIds.forEach(netId => sharedColsRecord[netId] = new Set());
+    const mergedNetworkNames = new Set(state.rows.map(row => row.mergedNetwork));
     if (state.rows.length > 0) {
         state.rows = state.rows.map((row, id) => {
             let typeCheck = false;
@@ -117,9 +62,10 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
             return row;
         });
     } else {
+        const defaultMatchingAttributeName = 'Matching.Attribute';
         const matchingColRow: MatchingTableRow = {
             id: 0,
-            mergedNetwork: 'Matching.Attribute',
+            mergedNetwork: defaultMatchingAttributeName,
             type: 'None',
             nameRecord: {},
             typeRecord: {},
@@ -136,6 +82,7 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
         matchingColRow.hasConflicts = typeSet.size > 1;
         matchingColRow.type = getResonableCompatibleConvertionType(typeSet);
         state.rows.push(matchingColRow);
+        mergedNetworkNames.add(defaultMatchingAttributeName);
     }
     const originalNetworkIds = Array.from(state.networkIds);
     networkIds.forEach((net1, index1) => {
@@ -168,9 +115,11 @@ const addNetworks = (state: NodeMatchingTableStore, networkIds: IdType[], networ
                         typeRecord[net2] = 'None';
                     }
                 });
+                const mergedNetworkName = generateUniqueName(mergedNetworkNames, col.name);
+                mergedNetworkNames.add(mergedNetworkName);
                 state.rows.push({
                     id: state.rows.length,
-                    mergedNetwork: col.name,
+                    mergedNetwork: mergedNetworkName,
                     type: getResonableCompatibleConvertionType(typeSet),
                     typeRecord: typeRecord,
                     nameRecord: matchCols,
@@ -233,7 +182,6 @@ const useNodeMatchingTableStore = create(immer<NodeMatchingTableStore>((set) => 
         rows: [],
         networkIds: new Set(),
     })),
-    addNetworkToTable: (networkId, netRecord, matchingCol) => set(state => { addNetwork(state, networkId, netRecord, matchingCol) }),
     addNetworksToTable: (networkIds, networkRecords, matchingCols) => set(state => { addNetworks(state, networkIds, networkRecords, matchingCols) }),
     removeNetworksFromTable: (networkIds) => set(state => { removeNetworks(state, networkIds) })
 })));

--- a/src/features/MergeNetworks/utils/helper-functions.ts
+++ b/src/features/MergeNetworks/utils/helper-functions.ts
@@ -119,3 +119,17 @@ export function getMergedType(typeRecord: Record<string, ValueTypeName | 'None'>
         mergedType: getResonableCompatibleConvertionType(typeSet)
     }
 }
+
+export function sortListAlphabetically(list: [string, IdType][]): [string, IdType][] {
+    return list.sort((a, b) => {
+        const nameA = a[0].toLowerCase();
+        const nameB = b[0].toLowerCase();
+        if (nameA < nameB) {
+            return -1;
+        }
+        if (nameA > nameB) {
+            return 1;
+        }
+        return 0;
+    });
+}

--- a/src/features/MergeNetworks/utils/helper-functions.ts
+++ b/src/features/MergeNetworks/utils/helper-functions.ts
@@ -37,59 +37,6 @@ export const getNetTableFromSummary = (summary: NdexNetworkSummary): Table => {
     return netTable;
 };
 
-export const processColumns = (
-    tableName: 'nodeTable' | 'edgeTable' | 'netTable',
-    toMergeNetworksList: Pair<string, string>[],
-    networkRecords: Record<IdType, NetworkRecord>,
-    initialTable?: MatchingTableRow[],
-): MatchingTableRow[] => {
-    const newTable: MatchingTableRow[] = initialTable ? [...initialTable] : [];
-    const sharedColsRecord: Record<IdType, string[]> = {};
-    toMergeNetworksList.forEach((net1, index1) => {
-        // Todo: make sure the column names are sorted alphabetically(case-insensitive)
-        networkRecords[net1[1]]?.[tableName]?.columns.forEach(col => {
-            if (!sharedColsRecord[net1[1]]?.includes(col.name)) {
-                const matchCols: Record<string, string> = {};
-                const typeRecord: Record<string, ValueTypeName | 'None'> = {};
-                matchCols[net1[1]] = col.name;
-                const typeSet = new Set<ValueTypeName>();
-                typeSet.add(col.type);
-                typeRecord[net1[1]] = col.type;
-                toMergeNetworksList.slice(0, index1)?.forEach(net2 => {
-                    matchCols[net2[1]] = 'None';
-                });
-                toMergeNetworksList.slice(index1 + 1).forEach(net2 => {
-                    const network = networkRecords[net2[1]];
-                    if (network?.[tableName]?.columns.some(nc => nc.name === col.name)) {
-                        const newSharedCols = sharedColsRecord[net2[1]] ? [...sharedColsRecord[net2[1]]] : [];
-                        newSharedCols.push(col.name);
-                        sharedColsRecord[net2[1]] = newSharedCols;
-                        matchCols[net2[1]] = col.name;
-                        const colType = network[tableName]?.columns.find(nc => nc.name === col.name)?.type;
-                        if (colType !== undefined) {
-                            typeSet.add(colType);
-                            typeRecord[net2[1]] = colType;
-                        }
-                    } else {
-                        matchCols[net2[1]] = 'None';
-                        typeRecord[net2[1]] = 'None';
-                    }
-                });
-
-                newTable.push({
-                    id: newTable.length,
-                    mergedNetwork: col.name,
-                    type: getResonableCompatibleConvertionType(typeSet),
-                    typeRecord: typeRecord,
-                    nameRecord: matchCols,
-                    hasConflicts: typeSet.size > 1
-                });
-            }
-        });
-    });
-    return newTable;
-};
-
 export function isStringArray(value: any): value is string[] {
     return Array.isArray(value) && value.every(item => typeof item === 'string');
 }

--- a/src/utils/network-utils.ts
+++ b/src/utils/network-utils.ts
@@ -4,9 +4,9 @@ export function generateUniqueName(existingNames: string[], proposedName: string
         return proposedName;
     } else {
         let i = 1;
-        while (existingNames.includes(proposedName + i)) {
+        while (existingNames.includes(proposedName + '_' + i)) {
             i++;
         }
-        return proposedName + i;
+        return proposedName + '_' + i;
     }
 }

--- a/src/utils/network-utils.ts
+++ b/src/utils/network-utils.ts
@@ -1,12 +1,24 @@
 // Network Naming Utilities
-export function generateUniqueName(existingNames: string[], proposedName: string): string {
-    if (!existingNames.includes(proposedName)) {
-        return proposedName;
-    } else {
-        let i = 1;
-        while (existingNames.includes(proposedName + '_' + i)) {
-            i++;
+export function generateUniqueName(existingNames: string[] | Set<string>, proposedName: string): string {
+    if (existingNames instanceof Set) {
+        if (!existingNames.has(proposedName)) {
+            return proposedName;
+        } else {
+            let i = 1;
+            while (existingNames.has(proposedName + '_' + i)) {
+                i++;
+            }
+            return proposedName + '_' + i;
         }
-        return proposedName + '_' + i;
+    } else {
+        if (!existingNames.includes(proposedName)) {
+            return proposedName;
+        } else {
+            let i = 1;
+            while (existingNames.includes(proposedName + '_' + i)) {
+                i++;
+            }
+            return proposedName + '_' + i;
+        }
     }
 }


### PR DESCRIPTION
1. In the finding unique name function, when a network name already exists in the workspace, append “_n” to the name instead of “n”.  When a user does change the name to a duplicate name, change the text color to orange and add a message explaining the reason.  
<img width="844" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/9e7d7ce7-79e2-42da-90df-2bc4bce70fc7">

2. In the default setting, name the new attribute “Matching.Attribute”  and rename the existing “Matching.Attribute” to “Matching.Attribute_n” if there is already one exists. Add checkers for duplicate attribute names. If the duplicates are detected, change the text to red and having a red error message somewhere in that dialog box.
<img width="831" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/17d92ed8-a7f6-4b3b-8b3a-6ca587482392">
<img width="798" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/afa5d483-51b7-48f5-8b0f-36dbef6b0a3e">


3. When an error is detected, grey out the merge button and display the reason in the tooltip instead of popup an error message after the user clicks the merge button. 
<img height="100" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/ebd9e6e8-cef6-4f36-9583-3b765c1f77d3">
<img height="100" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/c6487ccc-13a3-4ca7-a8cb-915d48f4b33b">
 

4. Make the header of the 2 tables in the network selector section more obvious. 
<img width="870" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/b3cdd210-6ca2-410c-8f73-bcdb879b4998">
 

5. Sort the list in the left window in alphabetical order (case insensitive).

6. Add tooltip to  “Matching.Attribute”  and also change the text color to make it more clear. 
<img width="826" alt="image" src="https://github.com/cytoscape/cytoscape-web/assets/39005000/241e74d4-56ca-45bf-9a6c-978f34db46d6">
