### PR TITLE
fix issue where the user couldnt fully scroll to the bottom of the table data when importing tables/networks from csv files

### DIFF
--- a/src/features/TableDataLoader/components/CreateNetworkFromTable/TableColumnAssignmentForm.tsx
+++ b/src/features/TableDataLoader/components/CreateNetworkFromTable/TableColumnAssignmentForm.tsx
@@ -279,8 +279,9 @@ export function TableColumnAssignmentForm(props: BaseMenuProps) {
         tableStyle={{ minWidth: '50rem' }}
         scrollable
         scrollHeight="400px"
-        height={450}
-        virtualScrollerOptions={{ itemSize: 10, delay: 50 }}
+        virtualScrollerOptions={{
+          itemSize: 10,
+        }}
       >
         {columns.map((h, i) => {
           return (

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
@@ -330,9 +330,8 @@ export function TableColumnAppendForm(props: BaseMenuProps) {
         size="small"
         tableStyle={{ minWidth: '50rem' }}
         scrollable
-        scrollHeight="300px"
-        height={300}
-        virtualScrollerOptions={{ itemSize: 10, delay: 50 }}
+        scrollHeight="350px"
+        virtualScrollerOptions={{ itemSize: 10 }}
       >
         {columns.map((h, i) => {
           return (


### PR DESCRIPTION
- the `delay` option was causing problems and the scroll position would keep resetting when the user scrolls
- the `height` option would conflict with the `scrollHeight` option