### PR TITLE
Duplicate branch handler for Circle Packing

### DIFF
--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
@@ -373,8 +373,10 @@ export const CirclePackingPanel = ({
       )
       .on('click', function (e: any, d: d3Hierarchy.HierarchyNode<D3TreeNode>) {
         if (d.height !== 0) {
+          // Selected item is a subsystem
           if (d.data.originalId !== undefined) {
-            exclusiveSelect(network.id, [d.data.originalId], [])
+            // Select both current and original branch
+            exclusiveSelect(network.id, [d.data.originalId, d.data.id], [])
           } else {
             exclusiveSelect(network.id, [d.data.id], [])
           }

--- a/src/features/HierarchyViewer/components/CustomLayout/DataBuilderUtil.ts
+++ b/src/features/HierarchyViewer/components/CustomLayout/DataBuilderUtil.ts
@@ -4,6 +4,7 @@ import { Table, ValueType } from '../../../../models/TableModel'
 import { SubsystemTag } from '../../model/HcxMetaTag'
 import { D3TreeNode } from './D3TreeNode'
 
+export const DuplicateNodeSeparator = '-'
 /**
  * Get the member list of the given node
  *
@@ -64,7 +65,9 @@ export const cyNetDag2tree2 = (
 
   // Create a new node ID based on visited count (use the same ID for the first visit)
   const newNodeId =
-    visited[nodeId] > 1 ? `${nodeId}-${visited[nodeId]}` : nodeId
+    visited[nodeId] > 1
+      ? `${nodeId}${DuplicateNodeSeparator}${visited[nodeId]}`
+      : nodeId
 
   const newNode: D3TreeNode = {
     id: newNodeId,

--- a/src/features/HierarchyViewer/components/MainPanel.tsx
+++ b/src/features/HierarchyViewer/components/MainPanel.tsx
@@ -26,6 +26,7 @@ import { VisualStyle } from '../../../models/VisualStyleModel'
 import { useVisualStyleStore } from '../../../store/VisualStyleStore'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import FilterPanel from './FilterPanel/FilterPanel'
+import { DuplicateNodeSeparator } from './CustomLayout/DataBuilderUtil'
 
 export const RENDERER_TAG: string = 'secondary'
 export interface Query {
@@ -183,14 +184,26 @@ export const MainPanel = (): JSX.Element => {
     return <MessagePanel message="Please select a subsystem" />
   }
 
+  // This is the ID of the selected subsystem in the hierarchy
+  let targetNode: IdType = selectedNodes[0]
+
   if (selectedNodes.length > 1) {
     // Multiple nodes are selected
-    return (
-      <MessagePanel
-        message="Multiple nodes are selected"
-        subMessage="Please select one subsystem to display the associated interactions"
-      />
-    )
+    // Check if same branches are selected
+    const normalizedIds = selectedNodes.map((nodeId) => {
+      return nodeId.split(DuplicateNodeSeparator)[0]
+    })
+    const uniqueBranches = new Set(normalizedIds)
+    if (uniqueBranches.size !== 1) {
+      return (
+        <MessagePanel
+          message="Multiple nodes are selected"
+          subMessage="Please select one subsystem to display the associated interactions"
+        />
+      )
+    } else {
+      targetNode = Array.from(uniqueBranches)[0]
+    }
   }
 
   // Special case: neither of ID or membership is available
@@ -203,8 +216,6 @@ export const MainPanel = (): JSX.Element => {
     )
   }
 
-  // This is the ID of the selected subsystem in the hierarchy
-  const targetNode: IdType = selectedNodes[0]
   const rootNetworkId: IdType = metadata?.interactionNetworkUUID ?? ''
 
   return (


### PR DESCRIPTION
There are some duplicate branches in the Circle Packing View. In the original version, only the original one will be highlighted when selecting subsystem in multiple locations in the hierarchy. This version selects both and display interaction network for the original branch. 