### PR TITLE
CW-242

### DIFF
--- a/src/components/TableBrowser/NetworkInfoPanel.tsx
+++ b/src/components/TableBrowser/NetworkInfoPanel.tsx
@@ -59,7 +59,6 @@ export default function NetworkInfoPanel(props: {
     (state) => state.summaries[currentNetworkId],
   )
   const properties = networkInfo?.properties ?? []
-  console.log(properties)
 
   const containsHtmlAnchor = (text: string) => {
     return /<a\s+href=/i.test(text);

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -220,6 +220,14 @@ const WorkSpaceEditor = (): JSX.Element => {
     )
     
     setSummaries({...summaries, ...newSummaries})
+
+    const loadedNetworks = Object.keys(newSummaries)
+    if(loadedNetworks.length !== networkIds.length){
+      networkIds.filter(id => !loadedNetworks.includes(id)).forEach((id) => {
+        deleteNetwork(id)
+      })
+    
+    }
   }
 
   const { maxNetworkElementsThreshold } = useContext(AppConfigContext)
@@ -403,12 +411,7 @@ const WorkSpaceEditor = (): JSX.Element => {
     })
     loadNetworkSummaries(toBeAdded)
       .then(() => {})
-      .catch((err) => {
-        console.error(err)
-        toBeAdded.forEach((id) => {
-          deleteNetwork(id)
-        })
-      })
+      .catch((err) => { console.error(err) })
   }, [workspace.networkIds])
 
   /**

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -411,7 +411,7 @@ const WorkSpaceEditor = (): JSX.Element => {
     })
     loadNetworkSummaries(toBeAdded)
       .then(() => {})
-      .catch((err) => { console.error(err) })
+      .catch((err) => console.error(err))
   }, [workspace.networkIds])
 
   /**

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -223,10 +223,13 @@ const WorkSpaceEditor = (): JSX.Element => {
 
     const loadedNetworks = Object.keys(newSummaries)
     if(loadedNetworks.length !== networkIds.length){
-      networkIds.filter(id => !loadedNetworks.includes(id)).forEach((id) => {
-        deleteNetwork(id)
+
+      const  networksFailtoLoad = networkIds.filter(id => !loadedNetworks.includes(id))
+      deleteNetwork(networksFailtoLoad)
+      addMessage({
+        message: `Failed to load network(s) with id(s): ${networksFailtoLoad.join(', ')}`,
+        duration: 5000,
       })
-    
     }
   }
 

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -223,10 +223,9 @@ const WorkSpaceEditor = (): JSX.Element => {
 
     const loadedNetworks = Object.keys(newSummaries)
     if(loadedNetworks.length !== networkIds.length){
-
       const  networksFailtoLoad = networkIds.filter(id => !loadedNetworks.includes(id))
-      deleteNetwork(networksFailtoLoad)
-      addMessage({
+      deleteNetwork(networksFailtoLoad)// remove the networks that the app fails to load from the workspace
+      addMessage({ // show a message to the user
         message: `Failed to load network(s) with id(s): ${networksFailtoLoad.join(', ')}`,
         duration: 5000,
       })

--- a/src/store/hooks/useNdexNetworkSummary.ts
+++ b/src/store/hooks/useNdexNetworkSummary.ts
@@ -71,10 +71,6 @@ export const ndexSummaryFetcher = async (
     const summaries: NdexNetworkSummary[] =
       await ndexClient.getNetworkSummariesByUUIDs(ids)
 
-    if(summaries.length !== ids.length){
-      console.error('Failed to fetch all summaries')
-    }
-    
     const processedSummaries = summaries.map((s) => {
       return {
         ...s,

--- a/src/store/hooks/useNdexNetworkSummary.ts
+++ b/src/store/hooks/useNdexNetworkSummary.ts
@@ -72,7 +72,7 @@ export const ndexSummaryFetcher = async (
       await ndexClient.getNetworkSummariesByUUIDs(ids)
 
     if(summaries.length !== ids.length){
-      throw new Error('Failed to fetch all summaries')
+      console.error('Failed to fetch all summaries')
     }
     
     const processedSummaries = summaries.map((s) => {

--- a/src/store/hooks/useNdexNetworkSummary.ts
+++ b/src/store/hooks/useNdexNetworkSummary.ts
@@ -71,6 +71,10 @@ export const ndexSummaryFetcher = async (
     const summaries: NdexNetworkSummary[] =
       await ndexClient.getNetworkSummariesByUUIDs(ids)
 
+    if(summaries.length !== ids.length){
+      throw new Error('Failed to fetch all summaries')
+    }
+    
     const processedSummaries = summaries.map((s) => {
       return {
         ...s,


### PR DESCRIPTION
Ticket: [Jira CW-242](https://cytoscape.atlassian.net/browse/CW-242)

Since the ndexClient would not throw error by itself even when the returned network summaries' length is NOT equal to the requested ones. (see [src/store/hooks/useNdexNetworkSummary.ts](https://github.com/cytoscape/cytoscape-web/compare/CW-242?expand=1#diff-5394aab37718c35579ad094cc10635f869c5a997d783d5551380efd3ec91bbc5) **line 71**)

Now I added a if-statement to check this and if this happens(for example when the network is private and the user does not have permission), it will logs out an error. And [src/components/Workspace/WorkspaceEditor.tsx](https://github.com/cytoscape/cytoscape-web/compare/CW-242?expand=1#diff-dbc87ef8753984874b0e2ee607155749ba50b0b378ec8c83a804a8fa6fc85e27) **line 225** will delete all the networks that are requested to add but cannot be loaded.