### PR TITLE
Merge Nodes/Edges in the same network (Difference merge)

### DIFF
--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -576,8 +576,8 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                             />
                             <Tooltip
                                 placement="top-start"
-                                title="Cannot ignore edges when operating 'Union Merge'"
-                                disableHoverListener={MergeType.union !== mergeOpType}  // Tooltip is only active when the checkbox is disabled
+                                title={`Cannot ignore edges when operating '${mergeOpType} Merge'`}
+                                disableHoverListener={MergeType.intersection === mergeOpType}  // Tooltip is only active when the checkbox is disabled
                             >
                                 <FormControlLabel
                                     control={
@@ -587,7 +587,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({ open, handleClose, uniqueName
                                             onChange={() => setMergeOnlyNodes(!mergeOnlyNodes)}
                                             name="mergeOnlyNodes"
                                             color="primary"
-                                            disabled={MergeType.union === mergeOpType}
+                                            disabled={MergeType.intersection !== mergeOpType}
                                         />
                                     }
                                     label="Merge only nodes and ignore edges"

--- a/src/features/MergeNetworks/models/Impl/CreateMergedNetworkWithView.ts
+++ b/src/features/MergeNetworks/models/Impl/CreateMergedNetworkWithView.ts
@@ -20,7 +20,7 @@ export const createMergedNetworkWithView = async (fromNetworks: IdType[], toNetw
     networkRecords: Record<IdType, NetworkRecord>, nodeAttributeMapping: MatchingTable, edgeAttributeMapping: MatchingTable,
     networkAttributeMapping: MatchingTable, matchingAttribute: Record<IdType, Column>, netSummaries: Record<IdType, NdexNetworkSummary>,
     mergeOpType: MergeType = MergeType.union, mergeWithinNetwork: boolean = false, mergeOnlyNodes: boolean = false, strictRemoveMode: boolean = false
-): Promise<NetworkWithView> => {
+): Promise<[NetworkWithView,NdexNetworkSummary]> => {
     if (checkAttribute(nodeAttributeMapping, edgeAttributeMapping, networkRecords, fromNetworks)) {
         throw new Error(`Attribute not found in the network`);
     }
@@ -52,7 +52,7 @@ export const createMergedNetworkWithView = async (fromNetworks: IdType[], toNetw
     const newVisualStyle: VisualStyle = baseVisualStyle ? (cloneDeep(baseVisualStyle)) : (VisualStyleFn.createVisualStyle());
     const newNetworkView: NetworkView = ViewModelFn.createViewModel(newNetwork)
 
-    await putNetworkSummaryToDb({
+    const networkSummary:NdexNetworkSummary = {
         isNdex: false,
         ownerUUID: toNetworkId,
         name: networkName,
@@ -63,7 +63,7 @@ export const createMergedNetworkWithView = async (fromNetworks: IdType[], toNetw
         isShowcase: false,
         isCertified: false,
         indexLevel: '',
-        hasLayout: true,
+        hasLayout: false,
         hasSample: false,
         cxFileSize: 0,
         cx2FileSize: 0,
@@ -79,15 +79,16 @@ export const createMergedNetworkWithView = async (fromNetworks: IdType[], toNetw
         externalId: toNetworkId,
         isDeleted: false,
         modificationTime: new Date(Date.now()),
-    })
+    }
+    await putNetworkSummaryToDb(networkSummary)
 
-    return {
+    return [{
         network: newNetwork,
         nodeTable: newNodeTable,
         edgeTable: newEdgeTable,
         visualStyle: newVisualStyle,
         networkViews: [newNetworkView],
         networkAttributes,
-    }
+    },networkSummary]
 }
 

--- a/src/features/MergeNetworks/models/Impl/DifferenceMerge.ts
+++ b/src/features/MergeNetworks/models/Impl/DifferenceMerge.ts
@@ -6,6 +6,7 @@ import { Column } from "../../../../models/TableModel/Column";
 import { ListOfValueType, SingleValueType, ValueType } from "../../../../models/TableModel/ValueType";
 import { MatchingTable } from "../MatchingTable";
 import { getMergedAttributes, getReversedMergedAttMap } from "./MatchingTableImpl";
+import { removePair } from "../../utils/helper-functions";
 import { preprocess, castAttributes, addMergedAtt, getKeybyAttribute, mergeAttributes, duplicateAttName } from "../../utils/attributes-operations";
 
 export function differenceMerge(fromNetworks: IdType[], toNetworkId: IdType, networkRecords: Record<IdType, NetworkRecord>,
@@ -38,6 +39,7 @@ export function differenceMerge(fromNetworks: IdType[], toNetworkId: IdType, net
     // record the node to edges mapping
     const sourceNode2EdgeMap = new Map<SingleValueType, Pair<string, IdType>[]>();
     const targetNode2EdgeMap = new Map<SingleValueType, Pair<string, IdType>[]>();
+    const edgeToRemove: Set<IdType> = new Set();
 
     for (const netId of fromNetworks) {
         const nodeLst = networkRecords[netId].network.nodes
@@ -50,106 +52,111 @@ export function differenceMerge(fromNetworks: IdType[], toNetworkId: IdType, net
     const baseMatchingColName: string = matchingAttribute[baseNetId].name
     const secMatchingColName: string = matchingAttribute[secondNetId].name    
 
+    const matchedNodes: Set<IdType> = new Set()
+    const unmatchedNodes: Set<IdType> = new Set()
+
+    function getIdentifiableFromEdge(edgeObj: Edge, netId: IdType, colName: string): [SingleValueType, SingleValueType, string] {
+        const edgeEntry = networkRecords[netId].edgeTable.rows.get(edgeObj.id)
+        const sourceEntry = networkRecords[netId].nodeTable.rows.get(edgeObj.s)
+        const targetEntry = networkRecords[netId].nodeTable.rows.get(edgeObj.t)
+        if (edgeEntry === undefined) throw new Error("Edge not found in the edge table")
+        if (sourceEntry === undefined || targetEntry === undefined) throw new Error("Node not found in the node table")
+        const sourceNodeKey = getKeybyAttribute(sourceEntry[colName])
+        const targetNodeKey = getKeybyAttribute(targetEntry[colName])
+        const edgeInteraction = String(edgeEntry['interaction']) ?? 'None'
+        return [sourceNodeKey, targetNodeKey, edgeInteraction]
+    }
+
     networkRecords[secondNetId].network.nodes.forEach(nodeObj => {
         const nodeEntry = networkRecords[secondNetId].nodeTable.rows.get(nodeObj.id)
         if (nodeEntry === undefined) throw new Error("Node not found in the node table")
         nodeToSubtract.add(getKeybyAttribute(nodeEntry[secMatchingColName]))
     })
 
-    if (strictRemoveMode) { // subtract the node as long as it exists in the second network    
+    networkRecords[baseNetId].network.nodes.forEach(nodeObj => {
+        const newNodeId: string = `${globalNodeId++}`;
+        node2nodeMap.set(`${baseNetId}-${nodeObj.id}`, newNodeId);
+        const nodeEntry = networkRecords[baseNetId].nodeTable.rows.get(nodeObj.id)
+        if (nodeEntry === undefined) throw new Error("Node not found in the node table")
+        const attributeMapKey = getKeybyAttribute(nodeEntry[baseMatchingColName]);
 
-        const remainingNodeIds: Set<IdType> = new Set(node2nodeMap.keys())
-        networkRecords[baseNetId].network.nodes.forEach(nodeObj => {
-            const newNodeId: string = `${globalNodeId++}`;
-            node2nodeMap.set(`${baseNetId}-${nodeObj.id}`, newNodeId);
-            const nodeEntry = networkRecords[baseNetId].nodeTable.rows.get(nodeObj.id)
-            if (nodeEntry === undefined) throw new Error("Node not found in the node table")
-            const attributeMapKey = getKeybyAttribute(nodeEntry[matchingAttribute[baseNetId].name]);
-    
-            if (mergeWithinNetwork && matchingAttributeMap.has(attributeMapKey)) {
-                const matchedNodeId = matchingAttributeMap.get(attributeMapKey);
-                if (matchedNodeId !== undefined) {
-                    initialNodeRows[matchedNodeId] = mergeAttributes( //merge within the network
-                        initialNodeRows[matchedNodeId], castAttributes(nodeEntry, baseNetId, nodeAttributeMapping)
-                    )
-                    node2nodeMap.set(`${baseNetId}-${nodeObj.id}`, matchedNodeId);//reset the node2nodeMap
-                }
-            }else{
-                if (attributeMapKey !== undefined && attributeMapKey !== '') {
-                    matchingAttributeMap.set(attributeMapKey, newNodeId);
-                }
-                initialNodeRows[newNodeId] = addMergedAtt(castAttributes(nodeEntry, baseNetId, nodeAttributeMapping),
-                nodeEntry[reversedAttMap.get(baseNetId) as string], mergedAttCol)
-            }    
-        })
-        networkRecords[baseNetId].network.edges.forEach(edgeObj => {
-            const edgeEntry = networkRecords[baseNetId].edgeTable.rows.get(edgeObj.id)
-            if (edgeEntry === undefined) throw new Error("Edge not found in the edge table")
-            if (remainingNodeIds.has(edgeObj.s) && remainingNodeIds.has(edgeObj.t)) {
-                const newEdgeId = `e${globalEdgeId++}`
-                initialEdgeRows[newEdgeId] = castAttributes(edgeEntry, baseNetId, edgeAttributeMapping, false)
-                NetworkFn.addEdge(mergedNetwork, { id: newEdgeId, s: node2nodeMap.get(edgeObj.s), t: node2nodeMap.get(edgeObj.t) } as Edge);
+        if (mergeWithinNetwork && matchingAttributeMap.has(attributeMapKey)) {
+            const matchedNodeId = matchingAttributeMap.get(attributeMapKey);
+            if (matchedNodeId !== undefined) {
+                initialNodeRows[matchedNodeId] = mergeAttributes( //merge within the network
+                    initialNodeRows[matchedNodeId], castAttributes(nodeEntry, baseNetId, nodeAttributeMapping)
+                )
+                node2nodeMap.set(`${baseNetId}-${nodeObj.id}`, matchedNodeId);//reset the node2nodeMap
             }
-        })
+        }else{
+            if (attributeMapKey !== undefined && attributeMapKey !== '') {
+                matchingAttributeMap.set(attributeMapKey, newNodeId);
+            }
+            initialNodeRows[newNodeId] = addMergedAtt(castAttributes(nodeEntry, baseNetId, nodeAttributeMapping),
+            nodeEntry[reversedAttMap.get(baseNetId) as string], mergedAttCol)
+            if(nodeToSubtract.has(attributeMapKey)) matchedNodes.add(newNodeId)
+            else unmatchedNodes.add(newNodeId)
+        }    
+    })
 
-    } else {// Only remove nodes if all their edges are being subtracted, too
-        function getIdentifiableFromEdge(edgeObj: Edge, netId: IdType, colName: string): [SingleValueType, SingleValueType, string] {
-            const edgeEntry = networkRecords[netId].edgeTable.rows.get(edgeObj.id)
-            const sourceEntry = networkRecords[netId].nodeTable.rows.get(edgeObj.s)
-            const targetEntry = networkRecords[netId].nodeTable.rows.get(edgeObj.t)
-            if (edgeEntry === undefined) throw new Error("Edge not found in the edge table")
-            if (sourceEntry === undefined || targetEntry === undefined) throw new Error("Node not found in the node table")
-            const sourceNodeKey = getKeybyAttribute(sourceEntry[colName])
-            const targetNodeKey = getKeybyAttribute(targetEntry[colName])
-            const edgeInteraction = String(edgeEntry['interaction']) ?? 'None'
-            return [sourceNodeKey, targetNodeKey, edgeInteraction]
+    if (strictRemoveMode) { // subtract the node as long as it exists in the seco
+        for(const nodeId of unmatchedNodes){
+            NetworkFn.addNode(mergedNetwork, nodeId);
         }
-
+        for(const nodeId of matchedNodes){
+            delete initialNodeRows[nodeId]
+        }
+    } else {// Only remove nodes if all their edges are being subtracted, too
         networkRecords[baseNetId].network.edges.forEach(edgeObj => {
             const [sourceNodeKey, targetNodeKey, edgeInteraction] = getIdentifiableFromEdge(edgeObj, baseNetId, baseMatchingColName)
             if (sourceNode2EdgeMap.has(sourceNodeKey)) {
-                sourceNode2EdgeMap.get(sourceNodeKey)?.push([edgeInteraction, edgeObj.id] as Pair<string, IdType>)
+                sourceNode2EdgeMap.get(sourceNodeKey)?.push([`${targetNodeKey}-${edgeInteraction}`, edgeObj.id] as Pair<string, IdType>)
             } else {
-                sourceNode2EdgeMap.set(sourceNodeKey, [[edgeInteraction, edgeObj.id] as Pair<string, IdType>])
+                sourceNode2EdgeMap.set(sourceNodeKey, [[`${targetNodeKey}-${edgeInteraction}`, edgeObj.id] as Pair<string, IdType>])
             }
             if (targetNode2EdgeMap.has(targetNodeKey)) {
-                targetNode2EdgeMap.get(targetNodeKey)?.push([edgeInteraction, edgeObj.id] as Pair<string, IdType>)
+                targetNode2EdgeMap.get(targetNodeKey)?.push([`${sourceNodeKey}-${edgeInteraction}`, edgeObj.id] as Pair<string, IdType>)
             } else {
-                targetNode2EdgeMap.set(targetNodeKey, [[edgeInteraction, edgeObj.id] as Pair<string, IdType>])
+                targetNode2EdgeMap.set(targetNodeKey, [[`${sourceNodeKey}-${edgeInteraction}`, edgeObj.id] as Pair<string, IdType>])
             }
         })
         networkRecords[secondNetId].network.edges.forEach(edgeObj => {
             const [sourceNodeKey, targetNodeKey, edgeInteraction] = getIdentifiableFromEdge(edgeObj, secondNetId, secMatchingColName)
             if (sourceNode2EdgeMap.has(sourceNodeKey)) {// remove the edge interaction from the list
-                removePair(sourceNode2EdgeMap.get(sourceNodeKey) as Pair<string, IdType>[], edgeInteraction)
+                removePair(sourceNode2EdgeMap.get(sourceNodeKey) as Pair<string, IdType>[], `${targetNodeKey}-${edgeInteraction}`)
+                edgeToRemove.add(`${sourceNodeKey}-${targetNodeKey}-${edgeInteraction}`)
             }
             if (targetNode2EdgeMap.has(targetNodeKey)) {
-                removePair(targetNode2EdgeMap.get(targetNodeKey) as Pair<string, IdType>[], edgeInteraction)
+                removePair(targetNode2EdgeMap.get(targetNodeKey) as Pair<string, IdType>[], `${sourceNodeKey}-${edgeInteraction}`)
+                edgeToRemove.add(`${sourceNodeKey}-${targetNodeKey}-${edgeInteraction}`)
             }
         })
-        networkRecords[baseNetId].network.nodes.forEach(nodeObj => {
-            const nodeEntry = networkRecords[baseNetId].nodeTable.rows.get(nodeObj.id)
-            if (nodeEntry === undefined) throw new Error("Node not found in the node table")
-            const nodeKey = getKeybyAttribute(nodeEntry[baseMatchingColName])
-            if ((!nodeToSubtract.has(nodeKey)) || (sourceNode2EdgeMap.get(nodeKey)?.length ?? 0) > 0 || (targetNode2EdgeMap.get(nodeKey)?.length ?? 0) > 0) {
-                const newNodeId = `${globalNodeId++}`
-                initialNodeRows[newNodeId] = addMergedAtt(castAttributes(nodeEntry, baseNetId, nodeAttributeMapping),
-                    nodeEntry[reversedAttMap.get(baseNetId) as string], mergedAttCol)
-                NetworkFn.addNode(mergedNetwork, newNodeId);
-                node2nodeMap.set(nodeObj.id, newNodeId)
+        for(const nodeId of unmatchedNodes){
+            NetworkFn.addNode(mergedNetwork, nodeId);
+        }
+        for(const nodeId of matchedNodes){
+            const nodeKey = getKeybyAttribute(initialNodeRows[nodeId][baseMatchingColName])
+            if((sourceNode2EdgeMap.get(nodeKey)?.length ?? 0) > 0 || (targetNode2EdgeMap.get(nodeKey)?.length ?? 0) > 0){
+                NetworkFn.addNode(mergedNetwork, nodeId);
+                unmatchedNodes.add(nodeId)
+            }else{
+                delete initialNodeRows[nodeId]
             }
-        })
-        const remainingNodeIds: Set<IdType> = new Set(node2nodeMap.keys())
-        networkRecords[baseNetId].network.edges.forEach(edgeObj => {
-            const edgeEntry = networkRecords[baseNetId].edgeTable.rows.get(edgeObj.id)
-            if (edgeEntry === undefined) throw new Error("Edge not found in the edge table")
-            if (remainingNodeIds.has(edgeObj.s) && remainingNodeIds.has(edgeObj.t)) {
-                const newEdgeId = `e${globalEdgeId++}`
-                initialEdgeRows[newEdgeId] = castAttributes(edgeEntry, baseNetId, edgeAttributeMapping, false)
-                NetworkFn.addEdge(mergedNetwork, { id: newEdgeId, s: node2nodeMap.get(edgeObj.s), t: node2nodeMap.get(edgeObj.t) } as Edge);
-            }
-        })
+        }
     }
+    networkRecords[baseNetId].network.edges.forEach(edgeObj => {
+        const [sourceNodeKey, targetNodeKey, edgeInteraction] = getIdentifiableFromEdge(edgeObj, baseNetId, baseMatchingColName)
+        const edgeEntry = networkRecords[baseNetId].edgeTable.rows.get(edgeObj.id)
+        if (edgeEntry === undefined) throw new Error("Edge not found in the edge table")
+        const sourceNodeId = node2nodeMap.get(`${baseNetId}-${edgeObj.s}`)
+        const targetNodeId =  node2nodeMap.get(`${baseNetId}-${edgeObj.t}`)
+        if (sourceNodeId && targetNodeId && unmatchedNodes.has(sourceNodeId) && unmatchedNodes.has(targetNodeId) 
+            && (strictRemoveMode||!edgeToRemove.has(`${sourceNodeKey}-${targetNodeKey}-${edgeInteraction}`))) {
+            const newEdgeId = `e${globalEdgeId++}`
+            initialEdgeRows[newEdgeId] = castAttributes(edgeEntry, baseNetId, edgeAttributeMapping, false)
+            NetworkFn.addEdge(mergedNetwork, { id: newEdgeId, s: sourceNodeId, t: targetNodeId } as Edge);
+        }
+    })
     TableFn.insertRows(mergedNodeTable, Object.entries(initialNodeRows));
     TableFn.insertRows(mergedEdgeTable, Object.entries(initialEdgeRows));
     return {
@@ -159,12 +166,3 @@ export function differenceMerge(fromNetworks: IdType[], toNetworkId: IdType, net
 
     }
 }
-
-// Function to find and remove the pair
-const removePair = (list: Pair<string, string>[], target: string): Pair<string, string> | undefined => {
-    const index = list.findIndex((pair) => pair[0] === target);
-    if (index !== -1) {
-        return list.splice(index, 1)[0];  // Remove the item and return it
-    }
-    return undefined;  // Return undefined if no item was found
-};

--- a/src/features/MergeNetworks/tests/differenceMerge.spec.ts
+++ b/src/features/MergeNetworks/tests/differenceMerge.spec.ts
@@ -1,0 +1,285 @@
+jest.mock('../../../models/NetworkModel', () => {
+    return {
+        default: {
+            createNetwork: jest.fn(),
+            createNetworkFromLists: jest.fn(),
+            addNode: jest.fn(),
+            addNodes: jest.fn(),
+            addEdges: jest.fn(),
+            addEdge: jest.fn()
+        }
+    };
+});
+
+import { Table } from '../../../models/TableModel';
+import { IdType } from '../../../models/IdType';
+import { Network } from '../../../models/NetworkModel';
+import NetworkFn from '../../../models/NetworkModel';
+import { Node } from '../../../models/NetworkModel/Node';
+import { Column } from '../../../models/TableModel/Column';
+import { Edge } from '../../../models/NetworkModel/Edge';
+import { createMatchingTable } from '../models/Impl/MatchingTableImpl';
+import { MatchingTableRow } from '../models/MatchingTable';
+import { differenceMerge } from '../models/Impl/DifferenceMerge';
+
+beforeEach(() => {
+    jest.resetAllMocks();
+    (NetworkFn.createNetwork as jest.Mock).mockImplementation((id: IdType) => ({
+        id,
+        nodes: [],
+        edges: []
+    }));
+    (NetworkFn.addNodes as jest.Mock).mockImplementation((network: Network, nodeIds: IdType[]) => {
+        nodeIds.forEach(nodeId => network.nodes.push({ id: nodeId }));
+        return network;
+    });
+    (NetworkFn.addNode as jest.Mock).mockImplementation((network: Network, nodeId: IdType) => {
+        network.nodes.push({ id: nodeId });
+        return network;
+    });
+    (NetworkFn.addEdges as jest.Mock).mockImplementation((network: Network, edges: Edge[]) => {
+        edges.forEach(edge => network.edges.push(edge));
+        return network;
+    });
+    (NetworkFn.addEdge as jest.Mock).mockImplementation((network: Network, edge: Edge) => {
+        network.edges.push(edge);
+        return network;
+    });
+    (NetworkFn.createNetworkFromLists as jest.Mock).mockImplementation((id: IdType, nodes: Node[], edges: Edge[]) => {
+        const network: Network = { id, nodes: [], edges: [] };
+        nodes.forEach(node => network.nodes.push({ id: node.id }));
+        edges.forEach(edge => network.edges.push(edge));
+        return network;
+    });
+});
+
+describe('intersection merge', () => {
+    it('should merge the networks successfully when only remove nodes if all their edges are being subtracted, too', () => {
+        const fromNetworks: IdType[] = ['net1', 'net2']
+        const toNetworkId = 'mergedNetwork'
+        const nodeLst1: Node[] = [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }, { id: 'n4' }, { id: 'n5' }, { id: 'n6' }]
+        const nodeLst2: Node[] = [{ id: 'n7' }, { id: 'n8' }, { id: 'n9' }, { id: 'n0' }]
+    
+        const edgeLst1: Edge[] = [{ id: 'e1', s: 'n1', t: 'n2' }, { id: 'e2', s: 'n2', t: 'n3' }, { id: 'e3', s: 'n3', t: 'n4' }, 
+                                    { id: 'e4', s: 'n4', t: 'n1' },{ id: 'e5', s: 'n1', t: 'n3' }, { id: 'e6', s: 'n2', t: 'n4' },
+                                    { id: 'e7', s: 'n4', t: 'n5' }, { id: 'e8', s: 'n5', t: 'n6' }]
+        const edgeLst2: Edge[] = [{ id: 'e1', s: 'n7', t: 'n8' }, { id: 'e2', s: 'n9', t: 'n8' }, { id: 'e3', s: 'n9', t: 'n0' },
+                                    { id: 'e4', s: 'n0', t: 'n7' },{ id: 'e5', s: 'n7', t: 'n9' },{ id: 'e6', s: 'n8', t: 'n0' }]
+        const net1: Network = NetworkFn.createNetworkFromLists(fromNetworks[0], nodeLst1, edgeLst1)
+        const net2: Network = NetworkFn.createNetworkFromLists(fromNetworks[1], nodeLst2, edgeLst2)
+    
+        const nodeTableRows1 = new Map();
+        nodeTableRows1.set(nodeLst1[0].id, { name: 'node 1'});
+        nodeTableRows1.set(nodeLst1[1].id, { name: 'node 2'});
+        nodeTableRows1.set(nodeLst1[2].id, { name: 'node 3'});
+        nodeTableRows1.set(nodeLst1[3].id, { name: 'node 4'});
+        nodeTableRows1.set(nodeLst1[4].id, { name: 'node 5'});
+        nodeTableRows1.set(nodeLst1[5].id, { name: 'node 6'});
+    
+        const nodeTableRows2 = new Map();
+        nodeTableRows2.set(nodeLst2[0].id, { name: 'node 1'});
+        nodeTableRows2.set(nodeLst2[1].id, { name: 'node 2' });
+        nodeTableRows2.set(nodeLst2[2].id, { name: 'node 3' });
+        nodeTableRows2.set(nodeLst2[3].id, { name: 'node 4' });
+    
+        const edgeTableRows1 = new Map();
+        edgeTableRows1.set(edgeLst1[0].id, { name: 'edge 1', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[1].id, { name: 'edge 2', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[2].id, { name: 'edge 3', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[3].id, { name: 'edge 4', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[4].id, { name: 'edge 5', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[5].id, { name: 'edge 6', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[6].id, { name: 'edge 7', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[7].id, { name: 'edge 8', interaction: 'a' });
+    
+        const edgeTableRows2 = new Map();
+        edgeTableRows2.set(edgeLst2[0].id, { name: 'edge 1', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[1].id, { name: 'edge 2', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[2].id, { name: 'edge 3', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[3].id, { name: 'edge 4', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[4].id, { name: 'edge 5', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[5].id, { name: 'edge 6', interaction: 'b' });
+    
+        const nodeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows1 };
+        const nodeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows2 };
+    
+        const edgeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows1 };
+        const edgeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows2 };
+        const networkRecords = {
+            [fromNetworks[0]]: {
+                network: net1,
+                nodeTable: nodeTable1 as Table,
+                edgeTable: edgeTable1 as Table
+            },
+            [fromNetworks[1]]: {
+                network: net2,
+                nodeTable: nodeTable2 as Table,
+                edgeTable: edgeTable2 as Table
+            }
+        }
+        const nodeAttributeMapping = createMatchingTable([
+            {
+                id: 0, mergedNetwork: 'matchingAtt', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
+            },
+            {
+                id: 1, mergedNetwork: 'name', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
+            }
+        ] as MatchingTableRow[])
+        const edgeAttributeMapping = createMatchingTable([
+            {
+                id: 0, mergedNetwork: 'name', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
+            },
+            {
+                id: 1, mergedNetwork: 'interaction', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'interaction', [fromNetworks[1]]: 'interaction', [fromNetworks[2]]: 'interaction' }
+            }
+        ] as MatchingTableRow[])
+        const matchingAttribute = {
+            [fromNetworks[0]]: { name: 'name', type: 'string' } as Column,
+            [fromNetworks[1]]: { name: 'name', type: 'string' } as Column
+        }
+        const mergedNodeLst: Node[] = [{ id: '4' }, { id: '5' }]
+        const mergedEdgeLst: Edge[] = [{ id: 'e0', s: '4', t: '5' }]
+        const mergedNetwork: Network = NetworkFn.createNetworkFromLists(toNetworkId, mergedNodeLst, mergedEdgeLst)
+        const mergedNodeTableRows = new Map();
+        mergedNodeTableRows.set(mergedNodeLst[0].id, { name: 'node 5', matchingAtt: 'node 5' });
+        mergedNodeTableRows.set(mergedNodeLst[1].id, { name: 'node 6', matchingAtt: 'node 6' });
+        const mergedNodeTable = { id: toNetworkId, columns: [{ name: 'matchingAtt', type: 'string' }, { name: 'name', type: 'string' }], rows: mergedNodeTableRows };
+
+        const mergedEdgeTableRows = new Map();
+        mergedEdgeTableRows.set(mergedEdgeLst[0].id, { name: 'edge 8', interaction: 'a' });
+        const mergedEdgeTable = { id: toNetworkId, columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: mergedEdgeTableRows };
+        const result = differenceMerge(fromNetworks, toNetworkId, networkRecords, nodeAttributeMapping, edgeAttributeMapping, matchingAttribute, false, false, true)
+        expect(result).toEqual({
+            network: mergedNetwork,
+            nodeTable: mergedNodeTable,
+            edgeTable: mergedEdgeTable
+        })
+    });
+    it('should merge the networks successfully when remove all nodes that are in the second network', () => {
+        const fromNetworks: IdType[] = ['net1', 'net2']
+        const toNetworkId = 'mergedNetwork'
+        const nodeLst1: Node[] = [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }, { id: 'n4' }, { id: 'n5' }, { id: 'n6' }]
+        const nodeLst2: Node[] = [{ id: 'n7' }, { id: 'n8' }, { id: 'n9' }, { id: 'n0' }]
+    
+        const edgeLst1: Edge[] = [{ id: 'e1', s: 'n1', t: 'n2' }, { id: 'e2', s: 'n2', t: 'n3' }, { id: 'e3', s: 'n3', t: 'n4' }, 
+                                    { id: 'e4', s: 'n4', t: 'n1' },{ id: 'e5', s: 'n1', t: 'n3' }, { id: 'e6', s: 'n2', t: 'n4' },
+                                    { id: 'e7', s: 'n4', t: 'n5' }, { id: 'e8', s: 'n5', t: 'n6' }]
+        const edgeLst2: Edge[] = [{ id: 'e1', s: 'n7', t: 'n8' }, { id: 'e2', s: 'n9', t: 'n8' }, { id: 'e3', s: 'n9', t: 'n0' },
+                                    { id: 'e4', s: 'n0', t: 'n7' },{ id: 'e5', s: 'n7', t: 'n9' },{ id: 'e6', s: 'n8', t: 'n0' }]
+        const net1: Network = NetworkFn.createNetworkFromLists(fromNetworks[0], nodeLst1, edgeLst1)
+        const net2: Network = NetworkFn.createNetworkFromLists(fromNetworks[1], nodeLst2, edgeLst2)
+    
+        const nodeTableRows1 = new Map();
+        nodeTableRows1.set(nodeLst1[0].id, { name: 'node 1'});
+        nodeTableRows1.set(nodeLst1[1].id, { name: 'node 2'});
+        nodeTableRows1.set(nodeLst1[2].id, { name: 'node 3'});
+        nodeTableRows1.set(nodeLst1[3].id, { name: 'node 4'});
+        nodeTableRows1.set(nodeLst1[4].id, { name: 'node 5'});
+        nodeTableRows1.set(nodeLst1[5].id, { name: 'node 6'});
+    
+        const nodeTableRows2 = new Map();
+        nodeTableRows2.set(nodeLst2[0].id, { name: 'node 1'});
+        nodeTableRows2.set(nodeLst2[1].id, { name: 'node 2' });
+        nodeTableRows2.set(nodeLst2[2].id, { name: 'node 3' });
+        nodeTableRows2.set(nodeLst2[3].id, { name: 'node 4' });
+    
+        const edgeTableRows1 = new Map();
+        edgeTableRows1.set(edgeLst1[0].id, { name: 'edge 1', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[1].id, { name: 'edge 2', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[2].id, { name: 'edge 3', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[3].id, { name: 'edge 4', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[4].id, { name: 'edge 5', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[5].id, { name: 'edge 6', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[6].id, { name: 'edge 7', interaction: 'a' });
+        edgeTableRows1.set(edgeLst1[7].id, { name: 'edge 8', interaction: 'a' });
+    
+        const edgeTableRows2 = new Map();
+        edgeTableRows2.set(edgeLst2[0].id, { name: 'edge 1', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[1].id, { name: 'edge 2', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[2].id, { name: 'edge 3', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[3].id, { name: 'edge 4', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[4].id, { name: 'edge 5', interaction: 'a' });
+        edgeTableRows2.set(edgeLst2[5].id, { name: 'edge 6', interaction: 'b' });
+    
+        const nodeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows1 };
+        const nodeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows2 };
+    
+        const edgeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows1 };
+        const edgeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows2 };
+        const networkRecords = {
+            [fromNetworks[0]]: {
+                network: net1,
+                nodeTable: nodeTable1 as Table,
+                edgeTable: edgeTable1 as Table
+            },
+            [fromNetworks[1]]: {
+                network: net2,
+                nodeTable: nodeTable2 as Table,
+                edgeTable: edgeTable2 as Table
+            }
+        }
+        const nodeAttributeMapping = createMatchingTable([
+            {
+                id: 0, mergedNetwork: 'matchingAtt', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
+            },
+            {
+                id: 1, mergedNetwork: 'name', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
+            }
+        ] as MatchingTableRow[])
+        const edgeAttributeMapping = createMatchingTable([
+            {
+                id: 0, mergedNetwork: 'name', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
+            },
+            {
+                id: 1, mergedNetwork: 'interaction', type: 'string', hasConflicts: false,
+                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
+                nameRecord: { [fromNetworks[0]]: 'interaction', [fromNetworks[1]]: 'interaction', [fromNetworks[2]]: 'interaction' }
+            }
+        ] as MatchingTableRow[])
+        const matchingAttribute = {
+            [fromNetworks[0]]: { name: 'name', type: 'string' } as Column,
+            [fromNetworks[1]]: { name: 'name', type: 'string' } as Column
+        }
+        const mergedNodeLst: Node[] = [{ id: '4' }, { id: '5' }, { id: '1' }, {id:'2'}, {id:'3'}]
+        const mergedEdgeLst: Edge[] = [{ id: 'e0', s: '1', t: '2' }, { id: 'e1', s: '1', t: '3' }, { id: 'e2', s: '3', t: '4' },
+                                        { id: 'e3', s: '4', t: '5' }]
+        const mergedNetwork: Network = NetworkFn.createNetworkFromLists(toNetworkId, mergedNodeLst, mergedEdgeLst)
+        const mergedNodeTableRows = new Map();
+        mergedNodeTableRows.set(mergedNodeLst[2].id, { name: 'node 2', matchingAtt: "node 2"});
+        mergedNodeTableRows.set(mergedNodeLst[3].id, { name: 'node 3', matchingAtt: "node 3"});
+        mergedNodeTableRows.set(mergedNodeLst[4].id, { name: 'node 4', matchingAtt: "node 4"});
+        mergedNodeTableRows.set(mergedNodeLst[0].id, { name: 'node 5', matchingAtt: "node 5"});
+        mergedNodeTableRows.set(mergedNodeLst[1].id, { name: 'node 6', matchingAtt: "node 6"});
+
+        const mergedNodeTable = { id: toNetworkId, columns: [{ name: 'matchingAtt', type: 'string' }, { name: 'name', type: 'string' }], rows: mergedNodeTableRows };
+
+        const mergedEdgeTableRows = new Map();
+        mergedEdgeTableRows.set(mergedEdgeLst[0].id, { name: 'edge 2', interaction: 'a' });
+        mergedEdgeTableRows.set(mergedEdgeLst[1].id, { name: 'edge 6', interaction: 'a' });
+        mergedEdgeTableRows.set(mergedEdgeLst[2].id, { name: 'edge 7', interaction: 'a' });
+        mergedEdgeTableRows.set(mergedEdgeLst[3].id, { name: 'edge 8', interaction: 'a' });
+
+
+        const mergedEdgeTable = { id: toNetworkId, columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: mergedEdgeTableRows };
+        const result = differenceMerge(fromNetworks, toNetworkId, networkRecords, nodeAttributeMapping, edgeAttributeMapping, matchingAttribute)
+        expect(result).toEqual({
+            network: mergedNetwork,
+            nodeTable: mergedNodeTable,
+            edgeTable: mergedEdgeTable
+        })
+    });
+});

--- a/src/features/MergeNetworks/tests/differenceMerge.spec.ts
+++ b/src/features/MergeNetworks/tests/differenceMerge.spec.ts
@@ -19,7 +19,7 @@ import { Node } from '../../../models/NetworkModel/Node';
 import { Column } from '../../../models/TableModel/Column';
 import { Edge } from '../../../models/NetworkModel/Edge';
 import { createMatchingTable } from '../models/Impl/MatchingTableImpl';
-import { MatchingTableRow } from '../models/MatchingTable';
+import { MatchingTable, MatchingTableRow } from '../models/MatchingTable';
 import { differenceMerge } from '../models/Impl/DifferenceMerge';
 
 beforeEach(() => {
@@ -54,58 +54,53 @@ beforeEach(() => {
 });
 
 describe('intersection merge', () => {
-    it('should merge the networks successfully when only remove nodes if all their edges are being subtracted, too', () => {
-        const fromNetworks: IdType[] = ['net1', 'net2']
-        const toNetworkId = 'mergedNetwork'
-        const nodeLst1: Node[] = [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }, { id: 'n4' }, { id: 'n5' }, { id: 'n6' }]
-        const nodeLst2: Node[] = [{ id: 'n7' }, { id: 'n8' }, { id: 'n9' }, { id: 'n0' }]
+    let fromNetworks: IdType[];
+    let toNetworkId: IdType;
+    let nodeLst1: Node[];
+    let nodeLst2: Node[];
+    let edgeLst1: Edge[];
+    let edgeLst2: Edge[];
+    let net1: Network;
+    let net2: Network;
+    let nodeTableRows1: Map<IdType, any>;
+    let nodeTableRows2: Map<IdType, any>;
+    let edgeTableRows1: Map<IdType, any>;
+    let edgeTableRows2: Map<IdType, any>;
+    let nodeTable1: Table;
+    let nodeTable2: Table;
+    let edgeTable1: Table;
+    let edgeTable2: Table;
+    let networkRecords: Record<IdType, { network: Network, nodeTable: Table, edgeTable: Table }>;
+    let nodeAttributeMapping: MatchingTable;
+    let edgeAttributeMapping: MatchingTable;
+    let matchingAttribute: Record<IdType, Column>;
+
+    beforeEach(() => {
+        fromNetworks = ['net1', 'net2']
+        toNetworkId = 'mergedNetwork'
+        nodeLst1 = [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }, { id: 'n4' }, { id: 'n5' }, { id: 'n6' }]
+        nodeLst2 = [{ id: 'n7' }, { id: 'n8' }, { id: 'n9' }, { id: 'n0' }]
     
-        const edgeLst1: Edge[] = [{ id: 'e1', s: 'n1', t: 'n2' }, { id: 'e2', s: 'n2', t: 'n3' }, { id: 'e3', s: 'n3', t: 'n4' }, 
+        edgeLst1 = [{ id: 'e1', s: 'n1', t: 'n2' }, { id: 'e2', s: 'n2', t: 'n3' }, { id: 'e3', s: 'n3', t: 'n4' }, 
                                     { id: 'e4', s: 'n4', t: 'n1' },{ id: 'e5', s: 'n1', t: 'n3' }, { id: 'e6', s: 'n2', t: 'n4' },
                                     { id: 'e7', s: 'n4', t: 'n5' }, { id: 'e8', s: 'n5', t: 'n6' }]
-        const edgeLst2: Edge[] = [{ id: 'e1', s: 'n7', t: 'n8' }, { id: 'e2', s: 'n9', t: 'n8' }, { id: 'e3', s: 'n9', t: 'n0' },
+        edgeLst2 = [{ id: 'e1', s: 'n7', t: 'n8' }, { id: 'e2', s: 'n9', t: 'n8' }, { id: 'e3', s: 'n9', t: 'n0' },
                                     { id: 'e4', s: 'n0', t: 'n7' },{ id: 'e5', s: 'n7', t: 'n9' },{ id: 'e6', s: 'n8', t: 'n0' }]
-        const net1: Network = NetworkFn.createNetworkFromLists(fromNetworks[0], nodeLst1, edgeLst1)
-        const net2: Network = NetworkFn.createNetworkFromLists(fromNetworks[1], nodeLst2, edgeLst2)
+        net1 = NetworkFn.createNetworkFromLists(fromNetworks[0], nodeLst1, edgeLst1)
+        net2 = NetworkFn.createNetworkFromLists(fromNetworks[1], nodeLst2, edgeLst2)
     
-        const nodeTableRows1 = new Map();
-        nodeTableRows1.set(nodeLst1[0].id, { name: 'node 1'});
-        nodeTableRows1.set(nodeLst1[1].id, { name: 'node 2'});
-        nodeTableRows1.set(nodeLst1[2].id, { name: 'node 3'});
-        nodeTableRows1.set(nodeLst1[3].id, { name: 'node 4'});
-        nodeTableRows1.set(nodeLst1[4].id, { name: 'node 5'});
-        nodeTableRows1.set(nodeLst1[5].id, { name: 'node 6'});
+        nodeTableRows1 = new Map([...nodeLst1.entries()].map(([i, node]) => [node.id, { name: `node ${i + 1}` }]));
+        nodeTableRows2 = new Map([...nodeLst2.entries()].map(([i, node]) => [node.id, { name: `node ${i + 1}` }]));
+
+        edgeTableRows1 = new Map(edgeLst1.map(edge => [edge.id, { name: `edge ${edge.id?.slice(1)}`, interaction: 'a' } ] ));
+        edgeTableRows2 = new Map(edgeLst2.map(edge => [edge.id, { name: `edge ${edge.id?.slice(1)}`, interaction: edge.id === 'e6' ? 'b' : 'a' }]));
     
-        const nodeTableRows2 = new Map();
-        nodeTableRows2.set(nodeLst2[0].id, { name: 'node 1'});
-        nodeTableRows2.set(nodeLst2[1].id, { name: 'node 2' });
-        nodeTableRows2.set(nodeLst2[2].id, { name: 'node 3' });
-        nodeTableRows2.set(nodeLst2[3].id, { name: 'node 4' });
+        nodeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows1 };
+        nodeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows2 };
     
-        const edgeTableRows1 = new Map();
-        edgeTableRows1.set(edgeLst1[0].id, { name: 'edge 1', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[1].id, { name: 'edge 2', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[2].id, { name: 'edge 3', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[3].id, { name: 'edge 4', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[4].id, { name: 'edge 5', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[5].id, { name: 'edge 6', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[6].id, { name: 'edge 7', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[7].id, { name: 'edge 8', interaction: 'a' });
-    
-        const edgeTableRows2 = new Map();
-        edgeTableRows2.set(edgeLst2[0].id, { name: 'edge 1', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[1].id, { name: 'edge 2', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[2].id, { name: 'edge 3', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[3].id, { name: 'edge 4', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[4].id, { name: 'edge 5', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[5].id, { name: 'edge 6', interaction: 'b' });
-    
-        const nodeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows1 };
-        const nodeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows2 };
-    
-        const edgeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows1 };
-        const edgeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows2 };
-        const networkRecords = {
+        edgeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows1 };
+        edgeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows2 };
+        networkRecords = {
             [fromNetworks[0]]: {
                 network: net1,
                 nodeTable: nodeTable1 as Table,
@@ -117,7 +112,7 @@ describe('intersection merge', () => {
                 edgeTable: edgeTable2 as Table
             }
         }
-        const nodeAttributeMapping = createMatchingTable([
+        nodeAttributeMapping = createMatchingTable([
             {
                 id: 0, mergedNetwork: 'matchingAtt', type: 'string', hasConflicts: false,
                 typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
@@ -129,7 +124,7 @@ describe('intersection merge', () => {
                 nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
             }
         ] as MatchingTableRow[])
-        const edgeAttributeMapping = createMatchingTable([
+        edgeAttributeMapping = createMatchingTable([
             {
                 id: 0, mergedNetwork: 'name', type: 'string', hasConflicts: false,
                 typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
@@ -141,10 +136,12 @@ describe('intersection merge', () => {
                 nameRecord: { [fromNetworks[0]]: 'interaction', [fromNetworks[1]]: 'interaction', [fromNetworks[2]]: 'interaction' }
             }
         ] as MatchingTableRow[])
-        const matchingAttribute = {
+        matchingAttribute = {
             [fromNetworks[0]]: { name: 'name', type: 'string' } as Column,
             [fromNetworks[1]]: { name: 'name', type: 'string' } as Column
         }
+    });
+    it('should merge the networks successfully when remove all nodes that are in the second network', () => {
         const mergedNodeLst: Node[] = [{ id: '4' }, { id: '5' }]
         const mergedEdgeLst: Edge[] = [{ id: 'e0', s: '4', t: '5' }]
         const mergedNetwork: Network = NetworkFn.createNetworkFromLists(toNetworkId, mergedNodeLst, mergedEdgeLst)
@@ -163,97 +160,7 @@ describe('intersection merge', () => {
             edgeTable: mergedEdgeTable
         })
     });
-    it('should merge the networks successfully when remove all nodes that are in the second network', () => {
-        const fromNetworks: IdType[] = ['net1', 'net2']
-        const toNetworkId = 'mergedNetwork'
-        const nodeLst1: Node[] = [{ id: 'n1' }, { id: 'n2' }, { id: 'n3' }, { id: 'n4' }, { id: 'n5' }, { id: 'n6' }]
-        const nodeLst2: Node[] = [{ id: 'n7' }, { id: 'n8' }, { id: 'n9' }, { id: 'n0' }]
-    
-        const edgeLst1: Edge[] = [{ id: 'e1', s: 'n1', t: 'n2' }, { id: 'e2', s: 'n2', t: 'n3' }, { id: 'e3', s: 'n3', t: 'n4' }, 
-                                    { id: 'e4', s: 'n4', t: 'n1' },{ id: 'e5', s: 'n1', t: 'n3' }, { id: 'e6', s: 'n2', t: 'n4' },
-                                    { id: 'e7', s: 'n4', t: 'n5' }, { id: 'e8', s: 'n5', t: 'n6' }]
-        const edgeLst2: Edge[] = [{ id: 'e1', s: 'n7', t: 'n8' }, { id: 'e2', s: 'n9', t: 'n8' }, { id: 'e3', s: 'n9', t: 'n0' },
-                                    { id: 'e4', s: 'n0', t: 'n7' },{ id: 'e5', s: 'n7', t: 'n9' },{ id: 'e6', s: 'n8', t: 'n0' }]
-        const net1: Network = NetworkFn.createNetworkFromLists(fromNetworks[0], nodeLst1, edgeLst1)
-        const net2: Network = NetworkFn.createNetworkFromLists(fromNetworks[1], nodeLst2, edgeLst2)
-    
-        const nodeTableRows1 = new Map();
-        nodeTableRows1.set(nodeLst1[0].id, { name: 'node 1'});
-        nodeTableRows1.set(nodeLst1[1].id, { name: 'node 2'});
-        nodeTableRows1.set(nodeLst1[2].id, { name: 'node 3'});
-        nodeTableRows1.set(nodeLst1[3].id, { name: 'node 4'});
-        nodeTableRows1.set(nodeLst1[4].id, { name: 'node 5'});
-        nodeTableRows1.set(nodeLst1[5].id, { name: 'node 6'});
-    
-        const nodeTableRows2 = new Map();
-        nodeTableRows2.set(nodeLst2[0].id, { name: 'node 1'});
-        nodeTableRows2.set(nodeLst2[1].id, { name: 'node 2' });
-        nodeTableRows2.set(nodeLst2[2].id, { name: 'node 3' });
-        nodeTableRows2.set(nodeLst2[3].id, { name: 'node 4' });
-    
-        const edgeTableRows1 = new Map();
-        edgeTableRows1.set(edgeLst1[0].id, { name: 'edge 1', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[1].id, { name: 'edge 2', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[2].id, { name: 'edge 3', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[3].id, { name: 'edge 4', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[4].id, { name: 'edge 5', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[5].id, { name: 'edge 6', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[6].id, { name: 'edge 7', interaction: 'a' });
-        edgeTableRows1.set(edgeLst1[7].id, { name: 'edge 8', interaction: 'a' });
-    
-        const edgeTableRows2 = new Map();
-        edgeTableRows2.set(edgeLst2[0].id, { name: 'edge 1', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[1].id, { name: 'edge 2', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[2].id, { name: 'edge 3', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[3].id, { name: 'edge 4', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[4].id, { name: 'edge 5', interaction: 'a' });
-        edgeTableRows2.set(edgeLst2[5].id, { name: 'edge 6', interaction: 'b' });
-    
-        const nodeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows1 };
-        const nodeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }], rows: nodeTableRows2 };
-    
-        const edgeTable1 = { id: fromNetworks[0], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows1 };
-        const edgeTable2 = { id: fromNetworks[1], columns: [{ name: 'name', type: 'string' }, { name: 'interaction', type: 'string' }], rows: edgeTableRows2 };
-        const networkRecords = {
-            [fromNetworks[0]]: {
-                network: net1,
-                nodeTable: nodeTable1 as Table,
-                edgeTable: edgeTable1 as Table
-            },
-            [fromNetworks[1]]: {
-                network: net2,
-                nodeTable: nodeTable2 as Table,
-                edgeTable: edgeTable2 as Table
-            }
-        }
-        const nodeAttributeMapping = createMatchingTable([
-            {
-                id: 0, mergedNetwork: 'matchingAtt', type: 'string', hasConflicts: false,
-                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
-                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
-            },
-            {
-                id: 1, mergedNetwork: 'name', type: 'string', hasConflicts: false,
-                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
-                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
-            }
-        ] as MatchingTableRow[])
-        const edgeAttributeMapping = createMatchingTable([
-            {
-                id: 0, mergedNetwork: 'name', type: 'string', hasConflicts: false,
-                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
-                nameRecord: { [fromNetworks[0]]: 'name', [fromNetworks[1]]: 'name', [fromNetworks[2]]: 'name' }
-            },
-            {
-                id: 1, mergedNetwork: 'interaction', type: 'string', hasConflicts: false,
-                typeRecord: { [fromNetworks[0]]: 'string', [fromNetworks[1]]: 'string', [fromNetworks[2]]: 'string' },
-                nameRecord: { [fromNetworks[0]]: 'interaction', [fromNetworks[1]]: 'interaction', [fromNetworks[2]]: 'interaction' }
-            }
-        ] as MatchingTableRow[])
-        const matchingAttribute = {
-            [fromNetworks[0]]: { name: 'name', type: 'string' } as Column,
-            [fromNetworks[1]]: { name: 'name', type: 'string' } as Column
-        }
+    it('should merge the networks successfully when only remove nodes if all their edges are being subtracted, too', () => {
         const mergedNodeLst: Node[] = [{ id: '4' }, { id: '5' }, { id: '1' }, {id:'2'}, {id:'3'}]
         const mergedEdgeLst: Edge[] = [{ id: 'e0', s: '1', t: '2' }, { id: 'e1', s: '1', t: '3' }, { id: 'e2', s: '3', t: '4' },
                                         { id: 'e3', s: '4', t: '5' }]

--- a/src/features/MergeNetworks/utils/helper-functions.ts
+++ b/src/features/MergeNetworks/utils/helper-functions.ts
@@ -11,6 +11,15 @@ export const findPairIndex = (pairs: Pair<string, string>[], uuid: string) => {
     return pairs.findIndex(pair => pair[1] === uuid);
 };
 
+// Function to find and remove the pair
+export const removePair = (list: Pair<string, string>[], target: string): Pair<string, string> | undefined => {
+    const index = list.findIndex((pair) => pair[0] === target);
+    if (index !== -1) {
+        return list.splice(index, 1)[0];  // Remove the item and return it
+    }
+    return undefined;  // Return undefined if no item was found
+};
+
 export const getNetTableFromSummary = (summary: NdexNetworkSummary): Table => {
     const id = summary.externalId;
     const cols: Column[] = [];


### PR DESCRIPTION
1. Implemented the 'Merge Nodes/Edges in the same network' function for difference merge
2. Added a unit test for difference merge
3. Solved a small bug when applying layout after creating a new merged network: before the network was initially set as `hasLayout:true`, this will cause error if the user interrupt the process of applying layout. Now it is initially set as `hasLayout:false` and update it as `hasLayout:true` only after successful application of layout.