### PR TITLE
add basic functionality to import networks from cx2 by url

### DIFF
--- a/src/models/CxModel/fetch-url-cx-util.ts
+++ b/src/models/CxModel/fetch-url-cx-util.ts
@@ -1,0 +1,67 @@
+import { NetworkWithView, createDataFromCx } from '../../utils/cx-utils'
+import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
+import { Cx2 } from './Cx2'
+import { v4 as uuidv4 } from 'uuid'
+import { Visibility } from '../NetworkSummaryModel/Visibility'
+export const fetchUrlCx = async (
+  url: string,
+  maxSize: number,
+): Promise<{
+  summary: NdexNetworkSummary
+  networkWithView: NetworkWithView
+}> => {
+  try {
+    const response = await fetch(url, { method: 'HEAD' }) // Use HEAD request to get headers first
+    const contentLength = response.headers.get('Content-Length')
+
+    if (contentLength && parseInt(contentLength, 10) > maxSize) {
+      // Example: 10MB limit
+      throw new Error('CX network too large')
+    }
+
+    // If size is acceptable, make a GET request to actually fetch the data
+    const fullResponse = await fetch(url)
+    if (!fullResponse.ok) {
+      throw new Error(`HTTP error! status: ${fullResponse.status}`)
+    }
+    const data: Cx2 = await fullResponse.json()
+    const uuid = uuidv4()
+    const network = await createDataFromCx(uuid, data)
+
+    const summary = {
+      isNdex: false,
+      ownerUUID: uuid,
+      name: (network.networkAttributes?.attributes?.name as string) || 'test',
+      isReadOnly: false,
+      subnetworkIds: [],
+      isValid: false,
+      warnings: [],
+      isShowcase: false,
+      isCertified: false,
+      indexLevel: '',
+      hasLayout: false,
+      hasSample: false,
+      cxFileSize: 0,
+      cx2FileSize: 0,
+      properties: [],
+      owner: '',
+      version: '',
+      completed: false,
+      visibility: 'PUBLIC' as Visibility,
+      nodeCount: network.network.nodes.length,
+      edgeCount: network.network.edges.length,
+      description: 'test',
+      creationTime: new Date(Date.now()),
+      externalId: uuid,
+      isDeleted: false,
+      modificationTime: new Date(Date.now()),
+    }
+    return {
+      summary,
+      networkWithView: network,
+    }
+  } catch (error) {
+    console.error('Failed to fetch URL:', error)
+    throw error // Rethrow or handle as needed
+  }
+}


### PR DESCRIPTION
- In the AppShell component, after the redirect logic runs:
   - Get the search parameters to see if there is a `import` key
   - Get the value of the `import` key and fetch the cx, convert the cx to cyweb models
   - Delete the `import` key so that the user doesnt run into the issue of importing the cx multiple times if they wanted to refresh the app
