### PR TITLE
Force to redirect to error page and this avoids infinite loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,12 +52,7 @@ const router = createBrowserRouter(
           <AppShell />
         </Suspense>
       }
-      errorElement={
-        <div>
-          <p>ERROR1</p>
-        </div>
-      }
-      // errorElement={<Error />}
+      errorElement={<Error />}
     >
       <Route
         path=":workspaceId"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,12 @@ const router = createBrowserRouter(
           <AppShell />
         </Suspense>
       }
-      errorElement={<Error />}
+      errorElement={
+        <div>
+          <p>ERROR1</p>
+        </div>
+      }
+      // errorElement={<Error />}
     >
       <Route
         path=":workspaceId"
@@ -63,11 +68,22 @@ const router = createBrowserRouter(
             <WorkspaceEditor />
           </Suspense>
         }
+        errorElement={<Error />}
       >
         <Route path="networks" element={<div />} />
-        <Route path="networks/:networkId" element={<div />} />
+        <Route
+          path="networks/:networkId"
+          element={<div />}
+          errorElement={
+            <div>
+              <p>ERROR in network</p>
+            </div>
+          }
+        />
         <Route path="*" element={<RedirectPanel />} />
       </Route>
+
+      <Route path="/error" element={<Error />} />
     </Route>,
   ),
   routerOpts,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,15 +70,11 @@ const router = createBrowserRouter(
         }
         errorElement={<Error />}
       >
-        <Route path="networks" element={<div />} />
+        <Route path="networks" element={<div />} errorElement={<Error />} />
         <Route
           path="networks/:networkId"
           element={<div />}
-          errorElement={
-            <div>
-              <p>ERROR in network</p>
-            </div>
-          }
+          errorElement={<Error />}
         />
         <Route path="*" element={<RedirectPanel />} />
       </Route>

--- a/src/Error.tsx
+++ b/src/Error.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid, Typography } from '@mui/material'
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 import {
   isRouteErrorResponse,
   useNavigate,
@@ -8,9 +8,14 @@ import {
 import { useWorkspaceStore } from './store/WorkspaceStore'
 
 export const Error = (): ReactElement => {
-  const error = useRouteError()
+  const error: any = useRouteError()
   const navigate = useNavigate()
   const resetWorkspace = useWorkspaceStore((state) => state.resetWorkspace)
+
+  useEffect(() => {
+    // Force to block infinite redirect and navigate to the error URL
+    navigate('/error', { replace: true })
+  }, [navigate])
 
   const handleReset = (): void => {
     resetWorkspace()
@@ -47,10 +52,9 @@ export const Error = (): ReactElement => {
       </Grid>
       <Grid item xs={12}>
         <Typography variant="body1">
-          Your local cache might contain outdated 
-          workspace data and it can be the cause of this error. 
-          Please reset your local workspace cache and restart 
-          the app using the button below.
+          Your local cache might contain outdated workspace data and it can be
+          the cause of this error. Please reset your local workspace cache and
+          restart the app using the button below.
         </Typography>
       </Grid>
       <Grid item xs={12}>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -190,7 +190,7 @@ const AppShell = (): ReactElement => {
       } catch (error) {
         throw new Error(`Failed to initialize the workspace: ${error.message}`)
       } finally {
-        initializedRef.current = true
+        // initializedRef.current = true
       }
     }
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -190,7 +190,7 @@ const AppShell = (): ReactElement => {
       } catch (error) {
         throw new Error(`Failed to initialize the workspace: ${error.message}`)
       } finally {
-        // initializedRef.current = true
+        initializedRef.current = true
       }
     }
 

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingLayout.ts
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingLayout.ts
@@ -36,21 +36,25 @@ export const createTreeLayout = (
     treeElementList,
     allMembers,
   )
-  const hierarchyRootNode: HierarchyNode<D3TreeNode> =
-    d3Hierarchy.stratify<D3TreeNode>()(treeElementList)
-  // countAllChildren(hierarchyRootNode)
+  try {
+    const hierarchyRootNode: HierarchyNode<D3TreeNode> =
+      d3Hierarchy.stratify<D3TreeNode>()(treeElementList)
+    // countAllChildren(hierarchyRootNode)
 
-  // hierarchyRootNode.sum((d: D3TreeNode) => d.members.length)
-  hierarchyRootNode
-    .sum((d: D3TreeNode) => 1)
-    .sort((a, b) => {
-      const valA = a.value as number
-      const valB = b.value as number
-      return valB - valA
-    })
+    // hierarchyRootNode.sum((d: D3TreeNode) => d.members.length)
+    hierarchyRootNode
+      .sum((d: D3TreeNode) => 1)
+      .sort((a, b) => {
+        const valA = a.value as number
+        const valB = b.value as number
+        return valB - valA
+      })
+    return hierarchyRootNode
+  } catch (e) {
+    console.error('Failed to build tree,', e)
+    throw e
+  }
   // hierarchyRootNode.sum((d: D3TreeNode) => Math.floor(Math.random() * 100))
-
-  return hierarchyRootNode
 }
 
 export const CirclePackingType = 'circlePacking'

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
@@ -466,7 +466,12 @@ export const CirclePackingPanel = ({
   useEffect(() => {
     if (circlePackingView === undefined) return
 
-    updateViewModel()
+    try {
+      updateViewModel()
+    } catch (e) {
+      console.error('Failed to build the Circle Packing view', e)
+      throw e
+    }
   }, [visualStyle])
 
   const updateViewModel = (): void => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const TerserPlugin = require('terser-webpack-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const CompressionWebpackPlugin = require('compression-webpack-plugin')
 const config = require('./src/assets/config.json')
-const { over } = require('lodash')
 
 const isProduction = process.env.NODE_ENV === 'production'
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const TerserPlugin = require('terser-webpack-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const CompressionWebpackPlugin = require('compression-webpack-plugin')
 const config = require('./src/assets/config.json')
+const { over } = require('lodash')
 
 const isProduction = process.env.NODE_ENV === 'production'
 
@@ -47,6 +48,9 @@ module.exports = {
   // watch the dist file for changes when using the dev server
   devServer: {
     hot: true,
+    client: {
+      overlay: true,
+    },
     static: path.resolve(__dirname, './dist'),
     // historyApiFallback: true,
     historyApiFallback: {
@@ -78,10 +82,10 @@ module.exports = {
     // netlify requires a _redirects file in the root of the dist folder to work with react router
     ...(process.env.BUILD === 'netlify'
       ? [
-        new CopyPlugin({
-          patterns: [{ from: 'netlify/_redirects', to: '.' }],
-        }),
-      ]
+          new CopyPlugin({
+            patterns: [{ from: 'netlify/_redirects', to: '.' }],
+          }),
+        ]
       : []),
     // ...(isProduction ? [] : [new ESLintPlugin({ extensions: ['ts', 'tsx'] })]),
     ...(isProduction ? [new CompressionWebpackPlugin()] : []),


### PR DESCRIPTION
When uncaught errors happen and it triggers infinite loop, it forces to redirect to the top error page and stop repeating the reload.

Usually this is a fatal data loss, but necessary to reset the state.