### PR TITLE
Infinite loop issue and Duplicate node ID problem in DAG-to-Tree function

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import appConfig from './assets/config.json'
 import { KeycloakContext } from '.'
 import { useCredentialStore } from './store/CredentialStore'
 import { RedirectPanel } from './RedirectPanel'
+import ErrorBoundary from './ErrorBoundary'
 
 enableMapSet()
 
@@ -91,7 +92,9 @@ export const App = (): React.ReactElement => {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <RouterProvider router={router} />
+      <ErrorBoundary>
+        <RouterProvider router={router} />
+      </ErrorBoundary>
     </ThemeProvider>
   )
 }

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -13,7 +13,7 @@ class ErrorBoundary extends Component<Props, State> {
     hasError: false,
   }
 
-  public static getDerivedStateFromError(_: Error): State {
+  public static getDerivedStateFromError(): State {
     // Update state so the next render will show the fallback UI.
     return { hasError: true }
   }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -304,7 +304,7 @@ const AppShell = (): ReactElement => {
       redirect()
         .then(() => {})
         .catch((e) => {
-          console.log(e)
+          console.error('Failed to redirect in initialization process', e)
         })
     }
   }, [id])

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -211,21 +211,24 @@ const WorkSpaceEditor = (): JSX.Element => {
     positions: Map<IdType, [number, number, number?]>,
   ) => void = useViewModelStore((state) => state.updateNodePositions)
 
-  const loadNetworkSummaries = async (networkIds:IdType[]): Promise<void> => {
+  const loadNetworkSummaries = async (networkIds: IdType[]): Promise<void> => {
     const currentToken = await getToken()
     const newSummaries = await useNdexNetworkSummary(
       networkIds,
       ndexBaseUrl,
       currentToken,
     )
-    
-    setSummaries({...summaries, ...newSummaries})
+
+    setSummaries({ ...summaries, ...newSummaries })
 
     const loadedNetworks = Object.keys(newSummaries)
-    if(loadedNetworks.length !== networkIds.length){
-      const  networksFailtoLoad = networkIds.filter(id => !loadedNetworks.includes(id))
-      deleteNetwork(networksFailtoLoad)// remove the networks that the app fails to load from the workspace
-      addMessage({ // show a message to the user
+    if (loadedNetworks.length !== networkIds.length) {
+      const networksFailtoLoad = networkIds.filter(
+        (id) => !loadedNetworks.includes(id),
+      )
+      deleteNetwork(networksFailtoLoad) // remove the networks that the app fails to load from the workspace
+      addMessage({
+        // show a message to the user
         message: `Failed to load network(s) with id(s): ${networksFailtoLoad.join(', ')}`,
         duration: 5000,
       })
@@ -448,7 +451,9 @@ const WorkSpaceEditor = (): JSX.Element => {
             `/${workspace.id}/networks/${currentNetworkId}${location.search.toString()}`,
           )
         })
-        .catch((err) => console.error('Failed to load a network:', err))
+        .catch((err) => {
+          console.error('* Failed to load a network:', err)
+        })
         .finally(() => {
           isLoadingRef.current = false
         })
@@ -460,7 +465,9 @@ const WorkSpaceEditor = (): JSX.Element => {
             `/${workspace.id}/networks/${currentNetworkId}${location.search.toString()}`,
           )
         })
-        .catch((err) => console.error('Failed to load a network:', err))
+        .catch((err) => {
+          console.error('Failed to load a network:', err)
+        })
         .finally(() => {
           isLoadingRef.current = false
         })

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingLayout.ts
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingLayout.ts
@@ -36,10 +36,10 @@ export const createTreeLayout = (
     treeElementList,
     allMembers,
   )
+
   try {
     const hierarchyRootNode: HierarchyNode<D3TreeNode> =
       d3Hierarchy.stratify<D3TreeNode>()(treeElementList)
-    // countAllChildren(hierarchyRootNode)
 
     // hierarchyRootNode.sum((d: D3TreeNode) => d.members.length)
     hierarchyRootNode
@@ -55,7 +55,6 @@ export const createTreeLayout = (
     // throw e
     return {} as HierarchyNode<D3TreeNode>
   }
-  // hierarchyRootNode.sum((d: D3TreeNode) => Math.floor(Math.random() * 100))
 }
 
 export const CirclePackingType = 'circlePacking'

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingLayout.ts
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingLayout.ts
@@ -51,8 +51,9 @@ export const createTreeLayout = (
       })
     return hierarchyRootNode
   } catch (e) {
-    console.error('Failed to build tree,', e)
-    throw e
+    console.error('Failed to build D3 tree,', e)
+    // throw e
+    return {} as HierarchyNode<D3TreeNode>
   }
   // hierarchyRootNode.sum((d: D3TreeNode) => Math.floor(Math.random() * 100))
 }

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
@@ -283,6 +283,8 @@ export const CirclePackingPanel = ({
     d: d3Hierarchy.HierarchyNode<D3TreeNode>,
     maxDepth: number,
   ): string => {
+    if (d === undefined) return 'none'
+
     // Always display all subsystems/genes if the search result is shown
     if (expandAll || d.depth === 0 || d.depth <= maxDepth) {
       return 'inline'
@@ -292,11 +294,17 @@ export const CirclePackingPanel = ({
   }
 
   const updateForZoom = (maxDepth: number): void => {
-    d3Selection
-      .selectAll('circle')
-      .style('display', (d: d3Hierarchy.HierarchyNode<D3TreeNode>): string =>
+    const circles: d3Selection.Selection<
+      d3Selection.BaseType,
+      unknown,
+      HTMLElement,
+      any
+    > = d3Selection.selectAll('circle')
+    circles.style(
+      'display',
+      (d: d3Hierarchy.HierarchyNode<D3TreeNode>): string =>
         showObjects(d, maxDepth),
-      )
+    )
 
     d3Selection
       .selectAll('text')
@@ -488,6 +496,8 @@ export const CirclePackingPanel = ({
       rootNode = createTreeLayout(network, nodeTable)
     }
 
+    if (rootNode && Object.keys(rootNode).length === 0) return
+
     const updatedView = applyVisualStyle({
       network: network,
       visualStyle: visualStyle,
@@ -522,7 +532,11 @@ export const CirclePackingPanel = ({
   }, [network])
 
   useEffect(() => {
-    if (circlePackingView === undefined) return
+    if (
+      circlePackingView === undefined ||
+      circlePackingView.hierarchy === undefined
+    )
+      return
 
     const isInitialized: boolean = initRef.current
     const rootNode: d3Hierarchy.HierarchyNode<D3TreeNode> =

--- a/src/features/HierarchyViewer/components/CustomLayout/DataBuilderUtil.ts
+++ b/src/features/HierarchyViewer/components/CustomLayout/DataBuilderUtil.ts
@@ -48,6 +48,17 @@ export const findRoot = (cyNet: Core): NodeSingular => {
   return roots[0]
 }
 
+/**
+ * Function to convert a DAG to a tree for stratify
+ *
+ * @param node
+ * @param parentId
+ * @param cyNet
+ * @param nodeTable
+ * @param visited
+ * @param treeElements
+ * @param members
+ */
 export const cyNetDag2tree2 = (
   node: NodeSingular,
   parentId: string | null,
@@ -64,9 +75,10 @@ export const cyNetDag2tree2 = (
   visited[nodeId] = visited[nodeId] === undefined ? 1 : visited[nodeId] + 1
 
   // Create a new node ID based on visited count (use the same ID for the first visit)
+  // The new ID is the original ID with a suffix '-1d', '-2d', ...
   const newNodeId =
     visited[nodeId] > 1
-      ? `${nodeId}${DuplicateNodeSeparator}${visited[nodeId]}`
+      ? `${nodeId}${DuplicateNodeSeparator}${visited[nodeId]}d`
       : nodeId
 
   const newNode: D3TreeNode = {
@@ -75,7 +87,6 @@ export const cyNetDag2tree2 = (
     parentId: parentId === null ? '' : parentId,
     name: nodeTable.rows.get(nodeId)?.name as string,
     size: getMembers(nodeId, nodeTable).length,
-    // size: 1,
     members: getMembers(nodeId, nodeTable),
   }
   treeElements.push(newNode)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import ReactGA from 'react-ga4'
 import { enableMapSet } from 'immer'
 import React, { createContext } from 'react'
 import Keycloak from 'keycloak-js'
+import ErrorBoundary from './ErrorBoundary'
 enableMapSet()
 
 export const KeycloakContext = createContext<Keycloak>(new Keycloak())
@@ -37,7 +38,9 @@ keycloak
         <AppConfigContext.Provider value={appConfig}>
           <React.StrictMode>
             <KeycloakContext.Provider value={keycloak}>
-              <App />
+              <ErrorBoundary>
+                <App />
+              </ErrorBoundary>
             </KeycloakContext.Provider>
           </React.StrictMode>
         </AppConfigContext.Provider>,


### PR DESCRIPTION
This resolves the infinite loop problem and issues in tree data generation.

In some cases, the DAG to tree function generates duplicate node IDs and now it is resolved by adding "d" as suffix for duplicate nodes.