### PR TITLE
Clear leaf selection function call added when switching the subsystem

### DIFF
--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
@@ -405,6 +405,9 @@ export const CirclePackingPanel = ({
           } else {
             exclusiveSelect(network.id, [d.data.id], [])
           }
+
+          // Clear the selection in leafs in the selected node
+          setSelectedLeaf('')
         } else {
           // This is a leaf node
 


### PR DESCRIPTION
Gene selection in circle packing (red circle) was not cleared after changing the selected subsystem. This fixes the issue.