### PR TITLE
fix bug where importing a cx network from url would not preserve the layout

### DIFF
--- a/src/models/CxModel/fetch-url-cx-util.ts
+++ b/src/models/CxModel/fetch-url-cx-util.ts
@@ -39,7 +39,18 @@ export const fetchUrlCx = async (
       isShowcase: false,
       isCertified: false,
       indexLevel: '',
-      hasLayout: false,
+      hasLayout: network.networkViews
+        .map(
+          (v) =>
+            Object.values(v.nodeViews).filter(
+              (nv) =>
+                nv.x !== undefined &&
+                nv.y !== undefined &&
+                nv.x !== 0 &&
+                nv.y !== 0,
+            ).length > 0,
+        )
+        .reduce((acc, cur) => acc || cur, false),
       hasSample: false,
       cxFileSize: 0,
       cx2FileSize: 0,


### PR DESCRIPTION
When generating the network summary for a imported cx network via url, check the resulting nodeviews to see if any of the nodes have a non zero non undefined position.  If at least one node has a non zero non undefined position, set the `hasLayout` field to true, preventing a default layout being run after loading the network.