### PR TITLE
fix issue where the incorrect network would be exported to an image

### DIFF
--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -612,12 +612,12 @@ const CyjsRenderer = ({
           return 0
         }
       }
-      setRendererFunction('cyjs', 'fit', fitFunction)
-      setRendererFunction('cyjs', 'exportPng', exportPngFunction)
-      setRendererFunction('cyjs', 'exportPdf', exportPdfFunction)
-      setRendererFunction('cyjs', 'exportSvg', exportSvgFunction)
-      setRendererFunction('cyjs', 'width', widthFunction)
-      setRendererFunction('cyjs', 'height', heightFunction)
+      setRendererFunction('cyjs', 'fit', fitFunction, id)
+      setRendererFunction('cyjs', 'exportPng', exportPngFunction, id)
+      setRendererFunction('cyjs', 'exportPdf', exportPdfFunction, id)
+      setRendererFunction('cyjs', 'exportSvg', exportSvgFunction, id)
+      setRendererFunction('cyjs', 'width', widthFunction, id)
+      setRendererFunction('cyjs', 'height', heightFunction, id)
     }
 
     return () => {

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm.tsx
@@ -16,6 +16,9 @@ import { ReactElement, useState } from 'react'
 import { saveAs } from 'file-saver'
 import { useRendererFunctionStore } from '../../../../store/RendererFunctionStore'
 import { ExportImageFormatProps } from './ExportNetworkToImageMenuItem'
+import { IdType } from '../../../../models/IdType'
+import { useUiStateStore } from '../../../../store/UiStateStore'
+import { useWorkspaceStore } from '../../../../store/WorkspaceStore'
 
 export const PaperSize = {
   LETTER: 'LETTER',
@@ -58,8 +61,20 @@ export const PdfExportForm = (props: ExportImageFormatProps): ReactElement => {
     setOrientation(event.target.value)
   }
 
+  const activeNetworkId: IdType = useUiStateStore(
+    (state) => state.ui.activeNetworkView,
+  )
+  const currentNetworkId: IdType = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
+  )
+
+  const targetNetworkId: IdType =
+    activeNetworkId === undefined || activeNetworkId === ''
+      ? currentNetworkId
+      : activeNetworkId
+
   const pdfFunction = useRendererFunctionStore((state) =>
-    state.getFunction('cyjs', 'exportPdf'),
+    state.getFunction('cyjs', 'exportPdf', targetNetworkId),
   )
 
   return (

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/PngExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/PngExportForm.tsx
@@ -17,6 +17,9 @@ import { ReactElement, useEffect, useState } from 'react'
 import { saveAs } from 'file-saver'
 import { useRendererFunctionStore } from '../../../../store/RendererFunctionStore'
 import { ExportImageFormatProps } from './ExportNetworkToImageMenuItem'
+import { IdType } from '../../../../models/IdType'
+import { useUiStateStore } from '../../../../store/UiStateStore'
+import { useWorkspaceStore } from '../../../../store/WorkspaceStore'
 
 const MIN_ZOOM = 0
 const MAX_ZOOM = 5
@@ -37,14 +40,26 @@ export const PngExportForm = (props: ExportImageFormatProps): ReactElement => {
   const [widthInches, setWidthInches] = useState<number>(0)
   const [heightInches, setHeightInches] = useState<number>(0)
 
+  const activeNetworkId: IdType = useUiStateStore(
+    (state) => state.ui.activeNetworkView,
+  )
+  const currentNetworkId: IdType = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
+  )
+
+  const targetNetworkId: IdType =
+    activeNetworkId === undefined || activeNetworkId === ''
+      ? currentNetworkId
+      : activeNetworkId
+
   const pngFunction = useRendererFunctionStore((state) =>
-    state.getFunction('cyjs', 'exportPng'),
+    state.getFunction('cyjs', 'exportPng', targetNetworkId),
   )
   const widthFunction = useRendererFunctionStore((state) =>
-    state.getFunction('cyjs', 'width'),
+    state.getFunction('cyjs', 'width', targetNetworkId),
   )
   const heightFunction = useRendererFunctionStore((state) =>
-    state.getFunction('cyjs', 'height'),
+    state.getFunction('cyjs', 'height', targetNetworkId),
   )
 
   const maxHeight = heightFunction?.() * MAX_ZOOM

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
@@ -11,14 +11,29 @@ import { ReactElement, useState } from 'react'
 import { saveAs } from 'file-saver'
 import { ExportImageFormatProps } from './ExportNetworkToImageMenuItem'
 import { useRendererFunctionStore } from '../../../../store/RendererFunctionStore'
+import { IdType } from '../../../../models/IdType'
+import { useUiStateStore } from '../../../../store/UiStateStore'
+import { useWorkspaceStore } from '../../../../store/WorkspaceStore'
 
 export const SvgExportForm = (props: ExportImageFormatProps): ReactElement => {
   const [loading, setLoading] = useState(false)
   const [fullBg, setFullBg] = useState(true)
   const [fileName, setFileName] = useState<string>('network')
 
+  const activeNetworkId: IdType = useUiStateStore(
+    (state) => state.ui.activeNetworkView,
+  )
+  const currentNetworkId: IdType = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
+  )
+
+  const targetNetworkId: IdType =
+    activeNetworkId === undefined || activeNetworkId === ''
+      ? currentNetworkId
+      : activeNetworkId
+
   const svgFunction = useRendererFunctionStore((state) =>
-    state.getFunction('cyjs', 'exportSvg'),
+    state.getFunction('cyjs', 'exportSvg', targetNetworkId),
   )
 
   return (

--- a/src/store/RendererFunctionStore.ts
+++ b/src/store/RendererFunctionStore.ts
@@ -1,8 +1,10 @@
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
+import { IdType } from '../models/IdType'
 
 interface RendererFunctionStore {
   rendererFunctions: Map<string, Map<string, Function>>
+  rendererFunctionsByNetworkId: Map<IdType, Map<string, Map<string, Function>>>
 }
 
 interface RendererFunctionActions {
@@ -10,22 +12,29 @@ interface RendererFunctionActions {
     rendererName: string,
     functionName: string,
     rendererFunction: Function,
+    networkId?: IdType,
   ) => void
 
   getFunction: (
     rendererName: string,
     functionName: string,
+    networkId?: IdType,
   ) => Function | undefined
 }
 
 export const useRendererFunctionStore = create(
   immer<RendererFunctionStore & RendererFunctionActions>((set, get) => ({
     rendererFunctions: new Map<string, Map<string, Function>>(),
+    rendererFunctionsByNetworkId: new Map<
+      IdType,
+      Map<string, Map<string, Function>>
+    >(),
 
     setFunction: (
       rendererName: string,
       functionName: string,
       rendererFunction: Function,
+      networkId?: IdType,
     ) => {
       set((state) => {
         if (!state.rendererFunctions.has(rendererName)) {
@@ -34,9 +43,37 @@ export const useRendererFunctionStore = create(
         state.rendererFunctions
           .get(rendererName)
           ?.set(functionName, rendererFunction)
+
+        if (networkId) {
+          if (!state.rendererFunctionsByNetworkId.has(networkId)) {
+            state.rendererFunctionsByNetworkId.set(
+              networkId,
+              new Map<string, Map<string, Function>>(),
+            )
+          }
+          if (
+            !state.rendererFunctionsByNetworkId
+              .get(networkId)
+              ?.has(rendererName)
+          ) {
+            state.rendererFunctionsByNetworkId
+              .get(networkId)
+              ?.set(rendererName, new Map<string, Function>())
+          }
+          state.rendererFunctionsByNetworkId
+            .get(networkId)
+            ?.get(rendererName)
+            ?.set(functionName, rendererFunction)
+        }
       })
     },
-    getFunction(rendererName, functionName) {
+    getFunction(rendererName, functionName, networkId?: IdType) {
+      if (networkId) {
+        return get()
+          .rendererFunctionsByNetworkId.get(networkId)
+          ?.get(rendererName)
+          ?.get(functionName)
+      }
       return get().rendererFunctions.get(rendererName)?.get(functionName)
     },
   })),


### PR DESCRIPTION
- use targetnetwork id to determine which network to export
- store renderer functions optionally by network id, use network id in conjunction with renderer and function name lookup