### PR TITLE
Rename som visual property names in vizmapper (CW-296)

### DIFF
--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -18,6 +18,7 @@ import { DefaultValueForm } from './Forms/DefaultValueForm'
 import { EmptyVisualPropertyViewBox } from './Forms/VisualPropertyViewBox'
 import { VisualPropertyGroup } from '../../models/VisualStyleModel/VisualPropertyGroup'
 import { useUiStateStore } from '../../store/UiStateStore'
+import { getDefaultVisualStyle } from '../../models/VisualStyleModel/impl/DefaultVisualStyle';
 
 function VisualPropertyView(props: {
   currentNetworkId: IdType
@@ -31,12 +32,16 @@ function VisualPropertyView(props: {
   const widthDisabled = nodeSizeLocked && NodeVisualPropertyName.NodeWidth === vpName
   const arrowColorDisabled = arrowColorMatchesEdge && (EdgeVisualPropertyName.EdgeSourceArrowColor === vpName || EdgeVisualPropertyName.EdgeTargetArrowColor === vpName)
   const disabled = widthDisabled || arrowColorDisabled
+
+  const edgeLineColorName = getDefaultVisualStyle()['edgeLineColor'].displayName
+  const heightName = getDefaultVisualStyle()['nodeHeight'].displayName
   return (
     <Tooltip
       placement='top'
+      arrow={true}
       title={disabled ? (widthDisabled ?
-        'To enable this visual property, uncheck the \'Lock node width and height\' in the \'Height\' property.' :
-        'To enable this visual property, uncheck the \'Edge color to arrows\' in the \'Line Color\' property.') : ''
+        `To enable this visual property, uncheck the \'Lock node width and height\' in the \'${heightName}\' property.` :
+        `To enable this visual property, uncheck the \'Edge color to arrows\' in the \'${edgeLineColorName}\' property.`) : ''
       }
     >
       <Box
@@ -92,12 +97,13 @@ function VisualPropertyView(props: {
           </Typography>
         </Box>
 
-        {disabled &&
+        {(disabled || visualProperty.tooltip) &&
           <Tooltip
             placement='top'
             title={disabled ? (widthDisabled ?
-              'To enable this visual property, uncheck the \'Lock node width and height\' in the \'Height\' property.' :
-              'To enable this visual property, uncheck the \'Edge color to arrows\' in the \'Line Color\' property.') : ''}
+              `To enable this visual property, uncheck the \'Lock node width and height\' in the \'${heightName}\' property.` :
+              `To enable this visual property, uncheck the \'Edge color to arrows\' in the \'${edgeLineColorName}\' property.`) :
+              (visualProperty.tooltip ?? '')}
             arrow={true}
             sx={{
               mr: 1,

--- a/src/models/VisualStyleModel/VisualProperty.ts
+++ b/src/models/VisualStyleModel/VisualProperty.ts
@@ -17,4 +17,5 @@ export interface VisualProperty<T extends VisualPropertyValueType> {
   defaultValue: T
   mapping?: VisualMappingFunction
   bypassMap: Bypass<T>
+  tooltip?: string
 }

--- a/src/models/VisualStyleModel/impl/DefaultVisualStyle.ts
+++ b/src/models/VisualStyleModel/impl/DefaultVisualStyle.ts
@@ -30,7 +30,7 @@ export const getDefaultVisualStyle = (): VisualStyle => ({
   nodeBorderLineType: {
     group: 'node',
     name: 'nodeBorderLineType',
-    displayName: 'Border Line',
+    displayName: 'Border Line Type',
     type: 'nodeBorderLine',
     defaultValue: 'solid',
     bypassMap: new Map(),
@@ -182,10 +182,11 @@ export const getDefaultVisualStyle = (): VisualStyle => ({
   nodeMaxLabelWidth: {
     group: 'node',
     name: 'nodeMaxLabelWidth',
-    displayName: 'Max Node Label Width',
+    displayName: 'Label Width',
     type: 'number',
     defaultValue: 100,
     bypassMap: new Map(),
+    tooltip: 'The maximum width of the node label'
   },
   nodeZOrder: {
     group: 'node',
@@ -198,7 +199,7 @@ export const getDefaultVisualStyle = (): VisualStyle => ({
   edgeLineColor: {
     group: 'edge',
     name: 'edgeLineColor',
-    displayName: 'Line Color',
+    displayName: 'Stroke Color',
     type: 'color',
     defaultValue: '#000000',
     bypassMap: new Map(),
@@ -334,10 +335,11 @@ export const getDefaultVisualStyle = (): VisualStyle => ({
   edgeMaxLabelWidth: {
     group: 'edge',
     name: 'edgeMaxLabelWidth',
-    displayName: 'Max Edge Label Width',
+    displayName: 'Label Width',
     type: 'number',
     defaultValue: 100,
     bypassMap: new Map(),
+    tooltip: 'The maximum width of the edge label'
   },
   edgeZOrder: {
     group: 'edge',


### PR DESCRIPTION
- Node "Border Line" to "Border Line Type"
- "Max Edge/Node Label Width" -> "Label Width" (with mouse over "The maximum width of the node label")
- Edge Line Color -> "Stroke Color"