### PR TITLE
Sort enum values in alphabetical order in Vizmapper UI and bold text when it is selected.

### DIFF
--- a/src/components/Vizmapper/VisualPropertyRender/EdgeArrowShape.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/EdgeArrowShape.tsx
@@ -40,7 +40,6 @@ export function EdgeArrowShapePicker(props: {
             sx={{
               color: currentValue === edgeArrowShape ? 'blue' : 'black',
               fontWeight: currentValue === edgeArrowShape ? 'bold' : 'normal',
-              width: 100,
               p: 1,
               '&:hover': { cursor: 'pointer' },
             }}
@@ -53,11 +52,13 @@ export function EdgeArrowShapePicker(props: {
                 flexDirection: 'column',
                 justifyContent: 'space-between',
                 alignContent: 'center',
-                width: 100,
+                width: 80,
               }}
             >
-              <EdgeArrowShape value={edgeArrowShape} isSelected={currentValue === edgeArrowShape} />
-              <Box>{edgeArrowShape}</Box>
+              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                <EdgeArrowShape value={edgeArrowShape} isSelected={currentValue === edgeArrowShape} />
+              </Box>
+              <Box sx={{ textAlign: 'center' }}>{edgeArrowShape}</Box>
             </Box>
           </Box>
         ),

--- a/src/components/Vizmapper/VisualPropertyRender/EdgeArrowShape.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/EdgeArrowShape.tsx
@@ -9,13 +9,13 @@ import {
   NoneArrowIcon,
 } from '../VisualStyleIcons'
 
-const edgeArrowShapeMap: Record<EdgeArrowShapeType, React.ReactElement> = {
-  [EdgeArrowShapeType.None]: <NoneArrowIcon />,
-  [EdgeArrowShapeType.Circle]: <CircleArrowIcon />,
-  [EdgeArrowShapeType.Diamond]: <DiamondArrowIcon />,
-  [EdgeArrowShapeType.Square]: <SquareArrowIcon />,
-  [EdgeArrowShapeType.Triangle]: <TriangleArrowIcon />,
-  [EdgeArrowShapeType.Tee]: <TeeArrowIcon />,
+const edgeArrowShapeMap: Record<EdgeArrowShapeType, (isSelected: boolean) => React.ReactElement> = {
+  [EdgeArrowShapeType.None]: (isSelected: boolean) => <NoneArrowIcon isSelected={isSelected} />,
+  [EdgeArrowShapeType.Circle]: (isSelected: boolean) => <CircleArrowIcon isSelected={isSelected} />,
+  [EdgeArrowShapeType.Diamond]: (isSelected: boolean) => <DiamondArrowIcon isSelected={isSelected} />,
+  [EdgeArrowShapeType.Square]: (isSelected: boolean) => <SquareArrowIcon isSelected={isSelected} />,
+  [EdgeArrowShapeType.Triangle]: (isSelected: boolean) => <TriangleArrowIcon isSelected={isSelected} />,
+  [EdgeArrowShapeType.Tee]: (isSelected: boolean) => <TeeArrowIcon isSelected={isSelected} />,
 }
 
 export function EdgeArrowShapePicker(props: {
@@ -24,6 +24,7 @@ export function EdgeArrowShapePicker(props: {
   closePopover: () => void
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
+  const sortedEdgeArrowShapes = Object.values(EdgeArrowShapeType).sort();
 
   return (
     <Box
@@ -33,11 +34,12 @@ export function EdgeArrowShapePicker(props: {
         flexWrap: 'wrap',
       }}
     >
-      {Object.values(EdgeArrowShapeType).map(
+      {sortedEdgeArrowShapes.map(
         (edgeArrowShape: EdgeArrowShapeType) => (
           <Box
             sx={{
               color: currentValue === edgeArrowShape ? 'blue' : 'black',
+              fontWeight: currentValue === edgeArrowShape ? 'bold' : 'normal',
               width: 100,
               p: 1,
               '&:hover': { cursor: 'pointer' },
@@ -54,7 +56,7 @@ export function EdgeArrowShapePicker(props: {
                 width: 100,
               }}
             >
-              <EdgeArrowShape value={edgeArrowShape} />
+              <EdgeArrowShape value={edgeArrowShape} isSelected={currentValue === edgeArrowShape} />
               <Box>{edgeArrowShape}</Box>
             </Box>
           </Box>
@@ -65,7 +67,9 @@ export function EdgeArrowShapePicker(props: {
 }
 
 export function EdgeArrowShape(props: {
-  value: EdgeArrowShapeType
+  value: EdgeArrowShapeType,
+  isSelected: boolean
 }): React.ReactElement {
-  return edgeArrowShapeMap[props.value] ?? <Box>{props.value}</Box>
+  const { value, isSelected } = props
+  return edgeArrowShapeMap[value](isSelected) ?? <Box>{value}</Box>
 }

--- a/src/components/Vizmapper/VisualPropertyRender/EdgeLine.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/EdgeLine.tsx
@@ -31,7 +31,6 @@ export function EdgeLinePicker(props: {
           sx={{
             color: currentValue === edgeLine ? 'blue' : 'black',
             fontWeight: currentValue === edgeLine ? 'bold' : 'normal',
-            width: 100,
             p: 1,
             '&:hover': { cursor: 'pointer' },
           }}
@@ -44,7 +43,7 @@ export function EdgeLinePicker(props: {
               flexDirection: 'column',
               justifyContent: 'space-between',
               alignItems: 'center',
-              width: 100,
+              width: 80,
             }}
           >
             <EdgeLine value={edgeLine} isSelected={currentValue === edgeLine} />

--- a/src/components/Vizmapper/VisualPropertyRender/EdgeLine.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/EdgeLine.tsx
@@ -5,10 +5,10 @@ import {
   SolidLineIcon,
   DashedLineIcon,
 } from '../VisualStyleIcons'
-const edgeLineMap: Record<EdgeLineType, React.ReactElement> = {
-  [EdgeLineType.Solid]: <SolidLineIcon />,
-  [EdgeLineType.Dotted]: <DottedLineIcon />,
-  [EdgeLineType.Dashed]: <DashedLineIcon />,
+const edgeLineMap: Record<EdgeLineType, (isSelected: boolean) => React.ReactElement> = {
+  [EdgeLineType.Solid]: (isSelected: boolean) => <SolidLineIcon isSelected={isSelected} />,
+  [EdgeLineType.Dotted]: (isSelected: boolean) => <DottedLineIcon isSelected={isSelected} />,
+  [EdgeLineType.Dashed]: (isSelected: boolean) => <DashedLineIcon isSelected={isSelected} />,
 }
 export function EdgeLinePicker(props: {
   currentValue: EdgeLineType | null
@@ -16,6 +16,7 @@ export function EdgeLinePicker(props: {
   closePopover: () => void
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
+  const sortedEdgeLines = Object.values(EdgeLineType).sort();
 
   return (
     <Box
@@ -25,10 +26,11 @@ export function EdgeLinePicker(props: {
         flexWrap: 'wrap',
       }}
     >
-      {Object.values(EdgeLineType).map((edgeLine: EdgeLineType) => (
+      {sortedEdgeLines.map((edgeLine: EdgeLineType) => (
         <Box
           sx={{
             color: currentValue === edgeLine ? 'blue' : 'black',
+            fontWeight: currentValue === edgeLine ? 'bold' : 'normal',
             width: 100,
             p: 1,
             '&:hover': { cursor: 'pointer' },
@@ -45,7 +47,7 @@ export function EdgeLinePicker(props: {
               width: 100,
             }}
           >
-            <EdgeLine value={edgeLine} />
+            <EdgeLine value={edgeLine} isSelected={currentValue === edgeLine} />
             <Box>{edgeLine}</Box>
           </Box>
         </Box>
@@ -54,6 +56,7 @@ export function EdgeLinePicker(props: {
   )
 }
 
-export function EdgeLine(props: { value: EdgeLineType }): React.ReactElement {
-  return edgeLineMap[props.value] ?? <Box>{props.value}</Box>
+export function EdgeLine(props: { value: EdgeLineType, isSelected: boolean }): React.ReactElement {
+  const { value, isSelected } = props
+  return edgeLineMap[value](isSelected) ?? <Box>{value}</Box>
 }

--- a/src/components/Vizmapper/VisualPropertyRender/Font.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Font.tsx
@@ -7,6 +7,7 @@ export function FontPicker(props: {
   closePopover: () => void
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
+  const sortedFontTypes = Object.values(FontType).sort();
 
   return (
     <Box
@@ -16,10 +17,11 @@ export function FontPicker(props: {
         flexWrap: 'wrap',
       }}
     >
-      {Object.values(FontType).map((font: FontType) => (
+      {sortedFontTypes.map((font: FontType) => (
         <Box
           sx={{
             color: currentValue === font ? 'blue' : 'black',
+            fontWeight: currentValue === font ? 'bold' : 'normal',
             width: 100,
             display: 'flex',
             flexDirection: 'column',
@@ -32,7 +34,7 @@ export function FontPicker(props: {
           onClick={() => onValueChange(font)}
           key={font}
         >
-          <Font value={font} />
+          <Font value={font} isSelected={currentValue === font} />
           {font}
         </Box>
       ))}
@@ -40,6 +42,7 @@ export function FontPicker(props: {
   )
 }
 
-export function Font(props: { value: FontType }): React.ReactElement {
-  return <Box sx={{ fontFamily: props.value }}>Aa</Box>
+export function Font(props: { value: FontType, isSelected: boolean }): React.ReactElement {
+  const { value, isSelected } = props
+  return <Box sx={{ fontFamily: value, transform: isSelected ? 'scale(1.1)' : 'none' }}>Aa</Box>
 }

--- a/src/components/Vizmapper/VisualPropertyRender/NodeBorderLine.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeBorderLine.tsx
@@ -35,7 +35,6 @@ export function NodeBorderLinePicker(props: {
             sx={{
               color: currentValue === borderLine ? 'blue' : 'black',
               fontWeight: currentValue === borderLine ? 'bold' : 'normal',
-              width: 100,
               p: 1,
               '&:hover': { cursor: 'pointer' },
             }}
@@ -48,7 +47,7 @@ export function NodeBorderLinePicker(props: {
                 justifyContent: 'space-between',
                 flexDirection: 'column',
                 alignItems: 'center',
-                width: 100,
+                width: 80,
               }}
             >
               <NodeBorderLine value={borderLine} isSelected={currentValue === borderLine} />

--- a/src/components/Vizmapper/VisualPropertyRender/NodeBorderLine.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeBorderLine.tsx
@@ -7,12 +7,12 @@ import {
   DoubleLineIcon,
 } from '../VisualStyleIcons'
 
-const nodeLineMap: Record<NodeBorderLineType, React.ReactElement> = {
-  [NodeBorderLineType.Solid]: <SolidLineIcon />,
-  [NodeBorderLineType.Dotted]: <DottedLineIcon />,
-  [NodeBorderLineType.Dashed]: <DashedLineIcon />,
-  [NodeBorderLineType.Double]: <DoubleLineIcon />,
-}
+const nodeLineMap: Record<NodeBorderLineType, (isSelected: boolean) => React.ReactElement> = {
+  [NodeBorderLineType.Solid]: (isSelected: boolean) => <SolidLineIcon isSelected={isSelected} />,
+  [NodeBorderLineType.Dotted]: (isSelected: boolean) => <DottedLineIcon isSelected={isSelected} />,
+  [NodeBorderLineType.Dashed]: (isSelected: boolean) => <DashedLineIcon isSelected={isSelected} />,
+  [NodeBorderLineType.Double]: (isSelected: boolean) => <DoubleLineIcon isSelected={isSelected} />,
+};
 
 export function NodeBorderLinePicker(props: {
   currentValue: NodeBorderLineType | null
@@ -20,7 +20,7 @@ export function NodeBorderLinePicker(props: {
   closePopover: () => void
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
-
+  const sortedBorderLines = Object.values(NodeBorderLineType).sort();
   return (
     <Box
       sx={{
@@ -29,11 +29,12 @@ export function NodeBorderLinePicker(props: {
         flexWrap: 'wrap',
       }}
     >
-      {Object.values(NodeBorderLineType).map(
+      {sortedBorderLines.map(
         (borderLine: NodeBorderLineType) => (
           <Box
             sx={{
               color: currentValue === borderLine ? 'blue' : 'black',
+              fontWeight: currentValue === borderLine ? 'bold' : 'normal',
               width: 100,
               p: 1,
               '&:hover': { cursor: 'pointer' },
@@ -50,7 +51,7 @@ export function NodeBorderLinePicker(props: {
                 width: 100,
               }}
             >
-              <NodeBorderLine value={borderLine} />
+              <NodeBorderLine value={borderLine} isSelected={currentValue === borderLine} />
               <Box>{borderLine}</Box>
             </Box>
           </Box>
@@ -61,7 +62,9 @@ export function NodeBorderLinePicker(props: {
 }
 
 export function NodeBorderLine(props: {
-  value: NodeBorderLineType
+  value: NodeBorderLineType,
+  isSelected: boolean
 }): React.ReactElement {
-  return nodeLineMap[props.value] ?? <Box>{props.value}</Box>
+  const { value, isSelected } = props
+  return nodeLineMap[value](isSelected) ?? <Box>{value}</Box>
 }

--- a/src/components/Vizmapper/VisualPropertyRender/NodeShape.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeShape.tsx
@@ -13,16 +13,16 @@ import {
 } from '../VisualStyleIcons'
 import React from 'react'
 
-const nodeShapeMap: Record<NodeShapeType, React.ReactElement> = {
-  [NodeShapeType.Ellipse]: <EllipseIcon />,
-  [NodeShapeType.Rectangle]: <RectangleIcon />,
-  [NodeShapeType.RoundRectangle]: <RoundRectangleIcon />,
-  [NodeShapeType.Triangle]: <TriangleIcon />,
-  [NodeShapeType.Diamond]: <DiamondIcon />,
-  [NodeShapeType.Hexagon]: <HexagonIcon />,
-  [NodeShapeType.Octagon]: <OctagonIcon />,
-  [NodeShapeType.Parallelogram]: <ParallelogramIcon />,
-  [NodeShapeType.Vee]: <VeeIcon />,
+const nodeShapeMap: Record<NodeShapeType, (isSelected: boolean) => React.ReactElement> = {
+  [NodeShapeType.Ellipse]: (isSelected: boolean) => <EllipseIcon isSelected={isSelected} />,
+  [NodeShapeType.Rectangle]: (isSelected: boolean) => <RectangleIcon isSelected={isSelected} />,
+  [NodeShapeType.RoundRectangle]: (isSelected: boolean) => <RoundRectangleIcon isSelected={isSelected} />,
+  [NodeShapeType.Triangle]: (isSelected: boolean) => <TriangleIcon isSelected={isSelected} />,
+  [NodeShapeType.Diamond]: (isSelected: boolean) => <DiamondIcon isSelected={isSelected} />,
+  [NodeShapeType.Hexagon]: (isSelected: boolean) => <HexagonIcon isSelected={isSelected} />,
+  [NodeShapeType.Octagon]: (isSelected: boolean) => <OctagonIcon isSelected={isSelected} />,
+  [NodeShapeType.Parallelogram]: (isSelected: boolean) => <ParallelogramIcon isSelected={isSelected} />,
+  [NodeShapeType.Vee]: (isSelected: boolean) => <VeeIcon isSelected={isSelected} />,
 }
 
 const nodeShapeDisplayNameMap: Record<NodeShapeType, string> = {
@@ -43,7 +43,7 @@ export function NodeShapePicker(props: {
   closePopover: () => void
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
-
+  const sortedNodeShapes = Object.values(NodeShapeType).sort();
   return (
     <Box
       sx={{
@@ -53,10 +53,11 @@ export function NodeShapePicker(props: {
         width: 300,
       }}
     >
-      {Object.values(NodeShapeType).map((shape: NodeShapeType) => (
+      {sortedNodeShapes.map((shape: NodeShapeType) => (
         <Box
           sx={{
             color: currentValue === shape ? 'blue' : 'black',
+            fontWeight: currentValue === shape ? 'bold' : 'normal',
             width: 100,
             p: 1,
             '&:hover': { cursor: 'pointer' },
@@ -73,7 +74,7 @@ export function NodeShapePicker(props: {
               width: 100,
             }}
           >
-            <NodeShape value={shape} />
+            <NodeShape value={shape} isSelected={currentValue === shape} />
             <Box>{nodeShapeDisplayNameMap[shape]}</Box>
           </Box>
         </Box>
@@ -82,6 +83,7 @@ export function NodeShapePicker(props: {
   )
 }
 
-export function NodeShape(props: { value: NodeShapeType }): React.ReactElement {
-  return nodeShapeMap[props.value] ?? <Box>{props.value}</Box>
+export function NodeShape(props: { value: NodeShapeType, isSelected: boolean }): React.ReactElement {
+  const { value, isSelected } = props
+  return nodeShapeMap[value](isSelected) ?? <Box>{value}</Box>
 }

--- a/src/components/Vizmapper/VisualPropertyRender/NodeShape.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeShape.tsx
@@ -50,7 +50,7 @@ export function NodeShapePicker(props: {
         display: 'flex',
         justifyContent: 'space-between',
         flexWrap: 'wrap',
-        width: 300,
+        width: 450,
       }}
     >
       {sortedNodeShapes.map((shape: NodeShapeType) => (
@@ -58,7 +58,6 @@ export function NodeShapePicker(props: {
           sx={{
             color: currentValue === shape ? 'blue' : 'black',
             fontWeight: currentValue === shape ? 'bold' : 'normal',
-            width: 100,
             p: 1,
             '&:hover': { cursor: 'pointer' },
           }}
@@ -71,7 +70,7 @@ export function NodeShapePicker(props: {
               flexDirection: 'column',
               justifyContent: 'space-between',
               alignItems: 'center',
-              width: 100,
+              width: 130,
             }}
           >
             <NodeShape value={shape} isSelected={currentValue === shape} />

--- a/src/components/Vizmapper/VisualPropertyRender/Visibility.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Visibility.tsx
@@ -2,23 +2,23 @@ import { VisibilityType } from '../../../models/VisualStyleModel/VisualPropertyV
 import { Box } from '@mui/material'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
-const visibilityMap: Record<VisibilityType, React.ReactElement> = {
-  [VisibilityType.Element]: (
+const visibilityMap: Record<VisibilityType, (isSelected: boolean) => React.ReactElement> = {
+  [VisibilityType.Element]: (isSelected: boolean) =>
     <VisibilityIcon
       sx={{
         p: 0,
         m: 0,
+        transform: isSelected ? 'scale(1.1)' : 'none'
       }}
-    />
-  ),
-  [VisibilityType.None]: (
+    />,
+  [VisibilityType.None]: (isSelected: boolean) =>
     <VisibilityOffIcon
       sx={{
         p: 0,
         m: 0,
+        transform: isSelected ? 'scale(1.1)' : 'none'
       }}
-    />
-  ),
+    />,
 }
 
 export function VisibilityPicker(props: {
@@ -40,6 +40,7 @@ export function VisibilityPicker(props: {
         <Box
           sx={{
             color: currentValue === visibility ? 'blue' : 'black',
+            fontWeight: currentValue === visibility ? 'bold' : 'normal',
             width: 100,
             p: 1,
             '&:hover': { cursor: 'pointer' },
@@ -51,7 +52,7 @@ export function VisibilityPicker(props: {
           onClick={() => onValueChange(visibility)}
           key={visibility}
         >
-          <Visibility value={visibility} />
+          <Visibility value={visibility} isSelected={currentValue === visibility} />
           <Box>{visibility}</Box>
         </Box>
       ))}
@@ -60,11 +61,13 @@ export function VisibilityPicker(props: {
 }
 
 export function Visibility(props: {
-  value: VisibilityType
+  value: VisibilityType,
+  isSelected: boolean
 }): React.ReactElement {
+  const { value, isSelected } = props
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      {visibilityMap[props.value]}
+      {visibilityMap[value](isSelected)}
     </Box>
   )
 }

--- a/src/components/Vizmapper/VisualStyleIcons.tsx
+++ b/src/components/Vizmapper/VisualStyleIcons.tsx
@@ -17,6 +17,7 @@ const defaultIconStyle = {
 export interface IconProps {
   style?: React.CSSProperties
   sx?: SxProps
+  isSelected?: boolean
 }
 
 /* ====[ LOGOS ]============================================================================== */
@@ -152,11 +153,12 @@ export function NodeLabelIcon(props: IconProps): React.ReactElement {
 /* ====[ NODE SHAPES ]======================================================================== */
 
 export function DiamondIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M16,-0 L32,16 L16,32 L-0,16 L16,-0 z" />
     </SvgIcon>
@@ -164,11 +166,12 @@ export function DiamondIcon(props: IconProps): React.ReactElement {
 }
 
 export function EllipseIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M16,32 C7.163,32 -0,24.837 -0,16 C-0,7.163 7.163,-0 16,-0 C24.837,-0 32,7.163 32,16 C32,24.837 24.837,32 16,32 z" />
     </SvgIcon>
@@ -176,11 +179,12 @@ export function EllipseIcon(props: IconProps): React.ReactElement {
 }
 
 export function HexagonIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M7.917,32 L-0.166,16 L7.917,0 L24.083,0 L32.166,16 L24.083,32 z" />
     </SvgIcon>
@@ -188,11 +192,12 @@ export function HexagonIcon(props: IconProps): React.ReactElement {
 }
 
 export function OctagonIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M9.373,32 L0,22.627 L0,9.373 L9.373,0 L22.627,-0 L32,9.373 L32,22.627 L22.627,32 z" />
     </SvgIcon>
@@ -200,11 +205,12 @@ export function OctagonIcon(props: IconProps): React.ReactElement {
 }
 
 export function RectangleIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M0,0 L32,0 L32,32 L0,32 L0,0 z" />
     </SvgIcon>
@@ -212,11 +218,12 @@ export function RectangleIcon(props: IconProps): React.ReactElement {
 }
 
 export function ParallelogramIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M21.68,0 L-0,0 L10.32,32 L32,32 L21.68,0 z" />
     </SvgIcon>
@@ -224,11 +231,12 @@ export function ParallelogramIcon(props: IconProps): React.ReactElement {
 }
 
 export function RoundRectangleIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M8,-0 L24,-0 C28.418,-0 32,3.582 32,8 L32,24 C32,28.418 28.418,32 24,32 L8,32 C3.582,32 -0,28.418 -0,24 L-0,8 C-0,3.582 3.582,-0 8,-0 z" />
     </SvgIcon>
@@ -236,11 +244,12 @@ export function RoundRectangleIcon(props: IconProps): React.ReactElement {
 }
 
 export function TriangleIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M0,32 L16,-0 L32,32 z" />
     </SvgIcon>
@@ -248,11 +257,12 @@ export function TriangleIcon(props: IconProps): React.ReactElement {
 }
 
 export function VeeIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M32,0 L16,32 L0,0 L32,0 z M32,0 L0,0 L16,11 L32,0 z" />
     </SvgIcon>
@@ -262,11 +272,12 @@ export function VeeIcon(props: IconProps): React.ReactElement {
 /* ====[ ARROW SHAPES ]======================================================================= */
 
 export function CircleArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M24,8 C28.418,8 32,11.582 32,16 C32,20.418 28.418,24 24,24 C20.159,23.988 16.913,21.231 16.15,17.5 L0,17.5 L0,14.5 L16.15,14.5 C16.893,10.658 20.138,8.098 24,8 z" />
     </SvgIcon>
@@ -274,11 +285,12 @@ export function CircleArrowIcon(props: IconProps): React.ReactElement {
 }
 
 export function DiamondArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M24,8 L32,16 L24,24 L17.5,17.5 L-0,17.5 L-0,14.5 L17.5,14.5 L24,8 z" />
     </SvgIcon>
@@ -286,11 +298,12 @@ export function DiamondArrowIcon(props: IconProps): React.ReactElement {
 }
 
 export function NoneArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M-0,14.5 L32,14.5 L32,17.5 L-0,17.5 L-0,14.5 z" />
     </SvgIcon>
@@ -298,11 +311,12 @@ export function NoneArrowIcon(props: IconProps): React.ReactElement {
 }
 
 export function SquareArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M16,24 L16,17.5 L0,17.5 L0,14.5 L16,14.5 L16,8 L32,8 L32,24 L16,24 z" />
     </SvgIcon>
@@ -310,11 +324,12 @@ export function SquareArrowIcon(props: IconProps): React.ReactElement {
 }
 
 export function TeeArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M29,8 L29,24 L24,24 L24,17.5 L0,17.5 L0,14.5 L24,14.5 L24,8 L29,8 z" />
     </SvgIcon>
@@ -322,11 +337,12 @@ export function TeeArrowIcon(props: IconProps): React.ReactElement {
 }
 
 export function TriangleArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M18,8 L32,16 L18,24 L18,17.5 L-0,17.5 L-0,14.5 L18,14.5 L18,8 z" />
     </SvgIcon>
@@ -334,11 +350,12 @@ export function TriangleArrowIcon(props: IconProps): React.ReactElement {
 }
 
 export function TriangleCrossArrowIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M13.5,8 L13.5,14.5 L18,14.5 L18,8 L32,16 L18,24 L18,17.5 L13.5,17.5 L13.5,24 L10.5,24 L10.5,17.5 L0,17.5 L0,14.5 L10.5,14.5 L10.5,8 L13.5,8 z" />
     </SvgIcon>
@@ -348,11 +365,12 @@ export function TriangleCrossArrowIcon(props: IconProps): React.ReactElement {
 /* ====[ LINE STYLES ]======================================================================== */
 
 export function DashedLineIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M29.789,0.09 L31.91,2.211 L24.839,9.282 L22.718,7.161 L29.789,0.09 z" />
       <path d="M7.161,22.718 L9.282,24.839 L2.211,31.91 L0.09,29.789 L7.161,22.718 z" />
@@ -362,11 +380,12 @@ export function DashedLineIcon(props: IconProps): React.ReactElement {
 }
 
 export function DottedLineIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M3.272,26.607 L5.393,28.728 L3.272,30.849 L1.151,28.728 L3.272,26.607 z" />
       <path d="M7.515,22.364 L9.636,24.485 L7.515,26.607 L5.393,24.485 L7.515,22.364 z" />
@@ -380,11 +399,12 @@ export function DottedLineIcon(props: IconProps): React.ReactElement {
 }
 
 export function SolidLineIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M0.09,29.789 L29.789,0.09 L31.91,2.211 L2.211,31.91 L0.09,29.789 z" />
     </SvgIcon>
@@ -392,11 +412,12 @@ export function SolidLineIcon(props: IconProps): React.ReactElement {
 }
 
 export function DoubleLineIcon(props: IconProps): React.ReactElement {
+  const { sx, style, isSelected } = props
   return (
     <SvgIcon
       viewBox="0 0 32 32"
-      sx={props.sx ?? defaultIconStyle.sx}
-      style={props.style ?? defaultIconStyle.style}
+      sx={{ ...(sx ?? defaultIconStyle.sx), transform: isSelected ? 'scale(1.1)' : 'none' }}
+      style={style ?? defaultIconStyle.style}
     >
       <path d="M-5.09,24.789 L24.789,-5.09 26.91,-3.211 L-3.211,26.91 L-5.09,24.789 z" />
       <path d="M5.09,34.789 L34.789,5.09 L36.91,7.211 L7.211,36.91 L5.09,34.789 z" />


### PR DESCRIPTION
Sort the enum items in the popup windows of vizmapper in **alphabetical** order, and **bold** the item if it is selected.

- Node Border Line Type
- Node Shape
- Edge Line Type
- Source/Target arrow shape
- Visibility
- Font

Examples:
|Name|Display|
| -------- | ------- |
|Node Border/Edge Line Type|<img width="381" alt="image" src="https://github.com/user-attachments/assets/cae59731-7fef-4732-b63d-53647f7abaef">|
|Node Shape| <img width="446" alt="image" src="https://github.com/user-attachments/assets/536e2fbf-1135-41ac-8053-cfa4075a364c">|
|Source/Target arrow shape|<img width="575" alt="image" src="https://github.com/user-attachments/assets/1c2095da-97fb-419b-a3bb-24f397cfbe24">|
|Visibility|<img width="200" alt="image" src="https://github.com/user-attachments/assets/61084fc3-b3d1-480b-8d51-c6ce92ca0a96">|
|Font|<img width="297" alt="image" src="https://github.com/user-attachments/assets/c49f1bfe-8410-4e41-b7fb-66f5b8cf6bd4">|