### PR TITLE
Vizmapper code cleanup

### DIFF
--- a/src/components/Vizmapper/Forms/VisualPropertyValueForm.tsx
+++ b/src/components/Vizmapper/Forms/VisualPropertyValueForm.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react'
-import { Box, Popover, Typography, Tooltip, Tabs, Tab, Divider } from '@mui/material'
+import {
+  Box,
+  Popover,
+  Typography,
+  Tooltip,
+  Tabs,
+  Tab,
+  Divider,
+} from '@mui/material'
 
 import {
   VisualProperty,
@@ -9,14 +17,7 @@ import {
 } from '../../../models/VisualStyleModel'
 
 import { NodeShape, NodeShapePicker } from '../VisualPropertyRender/NodeShape'
-import {
-  Color,
-  ColorPicker,
-  ColorPickerCompact,
-  ColorPickerViridis,
-  ColorPickerSequential,
-  ColorPickerDiverging,
-} from '../VisualPropertyRender/Color'
+import { Color, ColorPicker } from '../VisualPropertyRender/Color'
 import {
   NodeBorderLine,
   NodeBorderLinePicker,
@@ -64,7 +65,6 @@ import {
   NodeLabelPositionRender,
 } from '../VisualPropertyRender/NodeLabelPosition'
 import { IdType } from '../../../models/IdType'
-import { CheckBox } from '@mui/icons-material'
 import { LockColorCheckbox } from '../VisualPropertyRender/Checkbox'
 
 const vpType2RenderMap: Record<
@@ -132,132 +132,6 @@ const vpType2RenderMap: Record<
     pickerRender: NodeLabelPositionPicker,
     valueRender: NodeLabelPositionRender,
   },
-}
-
-const vpType2RenderMap2: Record<
-  VisualPropertyValueTypeName,
-  {
-    pickerRender: (props: {
-      currentValue: VisualPropertyValueType | null
-      onValueChange: (newValue: VisualPropertyValueType) => void
-      closePopover: () => void
-    }) => React.ReactElement
-    valueRender: (props: {
-      value: VisualPropertyValueType
-    }) => React.ReactElement
-  }
-> = {
-  color: {
-    pickerRender: ColorPickerCompact,
-    valueRender: Color,
-  },
-}
-const vpType2RenderMapViridis: Record<
-  VisualPropertyValueTypeName,
-  {
-    pickerRender: (props: {
-      currentValue: VisualPropertyValueType | null
-      onValueChange: (newValue: VisualPropertyValueType) => void
-      closePopover: () => void
-    }) => React.ReactElement
-    valueRender: (props: {
-      value: VisualPropertyValueType
-    }) => React.ReactElement
-  }
-> = {
-  color: {
-    pickerRender: ColorPickerViridis,
-    valueRender: Color,
-  },
-}
-
-const vpType2RenderMapSequential: Record<
-  VisualPropertyValueTypeName,
-  {
-    pickerRender: (props: {
-      currentValue: VisualPropertyValueType | null
-      onValueChange: (newValue: VisualPropertyValueType) => void
-      closePopover: () => void
-      currentNetworkId?: IdType
-      showCheckbox?: boolean
-      vpName?: VisualPropertyName
-    }) => React.ReactElement
-    valueRender: (props: {
-      value: VisualPropertyValueType
-    }) => React.ReactElement
-  }
-> = {
-  nodeShape: {
-    pickerRender: NodeShapePicker,
-    valueRender: NodeShape,
-  },
-  color: {
-    pickerRender: ColorPickerSequential,
-    valueRender: Color,
-  },
-  nodeBorderLine: {
-    pickerRender: NodeBorderLinePicker,
-    valueRender: NodeBorderLine,
-  },
-  number: {
-    pickerRender: NumberInput,
-    valueRender: NumberRender,
-  },
-  font: {
-    pickerRender: FontPicker,
-    valueRender: Font,
-  },
-  horizontalAlign: {
-    pickerRender: HorizontalAlignPicker,
-    valueRender: HorizontalAlign,
-  },
-  verticalAlign: {
-    pickerRender: VerticalAlignPicker,
-    valueRender: VerticalAlign,
-  },
-  visibility: {
-    pickerRender: VisibilityPicker,
-    valueRender: Visibility,
-  },
-  edgeArrowShape: {
-    pickerRender: EdgeArrowShapePicker,
-    valueRender: EdgeArrowShape,
-  },
-  edgeLine: {
-    pickerRender: EdgeLinePicker,
-    valueRender: EdgeLine,
-  },
-  string: {
-    pickerRender: StringInput,
-    valueRender: StringRender,
-  },
-  boolean: {
-    pickerRender: BooleanSwitch,
-    valueRender: BooleanRender,
-  },
-  nodeLabelPosition: {
-    pickerRender: NodeLabelPositionPicker,
-    valueRender: NodeLabelPositionRender,
-  },
-}
-
-const vpType2RenderMapDiverging: Record<
-  VisualPropertyValueTypeName,
-  {
-    pickerRender: (props: {
-      currentValue: VisualPropertyValueType | null
-      onValueChange: (newValue: VisualPropertyValueType) => void
-      closePopover: () => void
-    }) => React.ReactElement
-    valueRender: (props: {
-      value: VisualPropertyValueType
-    }) => React.ReactElement
-  }
-> = {
-  color: {
-    pickerRender: ColorPickerDiverging,
-    valueRender: Color,
-  }
 }
 
 // in some cases, we have specialized value renders
@@ -354,17 +228,18 @@ export function VisualPropertyValueForm(
   props: VisualPropertyValueFormProps,
 ): React.ReactElement {
   const [valuePicker, setValuePicker] = React.useState<Element | null>(null)
-  const [activeTab, setActiveTab] = React.useState(0)
-  const isColor = props.visualProperty.displayName.includes("Color");
-  const vpName = props.visualProperty.name;
-  const isEdgeLineColor = vpName === EdgeVisualPropertyName.EdgeLineColor || vpName === EdgeVisualPropertyName.EdgeTargetArrowColor || vpName === EdgeVisualPropertyName.EdgeSourceArrowColor;
+  const vpName = props.visualProperty.name
+  const isEdgeLineColor =
+    vpName === EdgeVisualPropertyName.EdgeLineColor ||
+    vpName === EdgeVisualPropertyName.EdgeTargetArrowColor ||
+    vpName === EdgeVisualPropertyName.EdgeSourceArrowColor
   const showValuePicker = (value: Element | null): void => {
     setValuePicker(value)
   }
 
   const closePopover = (): void => {
-    setValuePicker(null);
-  };
+    setValuePicker(null)
+  }
 
   if (
     vpType2RenderMap[props.visualProperty.type] == null &&
@@ -392,170 +267,36 @@ export function VisualPropertyValueForm(
         anchorOrigin={{ vertical: 'top', horizontal: 55 }}
       >
         <Box sx={{ overflow: 'hidden' }}>
-          {
-            isColor ? (
-              <>
-                <Tabs
-                  value={activeTab}
-                  onChange={(event, newValue) => setActiveTab(newValue)}
-                  aria-label="Tab panel"
-                >
-                  <Tab sx={{ pl: 3, pr: 3 }} label="ColorBrewer Sequential" />
-                  <Tab sx={{ pl: 3, pr: 3 }} label="ColorBrewer Diverging" />
-                  <Tab sx={{ pl: 3, pr: 3 }} label="Viridis Sequential" />
-                  <Tab sx={{ pl: 3, pr: 3 }} label="Swatches" />
-                  <Tab sx={{ pl: 3, pr: 3 }} label="Color Picker" />
-                </Tabs>
-              </>
-            ) : null
-          }
-          {activeTab === 0 && (
-            <Box
-              sx={{
-                margin: 'auto',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                '&::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                scrollbarWidth: 'none',
-                msOverflowStyle: 'none',
-              }}
-            >
-              {(
-                vpName2RenderMap[props.visualProperty.name]?.pickerRender ??
-                vpType2RenderMapSequential[props.visualProperty.type]
-                  .pickerRender ??
-                (() => { })
-              )({
-                onValueChange: (value: VisualPropertyValueType) =>
-                  props.onValueChange(value),
-                currentValue: props.currentValue,
-                currentNetworkId: props.currentNetworkId,
-                showCheckbox: props.showCheckbox ?? false,
-                vpName: props.visualProperty.name,
-                closePopover: closePopover,
-              })}
-            </Box>
+          <Box
+            sx={{
+              margin: 'auto',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              '&::-webkit-scrollbar': {
+                display: 'none',
+              },
+              scrollbarWidth: 'none',
+              msOverflowStyle: 'none',
+            }}
+          >
+            {' '}
+            {(
+              vpType2RenderMap[props.visualProperty.type].pickerRender ??
+              (() => {})
+            )({
+              onValueChange: (value: VisualPropertyValueType) =>
+                props.onValueChange(value),
+              currentValue: props.currentValue,
+              closePopover: closePopover,
+            })}
+          </Box>
+          {props.showCheckbox && isEdgeLineColor && (
+            <>
+              <Divider />
+              <LockColorCheckbox currentNetworkId={props.currentNetworkId} />
+            </>
           )}
-          {activeTab === 1 && (
-            <Box
-              sx={{
-                margin: 'auto',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                '&::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                scrollbarWidth: 'none',
-                msOverflowStyle: 'none',
-              }}
-            >
-              {(
-                vpType2RenderMapDiverging[props.visualProperty.type]
-                  .pickerRender ??
-                (() => { })
-              )({
-                onValueChange: (value: VisualPropertyValueType) =>
-                  props.onValueChange(value),
-                currentValue: props.currentValue,
-                closePopover: closePopover,
-              })}
-            </Box>
-          )}
-
-          {activeTab === 2 && (
-            <Box
-              sx={{
-                margin: 'auto',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                '&::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                scrollbarWidth: 'none',
-                msOverflowStyle: 'none',
-              }}
-            >
-              {(
-                vpType2RenderMapViridis[props.visualProperty.type]
-                  .pickerRender ??
-                (() => { })
-              )({
-                onValueChange: (value: VisualPropertyValueType) =>
-                  props.onValueChange(value),
-                currentValue: props.currentValue,
-                closePopover: closePopover,
-              })}
-            </Box>
-          )}
-
-          {activeTab === 3 && (
-            <Box
-              sx={{
-                margin: 'auto',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                '&::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                scrollbarWidth: 'none',
-                msOverflowStyle: 'none',
-              }}
-            >
-              {' '}
-              {(
-                vpType2RenderMap2[props.visualProperty.type].pickerRender ??
-                (() => { })
-              )({
-                onValueChange: (value: VisualPropertyValueType) =>
-                  props.onValueChange(value),
-                currentValue: props.currentValue,
-                closePopover: closePopover,
-              })}
-            </Box>
-          )}
-
-          {activeTab === 4 && (
-            <Box
-              sx={{
-                margin: 'auto',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                '&::-webkit-scrollbar': {
-                  display: 'none',
-                },
-                scrollbarWidth: 'none',
-                msOverflowStyle: 'none',
-              }}
-            >
-              {' '}
-              {(
-                vpType2RenderMap[props.visualProperty.type].pickerRender ??
-                (() => { })
-              )({
-                onValueChange: (value: VisualPropertyValueType) =>
-                  props.onValueChange(value),
-                currentValue: props.currentValue,
-                closePopover: closePopover
-              })}
-            </Box>
-          )}
-          {props.showCheckbox && isEdgeLineColor &&
-            (
-              <>
-                <Divider />
-                <LockColorCheckbox
-                  currentNetworkId={props.currentNetworkId}
-                />
-              </>
-            )
-          }
         </Box>
       </Popover>
     </Box>

--- a/src/components/Vizmapper/VisualPropertyRender/Color.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Color.tsx
@@ -1,5 +1,5 @@
 import { ColorType } from '../../../models/VisualStyleModel/VisualPropertyValue'
-import { Box } from '@mui/material'
+import { Box, Tab, Tabs } from '@mui/material'
 import { ChromePicker, SwatchesPicker, CompactPicker } from 'react-color'
 import React from 'react'
 import debounce from 'lodash.debounce'
@@ -17,6 +17,7 @@ export function ColorPicker(props: {
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
   const debouncedValueChange = debounce(onValueChange, 200)
+  const [activeTab, setActiveTab] = React.useState(0)
 
   // use local state to appear instantaneous in the color picker,
   // but the actual visual style model updates are debounced
@@ -26,128 +27,69 @@ export function ColorPicker(props: {
 
   return (
     <Box>
-      <ChromePicker
-        color={localColorValue}
-        onChange={(color: any) => {
-          setLocalColorValue(color.hex)
-          debouncedValueChange(color.hex)
-        }}
-      />
-    </Box>
-  )
-}
-
-export function ColorPickerCompact(props: {
-  currentValue: ColorType | null
-  onValueChange: (color: ColorType) => void
-  closePopover: () => void
-}): React.ReactElement {
-  const { onValueChange, currentValue } = props
-  const debouncedValueChange = debounce(onValueChange, 200)
-
-  // use local state to appear instantaneous in the color picker,
-  // but the actual visual style model updates are debounced
-  const [localColorValue, setLocalColorValue] = React.useState<ColorType>(
-    currentValue ?? `#ffffff`,
-  )
-
-  return (
-    <Box>
-      <CompactPicker
-        colors={CompactCustomColors}
-        color={localColorValue}
-        onChange={(color: any) => {
-          setLocalColorValue(color.hex)
-          debouncedValueChange(color.hex)
-        }}
-      />
-    </Box>
-  )
-}
-
-export function ColorPickerViridis(props: {
-  currentValue: ColorType | null
-  onValueChange: (color: ColorType) => void
-  closePopover: () => void
-}): React.ReactElement {
-  const { onValueChange, currentValue } = props
-  const debouncedValueChange = debounce(onValueChange, 200)
-
-  // use local state to appear instantaneous in the color picker,
-  // but the actual visual style model updates are debounced
-  const [localColorValue, setLocalColorValue] = React.useState<ColorType>(
-    currentValue ?? `#ffffff`,
-  )
-
-  return (
-    <Box>
-      <SwatchesPicker
-        width={231}
-        colors={VirdisCustomColors}
-        color={localColorValue}
-        onChange={(color: any) => {
-          setLocalColorValue(color.hex)
-          debouncedValueChange(color.hex)
-        }}
-      />
-    </Box>
-  )
-}
-
-export function ColorPickerSequential(props: {
-  currentValue: ColorType | null
-  onValueChange: (color: ColorType) => void
-  closePopover: () => void
-}): React.ReactElement {
-  const { onValueChange, currentValue } = props
-  const debouncedValueChange = debounce(onValueChange, 200)
-
-  // use local state to appear instantaneous in the color picker,
-  // but the actual visual style model updates are debounced
-  const [localColorValue, setLocalColorValue] = React.useState<ColorType>(
-    currentValue ?? `#ffffff`,
-  )
-
-  return (
-    <Box>
-      <SwatchesPicker
-        width={945}
-        colors={SequentialCustomColors}
-        color={localColorValue}
-        onChange={(color: any) => {
-          setLocalColorValue(color.hex)
-          debouncedValueChange(color.hex)
-        }}
-      />
-    </Box>
-  )
-}
-
-export function ColorPickerDiverging(props: {
-  currentValue: ColorType | null
-  onValueChange: (color: ColorType) => void
-  closePopover: () => void
-}): React.ReactElement {
-  const { onValueChange, currentValue } = props
-  const debouncedValueChange = debounce(onValueChange, 200)
-
-  // use local state to appear instantaneous in the color picker,
-  // but the actual visual style model updates are debounced
-  const [localColorValue, setLocalColorValue] = React.useState<ColorType>(
-    currentValue ?? `#ffffff`,
-  )
-
-  return (
-    <Box>
-      <SwatchesPicker
-        width={600}
-        colors={DivergingCustomColors}
-        color={localColorValue}
-        onChange={(color: any) => {
-          setLocalColorValue(color.hex)
-          debouncedValueChange(color.hex)
-        }}
-      />
+      <Tabs
+        value={activeTab}
+        onChange={(event, newValue) => setActiveTab(newValue)}
+        aria-label="Tab panel"
+      >
+        <Tab sx={{ pl: 3, pr: 3 }} label="ColorBrewer Sequential" />
+        <Tab sx={{ pl: 3, pr: 3 }} label="ColorBrewer Diverging" />
+        <Tab sx={{ pl: 3, pr: 3 }} label="Viridis Sequential" />
+        <Tab sx={{ pl: 3, pr: 3 }} label="Swatches" />
+        <Tab sx={{ pl: 3, pr: 3 }} label="Color Picker" />
+      </Tabs>
+      {activeTab === 0 && (
+        <SwatchesPicker
+          width={945}
+          colors={SequentialCustomColors}
+          color={localColorValue}
+          onChange={(color: any) => {
+            setLocalColorValue(color.hex)
+            debouncedValueChange(color.hex)
+          }}
+        />
+      )}
+      {activeTab === 1 && (
+        <SwatchesPicker
+          width={600}
+          colors={DivergingCustomColors}
+          color={localColorValue}
+          onChange={(color: any) => {
+            setLocalColorValue(color.hex)
+            debouncedValueChange(color.hex)
+          }}
+        />
+      )}
+      {activeTab === 2 && (
+        <SwatchesPicker
+          width={231}
+          colors={VirdisCustomColors}
+          color={localColorValue}
+          onChange={(color: any) => {
+            setLocalColorValue(color.hex)
+            debouncedValueChange(color.hex)
+          }}
+        />
+      )}
+      {activeTab === 3 && (
+        <CompactPicker
+          colors={CompactCustomColors}
+          color={localColorValue}
+          onChange={(color: any) => {
+            setLocalColorValue(color.hex)
+            debouncedValueChange(color.hex)
+          }}
+        />
+      )}
+      {activeTab === 4 && (
+        <ChromePicker
+          color={localColorValue}
+          onChange={(color: any) => {
+            setLocalColorValue(color.hex)
+            debouncedValueChange(color.hex)
+          }}
+        />
+      )}
     </Box>
   )
 }

--- a/src/components/Vizmapper/VisualPropertyRender/Color.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Color.tsx
@@ -38,58 +38,68 @@ export function ColorPicker(props: {
         <Tab sx={{ pl: 3, pr: 3 }} label="Swatches" />
         <Tab sx={{ pl: 3, pr: 3 }} label="Color Picker" />
       </Tabs>
-      {activeTab === 0 && (
-        <SwatchesPicker
-          width={945}
-          colors={SequentialCustomColors}
-          color={localColorValue}
-          onChange={(color: any) => {
-            setLocalColorValue(color.hex)
-            debouncedValueChange(color.hex)
-          }}
-        />
-      )}
-      {activeTab === 1 && (
-        <SwatchesPicker
-          width={600}
-          colors={DivergingCustomColors}
-          color={localColorValue}
-          onChange={(color: any) => {
-            setLocalColorValue(color.hex)
-            debouncedValueChange(color.hex)
-          }}
-        />
-      )}
-      {activeTab === 2 && (
-        <SwatchesPicker
-          width={231}
-          colors={VirdisCustomColors}
-          color={localColorValue}
-          onChange={(color: any) => {
-            setLocalColorValue(color.hex)
-            debouncedValueChange(color.hex)
-          }}
-        />
-      )}
-      {activeTab === 3 && (
-        <CompactPicker
-          colors={CompactCustomColors}
-          color={localColorValue}
-          onChange={(color: any) => {
-            setLocalColorValue(color.hex)
-            debouncedValueChange(color.hex)
-          }}
-        />
-      )}
-      {activeTab === 4 && (
-        <ChromePicker
-          color={localColorValue}
-          onChange={(color: any) => {
-            setLocalColorValue(color.hex)
-            debouncedValueChange(color.hex)
-          }}
-        />
-      )}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          p: 1,
+          height: 275,
+        }}
+      >
+        {activeTab === 0 && (
+          <SwatchesPicker
+            width={945}
+            colors={SequentialCustomColors}
+            color={localColorValue}
+            onChange={(color: any) => {
+              setLocalColorValue(color.hex)
+              debouncedValueChange(color.hex)
+            }}
+          />
+        )}
+        {activeTab === 1 && (
+          <SwatchesPicker
+            width={600}
+            colors={DivergingCustomColors}
+            color={localColorValue}
+            onChange={(color: any) => {
+              setLocalColorValue(color.hex)
+              debouncedValueChange(color.hex)
+            }}
+          />
+        )}
+        {activeTab === 2 && (
+          <SwatchesPicker
+            width={231}
+            colors={VirdisCustomColors}
+            color={localColorValue}
+            onChange={(color: any) => {
+              setLocalColorValue(color.hex)
+              debouncedValueChange(color.hex)
+            }}
+          />
+        )}
+        {activeTab === 3 && (
+          <CompactPicker
+            colors={CompactCustomColors}
+            color={localColorValue}
+            onChange={(color: any) => {
+              setLocalColorValue(color.hex)
+              debouncedValueChange(color.hex)
+            }}
+          />
+        )}
+        {activeTab === 4 && (
+          <ChromePicker
+            color={localColorValue}
+            onChange={(color: any) => {
+              setLocalColorValue(color.hex)
+              debouncedValueChange(color.hex)
+            }}
+          />
+        )}
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
- Remove ~300 lines of unnecessary and complex code
- Move color picker code and logic from the VisualPropertyValueForm into the more appropriate ColorPicker component
- Improve style/layout of the color picker by centering the color swatches or picker and making the color picker content have a consistent height of 275 pixels