### PR TITLE
translate nodeshape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "html-react-parser": "^3.0.12",
         "idb-keyval": "^6.2.0",
         "immer": "^10.0.2",
-        "keycloak-js": "21.0.0",
+        "keycloak-js": "25.0.1",
         "lodash": "^4.17.21",
         "lodash.debounce": "^4.0.8",
         "marked": "^4.2.4",
@@ -17876,10 +17876,9 @@
       }
     },
     "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-      "license": "MIT"
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.0.tgz",
+      "integrity": "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -18166,14 +18165,21 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keycloak-js": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-21.0.0.tgz",
-      "integrity": "sha512-yYdvajk3Jmxu7eq7jFKaGgfeDcXxirE5Oi52AnPWAGr0ask/Xty1+kVCTJUrwKsGrZ//HSAiuyEpe0t0rku8fQ==",
-      "license": "Apache-2.0",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.1.tgz",
+      "integrity": "sha512-ns5sKQ5Iz3UyVGIKq2XBBXNZTlTCg9bzybR+JB2Vn+fDHIo9EGgAY4kzrBWMwbeFuegY+qJwGs05N+W9jgY9tg==",
       "dependencies": {
-        "base64-js": "^1.5.1",
-        "js-sha256": "^0.9.0"
+        "js-sha256": "^0.11.0",
+        "jwt-decode": "^4.0.0"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "html-react-parser": "^3.0.12",
     "idb-keyval": "^6.2.0",
     "immer": "^10.0.2",
-    "keycloak-js": "21.0.0",
+    "keycloak-js": "25.0.1",
     "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
     "marked": "^4.2.4",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -16,7 +16,7 @@
   ],
   "maxNetworkElementsThreshold": 20000,
   "maxNetworkFileSize": 524288000,
-  "urlBaseName": "/cytoscape/",
+  "urlBaseName": "/",
   "openAIAPIKey": "",
   "googleAnalyticsId": "G-B3X9SFXC2P"
  }

--- a/src/components/NetworkPanel/CyjsRenderer/cyjs-factory.ts
+++ b/src/components/NetworkPanel/CyjsRenderer/cyjs-factory.ts
@@ -50,9 +50,6 @@ const createCyNodes = (
       ...Object.fromEntries(
         Array.from(nv.values.entries()).map(([k, v]) => {
           if (k === NodeVisualPropertyName.NodeShape) {
-            console.log('k', k)
-            console.log('v', v)
-            console.log(NodeShapeMapping[v as NodeShapeType])
             return [k, NodeShapeMapping[v as NodeShapeType]]
           }
           return [k, v]

--- a/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
+++ b/src/components/NetworkPanel/CyjsRenderer/cyjs-util.ts
@@ -11,6 +11,7 @@ import VisualStyleFn, {
   VisualPropertyName,
   VisualPropertyValueType,
   VisualStyle,
+  NodeShapeType,
 } from '../../../models/VisualStyleModel'
 import { CyjsDirectMapper } from '../../../models/VisualStyleModel/impl/CyjsProperties/CyjsStyleModels/CyjsDirectMapper'
 import { getCyjsVpName } from '../../../models/VisualStyleModel/impl/cyJsVisualPropertyConverter'
@@ -18,6 +19,7 @@ import { SpecialPropertyName } from '../../../models/VisualStyleModel/impl/CyjsP
 import { CyjsVisualPropertyName } from '../../../models/VisualStyleModel/impl/CyjsProperties/CyjsVisualPropertyName'
 import { VisualEditorProperties } from '../../../models/VisualStyleModel/VisualStyleOptions'
 import { computeNodeLabelPosition } from '../../../models/VisualStyleModel/impl/nodeLabelPositionMap'
+import { NodeShapeMapping } from './cyjs-factory'
 
 export const createCyjsDataMapper = (vs: VisualStyle): CyjsDirectMapper[] => {
   const nodeVps = VisualStyleFn.nodeVisualProperties(vs)
@@ -235,6 +237,8 @@ const updateCyObjects = <T extends View>(
             if (obj.data(key) === EdgeArrowShapeType.Arrow) {
               obj.data(key, EdgeArrowShapeType.Triangle)
             }
+          } else if (key === VisualPropertyName.NodeShape) {
+            obj.data(key, NodeShapeMapping[value as NodeShapeType])
           } else {
             obj.data(key, value)
           }

--- a/src/components/ToolBar/FileUpload.tsx
+++ b/src/components/ToolBar/FileUpload.tsx
@@ -73,7 +73,9 @@ export function FileUpload(props: FileUploadProps) {
   const setVisualStyle = useVisualStyleStore((state) => state.add)
 
   const ui = useUiStateStore((state) => state.ui)
-  const setVisualStyleOptions = useUiStateStore((state) => state.setVisualStyleOptions)
+  const setVisualStyleOptions = useUiStateStore(
+    (state) => state.setVisualStyleOptions,
+  )
 
   const setViewModel = useViewModelStore((state) => state.add)
 
@@ -96,16 +98,25 @@ export function FileUpload(props: FileUploadProps) {
       cxData,
     )
 
-    const visualStyle: VisualStyle = VisualStyleFn.createVisualStyleFromCx(cxData)
+    const visualStyle: VisualStyle =
+      VisualStyleFn.createVisualStyleFromCx(cxData)
 
     const networkView: NetworkView = ViewModelFn.createViewModelFromCX(
       LocalNetworkId,
       cxData,
     )
 
-    const visualStyleOptions: VisualStyleOptions = VisualStyleFn.createVisualStyleOptionsFromCx(cxData)
+    const visualStyleOptions: VisualStyleOptions =
+      VisualStyleFn.createVisualStyleOptionsFromCx(cxData)
 
-    return { network, nodeTable, edgeTable, visualStyle, networkView, visualStyleOptions }
+    return {
+      network,
+      nodeTable,
+      edgeTable,
+      visualStyle,
+      networkView,
+      visualStyleOptions,
+    }
   }
 
   const handleCX2File = async (jsonStr: string) => {
@@ -179,7 +190,14 @@ export function FileUpload(props: FileUploadProps) {
         modificationTime: new Date(Date.now()),
       })
       const res = await createDataFromLocalCx2(localUuid, json)
-      const { network, nodeTable, edgeTable, visualStyle, networkView, visualStyleOptions } = res
+      const {
+        network,
+        nodeTable,
+        edgeTable,
+        visualStyle,
+        networkView,
+        visualStyleOptions,
+      } = res
 
       // TODO the db syncing logic in various stores assumes the updated network is the current network
       // therefore, as a temporary fix, the first operation that should be done is to set the
@@ -251,7 +269,7 @@ export function FileUpload(props: FileUploadProps) {
         <MantineProvider>
           <ModalsProvider>
             <Modal
-              onClose={() => props.handleClose}
+              onClose={() => props.handleClose()}
               opened={props.show}
               zIndex={2000}
               centered
@@ -268,7 +286,7 @@ export function FileUpload(props: FileUploadProps) {
                 onReject={(files: any) => {
                   onFileError()
                 }}
-              // maxSize={}
+                // maxSize={}
               >
                 <Group
                   justify="center"

--- a/src/models/VisualStyleModel/VisualPropertyValue/NodeShapeType.ts
+++ b/src/models/VisualStyleModel/VisualPropertyValue/NodeShapeType.ts
@@ -4,7 +4,7 @@ export const NodeShapeType = {
   Ellipse: 'ellipse',
   Hexagon: 'hexagon',
   Octagon: 'octagon',
-  Parallelogram: 'rhomboid',
+  Parallelogram: 'parallelogram',
   RoundRectangle: 'round-rectangle',
   Triangle: 'triangle',
   Vee: 'vee',

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -19,19 +19,6 @@ import {
   VisualStyle,
 } from '..'
 
-const NodeShapeMapping: Record<string, NodeShapeType> = {
-  'rhomboid': NodeShapeType.Parallelogram,
-  'parallelogram': NodeShapeType.Parallelogram,
-  'diamond': NodeShapeType.Diamond,
-  'ellipse': NodeShapeType.Ellipse,
-  'triangle': NodeShapeType.Triangle,
-  'rectangle': NodeShapeType.Rectangle,
-  'round-rectangle': NodeShapeType.RoundRectangle,
-  'octagon': NodeShapeType.Octagon,
-  'hexagon': NodeShapeType.Hexagon,
-  'vee': NodeShapeType.Vee,
-}
-
 type CXLabelPositionValueType = 'center' | 'top' | 'bottom' | 'left' | 'right'
 export interface CXLabelPositionType {
   HORIZONTAL_ALIGN: CXLabelPositionValueType
@@ -252,7 +239,7 @@ export const VPNodeShapeTypeConverter = (
   return {
     cxVPName,
     valueConverter: (cxVPValue: CXVisualPropertyValue): NodeShapeType =>
-      NodeShapeMapping[cxVPValue as string] as NodeShapeType,
+      cxVPValue as NodeShapeType,
   }
 }
 

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -19,6 +19,19 @@ import {
   VisualStyle,
 } from '..'
 
+const NodeShapeMapping: Record<string, NodeShapeType> = {
+  'rhomboid': NodeShapeType.Parallelogram,
+  'parallelogram': NodeShapeType.Parallelogram,
+  'diamond': NodeShapeType.Diamond,
+  'ellipse': NodeShapeType.Ellipse,
+  'triangle': NodeShapeType.Triangle,
+  'rectangle': NodeShapeType.Rectangle,
+  'round-rectangle': NodeShapeType.RoundRectangle,
+  'octagon': NodeShapeType.Octagon,
+  'hexagon': NodeShapeType.Hexagon,
+  'vee': NodeShapeType.Vee,
+}
+
 type CXLabelPositionValueType = 'center' | 'top' | 'bottom' | 'left' | 'right'
 export interface CXLabelPositionType {
   HORIZONTAL_ALIGN: CXLabelPositionValueType
@@ -239,7 +252,7 @@ export const VPNodeShapeTypeConverter = (
   return {
     cxVPName,
     valueConverter: (cxVPValue: CXVisualPropertyValue): NodeShapeType =>
-      cxVPValue as NodeShapeType,
+      NodeShapeMapping[cxVPValue as string] as NodeShapeType,
   }
 }
 


### PR DESCRIPTION
Jira: [CW-302](https://cytoscape.atlassian.net/browse/CW-302)
`Parallelogram` does not in exist _cytoscape.js_. Instead, it only exists `rhomboid` in _cytoscape.js_.  Therefore, I updated the convertor so that both 'parallelogram' and 'rhomboid' in cx2 are mapped to 'rhomboid' and it can be rendered correctly.

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/4c4347d6-cabf-42e4-ac09-dc55f774d7b4">


[CW-302]: https://cytoscape.atlassian.net/browse/CW-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ