### PR TITLE
Updated Bypass Form UI

### DIFF
--- a/src/models/VisualStyleModel/impl/compute-view-util.ts
+++ b/src/models/VisualStyleModel/impl/compute-view-util.ts
@@ -270,8 +270,7 @@ const computeView = (
 
   visualProperties.forEach((vp: VisualProperty<VisualPropertyValueType>) => {
     const { defaultValue, mapping, bypassMap, name, group } = vp
-    const bypassId = group === 'node' ? id : translateEdgeIdToCX(id)
-    const bypass = bypassMap.get(bypassId)
+    const bypass = bypassMap.get(id)
     let pairsToAdd: [string, VisualPropertyValueType][] = []
     if (bypass !== undefined) {
       pairsToAdd = computeNameAndPropertyPairs(vp.name, bypass)


### PR DESCRIPTION
Update Bypass Form UI 
Bugs Solved:
1. **Edge Bypass Form Issue**: Previously, the edge bypass form failed to function because it modified the edge IDs by removing the first 'e' character. This caused a mismatch when the edge view builder attempted to check the edge ID directly with the bypass function. This inconsistency is now resolved by preserving the original edge IDs(removing the unnecessary translation).
2.  **Visual Property View Box**: When there was only one bypass value, the Visual Property View Box was incorrectly displaying a '?' icon instead of explicitly showing the value. The logic for determining when **only one bypass value** is present has now been fixed.

