### PR TITLE
Fix node edge counts

### DIFF
--- a/src/components/ToolBar/FileUpload.tsx
+++ b/src/components/ToolBar/FileUpload.tsx
@@ -159,8 +159,18 @@ export function FileUpload(props: FileUploadProps) {
       })
 
       const localUuid = uuidv4()
-      const localNodeCount = json[1].metaData[2].elementCount
-      const localEdgeCount = json[1].metaData[3].elementCount
+      const res = await createDataFromLocalCx2(localUuid, json)
+      const {
+        network,
+        nodeTable,
+        edgeTable,
+        visualStyle,
+        networkView,
+        visualStyleOptions,
+      } = res
+
+      const localNodeCount = network.nodes.length
+      const localEdgeCount = network.edges.length
       await putNetworkSummaryToDb({
         isNdex: false,
         ownerUUID: localUuid,
@@ -189,16 +199,6 @@ export function FileUpload(props: FileUploadProps) {
         isDeleted: false,
         modificationTime: new Date(Date.now()),
       })
-      const res = await createDataFromLocalCx2(localUuid, json)
-      const {
-        network,
-        nodeTable,
-        edgeTable,
-        visualStyle,
-        networkView,
-        visualStyleOptions,
-      } = res
-
       // TODO the db syncing logic in various stores assumes the updated network is the current network
       // therefore, as a temporary fix, the first operation that should be done is to set the
       // current network to be the new network id

--- a/src/components/Vizmapper/VisualPropertyRender/NodeLabelPosition.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeLabelPosition.tsx
@@ -1,11 +1,16 @@
 import {
   NodeLabelPositionType,
-  VerticalAlignType,
-  HorizontalAlignType,
+  NodeLabelPositionValueType,
 } from '../../../models/VisualStyleModel/VisualPropertyValue'
-import { Box, Button, Typography } from '@mui/material'
+import { Box, Button, MenuItem, Select, Typography } from '@mui/material'
 import { DEFAULT_NODE_LABEL_POSITION } from '../../../models/VisualStyleModel/impl/DefaultVisualStyle'
 import React from 'react'
+import {
+  NodeLabelOrientationType,
+  orientationToPositionMap,
+  translateNodePositionToOrientation,
+} from '../../../models/VisualStyleModel/impl/nodeLabelPositionMap'
+import { MantineProvider, NumberInput } from '@mantine/core'
 
 export function NodeLabelPositionPicker(props: {
   currentValue: NodeLabelPositionType | null
@@ -13,6 +18,13 @@ export function NodeLabelPositionPicker(props: {
   closePopover: (reason: string) => void
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
+
+  const [labelRegion, setLabelRegion] =
+    React.useState<NodeLabelOrientationType>(
+      translateNodePositionToOrientation(
+        currentValue ?? DEFAULT_NODE_LABEL_POSITION,
+      ),
+    )
 
   const [localValue, setLocalValue] = React.useState(
     currentValue ?? DEFAULT_NODE_LABEL_POSITION,
@@ -22,86 +34,91 @@ export function NodeLabelPositionPicker(props: {
     setLocalValue(currentValue ?? DEFAULT_NODE_LABEL_POSITION)
   }, [currentValue])
 
+  const handleRegionChange = (region: NodeLabelOrientationType) => {
+    const position = orientationToPositionMap[region]
+    setLabelRegion(region)
+    const computedPosition = Object.assign({}, position, {
+      MARGIN_X: localValue.MARGIN_X,
+      MARGIN_Y: localValue.MARGIN_Y,
+      JUSTIFICATION: localValue.JUSTIFICATION,
+    })
+
+    console.log(computedPosition)
+
+    setLocalValue(computedPosition)
+  }
+
   return (
-    <Box sx={{ p: 2 }}>
-      <Box>Vertical Align</Box>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-        }}
-      >
-        {Object.values(VerticalAlignType).map(
-          (verticalAlign: VerticalAlignType) => (
-            <Box
-              sx={{
-                color:
-                  localValue?.VERTICAL_ALIGN === verticalAlign
-                    ? 'blue'
-                    : 'black',
-                fontWeight:
-                  localValue?.VERTICAL_ALIGN === verticalAlign
-                    ? 'bold'
-                    : 'normal',
-
-                width: 100,
-                p: 1,
-                '&:hover': { cursor: 'pointer' },
-              }}
-              onClick={() => {
-                setLocalValue(
-                  Object.assign({}, localValue ?? DEFAULT_NODE_LABEL_POSITION, {
-                    VERTICAL_ALIGN: verticalAlign,
-                  }),
-                )
-              }}
-              key={verticalAlign}
-            >
-              {verticalAlign}
-            </Box>
-          ),
-        )}
+    <Box sx={{ p: 1 }}>
+      <Box sx={{ p: 1 }}>
+        <Box sx={{ mb: 1 }}>Orientation</Box>
+        <Select
+          size="small"
+          value={labelRegion}
+          label="Preset label positions"
+          onChange={(e) =>
+            handleRegionChange(e.target.value as NodeLabelOrientationType)
+          }
+        >
+          {Object.values(NodeLabelOrientationType).map((region) => {
+            return (
+              <MenuItem key={region} value={region}>
+                {region}
+              </MenuItem>
+            )
+          })}
+        </Select>
       </Box>
-      <Box>Horizontal Align</Box>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-        }}
-      >
-        {Object.values(HorizontalAlignType).map(
-          (horizontalAlign: HorizontalAlignType) => (
-            <Box
-              sx={{
-                color:
-                  localValue?.HORIZONTAL_ALIGN === horizontalAlign
-                    ? 'blue'
-                    : 'black',
-                fontWeight:
-                  localValue?.HORIZONTAL_ALIGN === horizontalAlign
-                    ? 'bold'
-                    : 'normal',
-
-                width: 100,
-                p: 1,
-                '&:hover': { cursor: 'pointer' },
-              }}
-              onClick={() => {
-                setLocalValue(
-                  Object.assign({}, localValue ?? DEFAULT_NODE_LABEL_POSITION, {
-                    HORIZONTAL_ALIGN: horizontalAlign,
-                  }),
-                )
-              }}
-              key={horizontalAlign}
-            >
-              {horizontalAlign}
-            </Box>
-          ),
-        )}
+      <Box sx={{ p: 1 }}>
+        <Box sx={{ mb: 1 }}>Label Justification</Box>
+        <Select
+          size="small"
+          value={localValue.JUSTIFICATION}
+          label="Text justification"
+          onChange={(e) => {
+            setLocalValue({
+              ...localValue,
+              JUSTIFICATION: e.target.value as NodeLabelPositionValueType,
+            })
+          }}
+        >
+          <MenuItem value="left">Left</MenuItem>
+          <MenuItem value="center">Center</MenuItem>
+          <MenuItem value="right">Right</MenuItem>
+        </Select>{' '}
       </Box>
+
+      <MantineProvider>
+        <Box sx={{ p: 1 }}>
+          <Box sx={{ mb: 1 }}>X offset</Box>
+          <NumberInput
+            allowDecimal={false}
+            value={localValue.MARGIN_X}
+            onChange={(e: number) => {
+              setLocalValue({
+                ...localValue,
+                MARGIN_X: e,
+              })
+            }}
+          />
+        </Box>
+
+        <Box sx={{ p: 1 }}>
+          <Box sx={{ mb: 1 }}>Y offset</Box>
+
+          <NumberInput
+            allowDecimal={false}
+            value={localValue.MARGIN_Y}
+            onChange={(e: number) => {
+              setLocalValue({
+                ...localValue,
+                MARGIN_Y: e,
+              })
+            }}
+          />
+        </Box>
+      </MantineProvider>
+
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
           color="error"

--- a/src/components/Vizmapper/VisualPropertyRender/NodeLabelPosition.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeLabelPosition.tsx
@@ -19,7 +19,7 @@ export function NodeLabelPositionPicker(props: {
 }): React.ReactElement {
   const { onValueChange, currentValue } = props
 
-  const [labelRegion, setLabelRegion] =
+  const [labelOrientation, setlabelOrientation] =
     React.useState<NodeLabelOrientationType>(
       translateNodePositionToOrientation(
         currentValue ?? DEFAULT_NODE_LABEL_POSITION,
@@ -34,16 +34,14 @@ export function NodeLabelPositionPicker(props: {
     setLocalValue(currentValue ?? DEFAULT_NODE_LABEL_POSITION)
   }, [currentValue])
 
-  const handleRegionChange = (region: NodeLabelOrientationType) => {
-    const position = orientationToPositionMap[region]
-    setLabelRegion(region)
+  const handleOrientationChange = (orientation: NodeLabelOrientationType) => {
+    const position = orientationToPositionMap[orientation]
+    setlabelOrientation(orientation)
     const computedPosition = Object.assign({}, position, {
       MARGIN_X: localValue.MARGIN_X,
       MARGIN_Y: localValue.MARGIN_Y,
       JUSTIFICATION: localValue.JUSTIFICATION,
     })
-
-    console.log(computedPosition)
 
     setLocalValue(computedPosition)
   }
@@ -54,16 +52,16 @@ export function NodeLabelPositionPicker(props: {
         <Box sx={{ mb: 1 }}>Orientation</Box>
         <Select
           size="small"
-          value={labelRegion}
+          value={labelOrientation}
           label="Preset label positions"
           onChange={(e) =>
-            handleRegionChange(e.target.value as NodeLabelOrientationType)
+            handleOrientationChange(e.target.value as NodeLabelOrientationType)
           }
         >
-          {Object.values(NodeLabelOrientationType).map((region) => {
+          {Object.values(NodeLabelOrientationType).map((orientation) => {
             return (
-              <MenuItem key={region} value={region}>
-                {region}
+              <MenuItem key={orientation} value={orientation}>
+                {orientation}
               </MenuItem>
             )
           })}

--- a/src/models/VisualStyleModel/impl/nodeLabelPositionMap.ts
+++ b/src/models/VisualStyleModel/impl/nodeLabelPositionMap.ts
@@ -1,6 +1,168 @@
 import _ from 'lodash'
 import { NodeLabelPositionType } from '../VisualPropertyValue'
 
+export const NodeLabelOrientationType = {
+  TopLeft: 'top-left',
+  TopCenter: 'top-center',
+  TopRight: 'top-right',
+  CenterLeft: 'center-left',
+  Center: 'center',
+  CenterRight: 'center-right',
+  BottomLeft: 'bottom-left',
+  BottomCenter: 'bottom-center',
+  BottomRight: 'bottom-right',
+} as const
+export type NodeLabelOrientationType =
+  (typeof NodeLabelOrientationType)[keyof typeof NodeLabelOrientationType]
+
+const orientationToCyJsValueMap: Record<
+  NodeLabelOrientationType,
+  { verticalAlign: string; horizontalAlign: string }
+> = {
+  [NodeLabelOrientationType.TopLeft]: {
+    horizontalAlign: 'left',
+    verticalAlign: 'top',
+  },
+  [NodeLabelOrientationType.TopCenter]: {
+    horizontalAlign: 'center',
+    verticalAlign: 'top',
+  },
+  [NodeLabelOrientationType.TopRight]: {
+    horizontalAlign: 'right',
+    verticalAlign: 'top',
+  },
+  [NodeLabelOrientationType.CenterLeft]: {
+    horizontalAlign: 'left',
+    verticalAlign: 'center',
+  },
+  [NodeLabelOrientationType.Center]: {
+    horizontalAlign: 'center',
+    verticalAlign: 'center',
+  },
+  [NodeLabelOrientationType.CenterRight]: {
+    horizontalAlign: 'right',
+    verticalAlign: 'center',
+  },
+  [NodeLabelOrientationType.BottomLeft]: {
+    horizontalAlign: 'left',
+    verticalAlign: 'bottom',
+  },
+  [NodeLabelOrientationType.BottomCenter]: {
+    horizontalAlign: 'center',
+    verticalAlign: 'bottom',
+  },
+  [NodeLabelOrientationType.BottomRight]: {
+    horizontalAlign: 'right',
+    verticalAlign: 'bottom',
+  },
+}
+
+export const translateNodePositionToOrientation = (
+  position: NodeLabelPositionType,
+): NodeLabelOrientationType => {
+  const computedPosition = computeNodeLabelPosition(position)
+  let orientation: NodeLabelOrientationType = NodeLabelOrientationType.Center
+  Object.entries(orientationToCyJsValueMap).forEach(
+    ([orientationKey, cyjsValue]) => {
+      if (
+        computedPosition.horizontalAlign == cyjsValue.horizontalAlign &&
+        computedPosition.verticalAlign == cyjsValue.verticalAlign
+      ) {
+        orientation = orientationKey as NodeLabelOrientationType
+      }
+    },
+  )
+
+  return orientation
+}
+
+export const orientationToPositionMap: Record<
+  NodeLabelOrientationType,
+  NodeLabelPositionType
+> = {
+  [NodeLabelOrientationType.TopLeft]: {
+    HORIZONTAL_ALIGN: 'right',
+    VERTICAL_ALIGN: 'bottom',
+    HORIZONTAL_ANCHOR: 'left',
+    VERTICAL_ANCHOR: 'top',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.TopCenter]: {
+    HORIZONTAL_ALIGN: 'center',
+    VERTICAL_ALIGN: 'bottom',
+    HORIZONTAL_ANCHOR: 'center',
+    VERTICAL_ANCHOR: 'top',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.TopRight]: {
+    HORIZONTAL_ALIGN: 'left',
+    VERTICAL_ALIGN: 'bottom',
+    HORIZONTAL_ANCHOR: 'right',
+    VERTICAL_ANCHOR: 'top',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.CenterLeft]: {
+    HORIZONTAL_ALIGN: 'right',
+    VERTICAL_ALIGN: 'center',
+    HORIZONTAL_ANCHOR: 'left',
+    VERTICAL_ANCHOR: 'center',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.Center]: {
+    HORIZONTAL_ALIGN: 'center',
+    VERTICAL_ALIGN: 'center',
+    HORIZONTAL_ANCHOR: 'center',
+    VERTICAL_ANCHOR: 'center',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.CenterRight]: {
+    HORIZONTAL_ALIGN: 'left',
+    VERTICAL_ALIGN: 'center',
+    HORIZONTAL_ANCHOR: 'right',
+    VERTICAL_ANCHOR: 'center',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.BottomLeft]: {
+    HORIZONTAL_ALIGN: 'right',
+    VERTICAL_ALIGN: 'top',
+    HORIZONTAL_ANCHOR: 'left',
+    VERTICAL_ANCHOR: 'bottom',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.BottomCenter]: {
+    HORIZONTAL_ALIGN: 'center',
+    VERTICAL_ALIGN: 'top',
+    HORIZONTAL_ANCHOR: 'center',
+    VERTICAL_ANCHOR: 'bottom',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+  [NodeLabelOrientationType.BottomRight]: {
+    HORIZONTAL_ALIGN: 'left',
+    VERTICAL_ALIGN: 'top',
+    HORIZONTAL_ANCHOR: 'right',
+    VERTICAL_ANCHOR: 'bottom',
+    MARGIN_X: 0,
+    MARGIN_Y: 0,
+    JUSTIFICATION: 'center',
+  },
+}
+
 export const nodeLabelPositionMap: any = {
   center: {
     center: {


### PR DESCRIPTION
Derive node and edge counts from the generated network model instead of extracting them from the cx metadata when a network is loaded from a cx file