### PR TITLE
Bypass Form Debug and UI Adjustment 

### DIFF
--- a/src/components/Vizmapper/Forms/BypassForm.tsx
+++ b/src/components/Vizmapper/Forms/BypassForm.tsx
@@ -17,9 +17,15 @@ import {
   Select,
   MenuItem,
   Tooltip,
+  AccordionDetails,
+  Accordion,
+  AccordionSummary,
 } from '@mui/material'
-import InfoIcon from '@mui/icons-material/Info'
-import DeleteIcon from '@mui/icons-material/Delete'
+import {
+  Delete as DeleteIcon,
+  Info as InfoIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@mui/icons-material'
 import * as MapperFactory from '../../../models/VisualStyleModel/impl/MapperFactory'
 import { IdType } from '../../../models/IdType'
 import {
@@ -185,85 +191,6 @@ function BypassFormContent(props: {
 
   const nonEmptyBypassForm = (
     <>
-      <TableContainer sx={{ height: 475, overflow: 'auto' }}>
-        <Table size={'small'} stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                <Select
-                  size="small"
-                  labelId="label"
-                  value={eleNameByCol}
-                  onChange={handleEleNameChange}
-                >
-                  {selectedElementTable.columns.map((col: Column) => {
-                    return <MenuItem value={col.name}>{col.name}</MenuItem>
-                  })}
-                </Select>
-              </TableCell>
-              <TableCell sx={{ minWidth: 180 }}>
-                Bypass/Overwrite
-                <Tooltip
-                  arrow={true}
-                  title="This is to overwrite "
-                  placement="top"
-                >
-                  <IconButton sx={{ padding: 0.5, mb: 0.5 }}>
-                    <InfoIcon />
-                  </IconButton>
-                </Tooltip>
-              </TableCell>
-              <TableCell>Undo</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody sx={{ overflow: 'auto' }}>
-            {elementsToRender.map((ele) => {
-              const { id, selected, hasBypass } = ele
-              const bypassValue = visualProperty.bypassMap?.get(id) ?? null
-              return (
-                <TableRow key={id}>
-                  <TableCell sx={{ maxWidth: 200, overflow: 'auto' }}>
-                    <div>
-                      {selectedElementTable.rows.get(id)?.[eleNameByCol] ?? ''}
-                    </div>
-                  </TableCell>
-
-                  <TableCell>
-                    <VisualPropertyValueForm
-                      visualProperty={visualProperty}
-                      currentValue={bypassValue}
-                      currentNetworkId={currentNetworkId}
-                      onValueChange={(value) => {
-                        setBypass(
-                          currentNetworkId,
-                          visualProperty.name,
-                          [id],
-                          value,
-                        )
-                      }}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <IconButton
-                      onClick={() => {
-                        deleteBypass(currentNetworkId, visualProperty.name, [
-                          id,
-                        ])
-                      }}
-                      disabled={!hasBypass}
-                    >
-                      <DeleteIcon />
-                    </IconButton>
-                  </TableCell>
-                </TableRow>
-              )
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-
-      <Divider />
-
       <Box
         sx={{
           display: 'flex',
@@ -305,6 +232,92 @@ function BypassFormContent(props: {
           </Button>
         </Box>
       </Box>
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography>Advanced Options</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer sx={{ height: '400px', overflow: 'auto' }}>
+            <Table size={'small'} stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>
+                    <Select
+                      size="small"
+                      labelId="label"
+                      value={eleNameByCol}
+                      onChange={handleEleNameChange}
+                    >
+                      {selectedElementTable.columns.map((col: Column) => {
+                        return <MenuItem value={col.name}>{col.name}</MenuItem>
+                      })}
+                    </Select>
+                  </TableCell>
+                  <TableCell sx={{ minWidth: 180 }}>
+                    Bypass/Overwrite
+                    <Tooltip
+                      arrow={true}
+                      title="This is to overwrite "
+                      placement="top"
+                    >
+                      <IconButton sx={{ padding: 0.5, mb: 0.5 }}>
+                        <InfoIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell>Remove</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody sx={{ overflow: 'auto' }}>
+                {elementsToRender.map((ele) => {
+                  const { id, selected, hasBypass } = ele
+                  const bypassValue = visualProperty.bypassMap?.get(id) ?? null
+                  return (
+                    <TableRow key={id}>
+                      <TableCell sx={{ maxWidth: 200, overflow: 'auto' }}>
+                        <div>
+                          {selectedElementTable.rows.get(id)?.[eleNameByCol] ??
+                            ''}
+                        </div>
+                      </TableCell>
+
+                      <TableCell>
+                        <VisualPropertyValueForm
+                          visualProperty={visualProperty}
+                          currentValue={bypassValue}
+                          currentNetworkId={currentNetworkId}
+                          onValueChange={(value) => {
+                            setBypass(
+                              currentNetworkId,
+                              visualProperty.name,
+                              [id],
+                              value,
+                            )
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <IconButton
+                          onClick={() => {
+                            deleteBypass(
+                              currentNetworkId,
+                              visualProperty.name,
+                              [id],
+                            )
+                          }}
+                          disabled={!hasBypass}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
     </>
   )
 

--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -170,7 +170,7 @@ function VisualPropertyView(props: {
             }}
           >
             <IconButton sx={{ padding: 0.5 }}>
-              <InfoIcon />
+              <InfoIcon sx={{ color: 'rgb(0,0,0,0.4)' }} />
             </IconButton>
           </Tooltip>
         )}

--- a/src/models/VisualStyleModel/impl/compute-view-util.ts
+++ b/src/models/VisualStyleModel/impl/compute-view-util.ts
@@ -270,8 +270,7 @@ const computeView = (
 
   visualProperties.forEach((vp: VisualProperty<VisualPropertyValueType>) => {
     const { defaultValue, mapping, bypassMap, name, group } = vp
-    const bypassId = group === 'node' ? id : translateEdgeIdToCX(id)
-    const bypass = bypassMap.get(bypassId)
+    const bypass = bypassMap.get(id)
     let pairsToAdd: [string, VisualPropertyValueType][] = []
     if (bypass !== undefined) {
       pairsToAdd = computeNameAndPropertyPairs(vp.name, bypass)


### PR DESCRIPTION
## Update Bypass Form UI 
The bypass form targets two use cases:
### 1.  The user selects no edges or nodes

It is assumed in this case the user wants to check the which elements have bypass on them.

If there is not one single element has bypass for this visual property, then the following window will show to remind user to select some elements to set bypass

<img width="600" alt="image" src="https://github.com/user-attachments/assets/a72096e8-e5a4-46a7-9671-aca32ac338a0">

If there exists element(s) that have bypass on them, then show it to the user( the detailed table component is **EXPANDED automatically**). The element(s) would also be SELECTED automatically.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/8933c6a7-4cee-44cb-bb68-3e3f621e1f95">

### 2. The user has selected some edges or nodes

It is assumed that in this case the user wants to directly set bypass for ALL the elements he/she has selected. Therefore, the detailed table is **automatically COLLAPSED**). However, if the user wants to set different values for different elements, then he/she has to manually click the dropdown button.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/143d7784-0665-4f37-af6f-0ad10b4409a6">

## More Details about the UI
### Automatically adjust the pop-up window's position
Since the height of the pop-up window changes dramatically when the dropdown component is collapsed or expanded, so a reposition would be operated after each click to the dropdown button to ensure that it would exceed the browser window.

### Added a divider between elements that have and do not have bypasses on them
<img width="400" alt="image" src="https://github.com/user-attachments/assets/719e9d2f-c718-49a0-a9ad-6a3001828455">


## Bugs Solved:
1. **Edge Bypass Form Issue**: Previously, the edge bypass form failed to function because it modified the edge IDs by removing the first 'e' character. This caused a mismatch when the edge view builder attempted to check the edge ID directly with the bypass function. This inconsistency is now resolved by preserving the original edge IDs(removing the unnecessary translation).
2.  **Visual Property View Box**: When there was only one bypass value, the Visual Property View Box was incorrectly displaying a '?' icon instead of explicitly showing the value. The logic for determining when **only one bypass value** is present has now been fixed.

