### PR TITLE
Solved bug of Edge Z-Order

### DIFF
--- a/src/components/Vizmapper/Forms/BypassForm.tsx
+++ b/src/components/Vizmapper/Forms/BypassForm.tsx
@@ -199,6 +199,7 @@ function BypassFormContent(props: {
     elements: Map<string, boolean>,
     hasBypass: boolean,
   ) => {
+    // Sort the elements alphabetically according to the selected column
     const sortedElements = Array.from(elements.keys()).sort((idA, idB) => {
       const nameA: string = getKeybyAttribute(
         selectedElementTable.rows.get(idA)?.[eleNameByCol] ?? '',
@@ -206,7 +207,9 @@ function BypassFormContent(props: {
       const nameB: string = getKeybyAttribute(
         selectedElementTable.rows.get(idB)?.[eleNameByCol] ?? '',
       ).toString()
-      return nameA.localeCompare(nameB) // Sort alphabetically
+      if (nameA === '' && nameB !== '') return 1
+      if (nameB === '' && nameA !== '') return -1
+      return nameA.localeCompare(nameB)
     })
 
     return sortedElements.map((id) => {

--- a/src/models/VisualStyleModel/impl/DefaultVisualStyle.ts
+++ b/src/models/VisualStyleModel/impl/DefaultVisualStyle.ts
@@ -350,7 +350,7 @@ export const getDefaultVisualStyle = (): VisualStyle => ({
   },
   edgeZOrder: {
     group: 'edge',
-    name: 'nodeZOrder',
+    name: 'edgeZOrder',
     displayName: 'Z Order',
     type: 'number',
     defaultValue: 0,


### PR DESCRIPTION
Jira Ticket: [CW-319](https://cytoscape.atlassian.net/browse/CW-319) 

- Corrected the typo in `DefaultVisualStyle`. It should be edgeZOrder instead of nodeZOrder.


Additional change on [Bypass Form UI Adjustment, CW-306](https://github.com/cytoscape/cytoscape-web/pull/265)
In the bypass table, empty strings are sorted to the end (instead of  to the top)after sorting alphabetically, which makes it more user-friendly:
|Before|After|
|-|-|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/c3bf9e0c-880c-4995-b7ff-0b48fa5228c4">|<img width="400" alt="image" src="https://github.com/user-attachments/assets/e924466b-e1f3-492a-b915-bde2312db999">|




[CW-319]: https://cytoscape.atlassian.net/browse/CW-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ