### PR TITLE
Immediately apply the Bypass Value and Table Browser Toolbar Debug

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -689,12 +689,20 @@ export default function TableBrowser(props: {
   const tableBrowserToolbar = (
     <Box sx={{ height: TOOLBAR_HEIGHT, display: 'flex', alignItems: 'center' }}>
       <Tooltip title="Search" placement="top">
-        <Button sx={{ mr: 1 }} onClick={() => setShowSearch(!showSearch)}>
+        <Button
+          sx={{ mr: 1 }}
+          disabled={tables[props.currentNetworkId] === undefined}
+          onClick={() => setShowSearch(!showSearch)}
+        >
           <span className="icon">&#82;</span>
         </Button>
       </Tooltip>
       <Tooltip title="Insert New Column" placement="top">
-        <Button sx={{ mr: 1 }} onClick={() => setShowCreateColumnForm(true)}>
+        <Button
+          sx={{ mr: 1 }}
+          disabled={tables[props.currentNetworkId] === undefined}
+          onClick={() => setShowCreateColumnForm(true)}
+        >
           <span className="icon">&#8209;</span>
         </Button>
       </Tooltip>

--- a/src/components/Vizmapper/Forms/BypassForm.tsx
+++ b/src/components/Vizmapper/Forms/BypassForm.tsx
@@ -294,33 +294,34 @@ function BypassFormContent(props: {
       >
         <Box sx={{ m: 2, display: 'flex', justifyContent: 'space-between' }}>
           <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-            <Typography sx={{ mr: 1, pt: 0.25 }}>Bypass Value:</Typography>
+            <Typography sx={{ mr: 1, pt: 0.25 }}>
+              {`Apply the bypass value to all selected ${isNode ? 'nodes' : 'edges'}:`}
+            </Typography>
             <VisualPropertyValueForm
               visualProperty={visualProperty}
               currentValue={bypassValue}
               currentNetworkId={currentNetworkId}
-              onValueChange={(newBypassValue: VisualPropertyValueType): void =>
+              onValueChange={(
+                newBypassValue: VisualPropertyValueType,
+              ): void => {
                 setBypassValue(newBypassValue)
-              }
+                setBypass(
+                  currentNetworkId,
+                  visualProperty.name,
+                  selectedElements,
+                  newBypassValue,
+                )
+                setElementsWithBypass(() => {
+                  const newMap = new Map()
+                  selectedElements.forEach((id) => {
+                    newMap.set(id, true)
+                  })
+                  return newMap
+                })
+                setElementsWithoutBypass(() => new Map())
+              }}
             />
           </Box>
-
-          <Button
-            sx={{ ml: 1 }}
-            size="small"
-            variant="contained"
-            disabled={!validElementsSelected}
-            onClick={() => {
-              setBypass(
-                currentNetworkId,
-                visualProperty.name,
-                selectedElements,
-                bypassValue,
-              )
-            }}
-          >
-            Apply to Selected
-          </Button>
         </Box>
         <Box sx={{ ml: 2 }}>
           {isSize && <LockSizeCheckbox currentNetworkId={currentNetworkId} />}


### PR DESCRIPTION
### Immediately apply the bypass value 
Immediately apply the bypass value as long as the user inputs the bypass value (get rid of the 'Apply to all selected' button')

<img width="400" alt="image" src="https://github.com/user-attachments/assets/34f20104-d201-4010-929a-2c25a6783c4f">


### Table Browser Toolbar Debug:
If no network is selected, then gray out the icons in table browser toolbar to avoid triggering bugs.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/ac73a6c5-186f-4fdb-b306-d4528fd99afa">
