### PR TITLE
Set max and min for continuous mapping

### DIFF
--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -98,29 +98,34 @@ const toRangeAndDomain = <T extends VisualPropertyValueType>(
 const getMapper = <T extends VisualPropertyValueType>(
   cm: ContinuousMappingFunction,
 ): Mapper => {
-  const { controlPoints, defaultValue } = cm
+  const { min, max, controlPoints, defaultValue } = cm
+  const minValue = min.value as number
+  const maxValue = max.value as number
+  const minVpValue = min.vpValue as T
+  const maxVpValue = max.vpValue as T
   const [domain, range] = toRangeAndDomain<T>(controlPoints)
   const d3Mapper = d3Scale.scaleLinear<T>().domain(domain).range(range)
   const mapper = (attrValue: ValueType): VisualPropertyValueType => {
     if (attrValue !== undefined) {
-      return d3Mapper(attrValue as number)
+      const numericAttrValue = attrValue as number
+      const isLessThanMin =
+        (min.inclusive ?? false)
+          ? numericAttrValue < minValue
+          : numericAttrValue <= minValue
+      const isGreaterThanMax =
+        (max.inclusive ?? false)
+          ? numericAttrValue > maxValue
+          : numericAttrValue >= maxValue
+      if (isGreaterThanMax) {
+        return maxVpValue
+      } else if (isLessThanMin) {
+        return minVpValue
+      } else {
+        return d3Mapper(numericAttrValue)
+      }
     }
     return defaultValue
   }
 
   return mapper
 }
-
-// const getColorMapper = (cm: ContinuousMappingFunction): Mapper => {
-//   const { controlPoints, defaultValue } = cm
-//   const [domain, range] = toRangeAndDomain<ColorType>(controlPoints)
-//   const colorMapper = d3Scale.scaleLinear<string>().domain(domain).range(range)
-//   const mapper = (attrValue: ValueType): VisualPropertyValueType => {
-//     if (attrValue !== undefined) {
-//       return colorMapper(attrValue as number) as ColorType
-//     }
-//     return defaultValue
-//   }
-
-//   return mapper
-// }

--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -98,34 +98,15 @@ const toRangeAndDomain = <T extends VisualPropertyValueType>(
 const getMapper = <T extends VisualPropertyValueType>(
   cm: ContinuousMappingFunction,
 ): Mapper => {
-  const { min, max, controlPoints, defaultValue } = cm
-  const minValue = min.value as number
-  const maxValue = max.value as number
-  const minVpValue = min.vpValue as T
-  const maxVpValue = max.vpValue as T
+  const { controlPoints, defaultValue } = cm
   const [domain, range] = toRangeAndDomain<T>(controlPoints)
   const d3Mapper = d3Scale.scaleLinear<T>().domain(domain).range(range)
+  d3Mapper.clamp(true) //
   const mapper = (attrValue: ValueType): VisualPropertyValueType => {
     if (attrValue !== undefined) {
-      const numericAttrValue = attrValue as number
-      const isLessThanMin =
-        (min.inclusive ?? false)
-          ? numericAttrValue < minValue
-          : numericAttrValue <= minValue
-      const isGreaterThanMax =
-        (max.inclusive ?? false)
-          ? numericAttrValue > maxValue
-          : numericAttrValue >= maxValue
-      if (isGreaterThanMax) {
-        return maxVpValue
-      } else if (isLessThanMin) {
-        return minVpValue
-      } else {
-        return d3Mapper(numericAttrValue)
-      }
+      return d3Mapper(attrValue as number)
     }
     return defaultValue
   }
-
   return mapper
 }

--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -101,7 +101,7 @@ const getMapper = <T extends VisualPropertyValueType>(
   const { controlPoints, defaultValue } = cm
   const [domain, range] = toRangeAndDomain<T>(controlPoints)
   const d3Mapper = d3Scale.scaleLinear<T>().domain(domain).range(range)
-  d3Mapper.clamp(true) //
+  d3Mapper.clamp(true) // make sure the value outside the domain is clamped to the range
   const mapper = (attrValue: ValueType): VisualPropertyValueType => {
     if (attrValue !== undefined) {
       return d3Mapper(attrValue as number)


### PR DESCRIPTION
### Refined the continuous mapping

- In the previous version, the mapping function would blindly do the mapping whether the attribute value is out of the domain or not.
- Now, the refined version would detect the attribute value and if it is out the defined domain, then apply the max/min vp value.