### PR TITLE
Deselect the other element type when the element selection type changes

### DIFF
--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -318,11 +318,11 @@ const CyjsRenderer = ({
             setClickSelection(true)
           }
         } else {
-          const selectedNodes: IdType[] =
+          let selectedNodes: IdType[] =
             networkView?.selectedNodes !== undefined
               ? [...networkView?.selectedNodes]
               : []
-          const selectedEdges: IdType[] =
+          let selectedEdges: IdType[] =
             networkView?.selectedEdges !== undefined
               ? [...networkView?.selectedEdges]
               : []
@@ -343,8 +343,8 @@ const CyjsRenderer = ({
               }
             } else {
               // Exclusive selection
-              selectedNodes.length = 0 // Clear all selections
-              selectedNodes.push(elementId) // Select the current element
+              selectedNodes = [elementId] // Select the current element
+              selectedEdges = [] // Deselect all edges
             }
           } else {
             if (isModifierKey) {
@@ -357,8 +357,8 @@ const CyjsRenderer = ({
               }
             } else {
               // Exclusive selection
-              selectedEdges.length = 0 // Clear all selections
-              selectedEdges.push(elementId) // Select the current element
+              selectedEdges = [elementId] // Select the current element
+              selectedNodes = [] // Deselect all nodes
             }
           }
           exclusiveSelect(id, selectedNodes, selectedEdges)


### PR DESCRIPTION
If the user selects one or some node-type element(s), the user has to select edge-type elements by keeping pressing 'Shift' or 'command'. Otherwise, the nodes would be deselected and the newly clicked edge would be selected. 

And verse vice.