### PR TITLE
UI Tweak

### DIFF
--- a/src/components/LayoutTools/LayoutToolsBasePanel.tsx
+++ b/src/components/LayoutTools/LayoutToolsBasePanel.tsx
@@ -11,6 +11,15 @@ export const LayoutToolsBasePanel = (): JSX.Element => {
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
         aria-controls="manual-layout"
+        sx={{
+          minHeight: '44px', // collapsed summary height
+          '&.Mui-expanded': {
+            minHeight: '44px', // expanded summary height
+          },
+          '.MuiAccordionSummary-content': {
+            margin: 0,
+          },
+        }}
       >
         <Typography>Layout Tools</Typography>
       </AccordionSummary>

--- a/src/components/NetworkPanel/NetworkTabs.tsx
+++ b/src/components/NetworkPanel/NetworkTabs.tsx
@@ -58,12 +58,37 @@ export const NetworkTabs = ({
         flexDirection: 'column',
       }}
     >
-      <Tabs value={selected} onChange={handleChange}>
-        {rendererList.map((renderer: Renderer, index: number) => {
-          return <Tab key={index} label={renderer.name} />
-        })}
-      </Tabs>
-
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          p: 0,
+          m: 0,
+        }}
+      >
+        <Tabs
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            '& button': {
+              height: '2.5em',
+              minHeight: '2.5em',
+            },
+            height: '2.5em',
+            minHeight: '2.5em',
+            flexGrow: 1,
+          }}
+          value={selected}
+          onChange={handleChange}
+        >
+          {rendererList.map((renderer: Renderer, index: number) => {
+            return (
+              <Tab sx={{ height: '40px' }} key={index} label={renderer.name} />
+            )
+          })}
+        </Tabs>
+      </Box>
       <Box ref={boxRef} sx={{ flexGrow: 1, width: '100%' }}>
         {rendererList.map((renderer: Renderer, index: number) => {
           return (

--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -103,10 +103,12 @@ function VisualPropertyView(props: {
           }}
         >
           {disabled ? (
-            <EmptyVisualPropertyViewBox sx={{ mr: 1, cursor: 'not-allowed' }} />
+            <EmptyVisualPropertyViewBox
+              sx={{ ml: 0.5, mr: 2.1, cursor: 'not-allowed' }}
+            />
           ) : (
             <DefaultValueForm
-              sx={{ mr: 1 }}
+              sx={{ ml: 0.5, mr: 2.1 }}
               visualProperty={visualProperty}
               currentNetworkId={currentNetworkId}
             />
@@ -119,7 +121,7 @@ function VisualPropertyView(props: {
                 }
               >
                 <EmptyVisualPropertyViewBox
-                  sx={{ mr: 1, cursor: 'not-allowed' }}
+                  sx={{ mr: 2.1, cursor: 'not-allowed' }}
                 />
               </Tooltip>
               <Tooltip
@@ -130,19 +132,19 @@ function VisualPropertyView(props: {
                 }
               >
                 <EmptyVisualPropertyViewBox
-                  sx={{ mr: 1, cursor: 'not-allowed' }}
+                  sx={{ mr: 2.1, cursor: 'not-allowed' }}
                 />
               </Tooltip>
             </>
           ) : (
             <>
               <MappingForm
-                sx={{ mr: 1 }}
+                sx={{ mr: 2.1 }}
                 currentNetworkId={currentNetworkId}
                 visualProperty={visualProperty}
               />
               <BypassForm
-                sx={{ mr: 1 }}
+                sx={{ mr: 2.1 }}
                 currentNetworkId={currentNetworkId}
                 visualProperty={visualProperty}
               />
@@ -151,7 +153,7 @@ function VisualPropertyView(props: {
 
           <Typography
             variant="body2"
-            sx={{ ml: 1, color: disabled ? 'gray' : 'black' }}
+            sx={{ color: disabled ? 'gray' : 'black' }}
           >
             {visualProperty.displayName}
           </Typography>
@@ -185,6 +187,7 @@ export default function VizmapperView(props: {
 }): React.ReactElement {
   const TAB_ROTATE_DEGREE = 330
   const TAB_TEXT_WIDTH = 34
+  const FONT_SIZE = 10
   const [currentTabIndex, setCurrentTabIndex] = React.useState(0)
   const visualStyles: Record<IdType, VisualStyle> = useVisualStyleStore(
     (state) => state.visualStyles,
@@ -245,12 +248,12 @@ export default function VizmapperView(props: {
           backgroundColor: '#2F80ED',
           '& button.Mui-selected': { color: 'white' },
           '& button': {
-            minHeight: 32,
-            height: 32,
+            minHeight: 34,
+            height: 34,
             width: 30,
           },
-          height: 32,
-          minHeight: 32,
+          height: 34,
+          minHeight: 34,
         }}
         onChange={(e, nextTab) => setCurrentTabIndex(nextTab)}
       >
@@ -258,13 +261,13 @@ export default function VizmapperView(props: {
         <Tab label={<Typography variant="caption">Edges</Typography>} />
         <Tab label={<Typography variant="caption">Network</Typography>} />
       </Tabs>
-      <Box sx={{ display: 'flex', p: 0.5, ml: 1, minHeight: '36px' }}>
+      <Box sx={{ display: 'flex', p: 1.5, ml: 0.5, minHeight: '40px' }}>
         <Box
           sx={{
             width: TAB_TEXT_WIDTH,
             textAlign: 'center',
             mr: 1.5,
-            fontSize: 12,
+            fontSize: FONT_SIZE,
             transform: `rotate(${TAB_ROTATE_DEGREE}deg)`,
           }}
         >
@@ -275,7 +278,7 @@ export default function VizmapperView(props: {
             width: TAB_TEXT_WIDTH,
             textAlign: 'center',
             mr: 1.5,
-            fontSize: 12,
+            fontSize: FONT_SIZE,
             transform: `rotate(${TAB_ROTATE_DEGREE}deg)`,
           }}
         >
@@ -285,7 +288,7 @@ export default function VizmapperView(props: {
           sx={{
             width: TAB_TEXT_WIDTH,
             textAlign: 'center',
-            fontSize: 12,
+            fontSize: FONT_SIZE,
             transform: `rotate(${TAB_ROTATE_DEGREE}deg)`,
           }}
         >

--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -183,6 +183,8 @@ export default function VizmapperView(props: {
   networkId: IdType
   height: number
 }): React.ReactElement {
+  const TAB_ROTATE_DEGREE = 330
+  const TAB_TEXT_WIDTH = 34
   const [currentTabIndex, setCurrentTabIndex] = React.useState(0)
   const visualStyles: Record<IdType, VisualStyle> = useVisualStyleStore(
     (state) => state.visualStyles,
@@ -243,12 +245,12 @@ export default function VizmapperView(props: {
           backgroundColor: '#2F80ED',
           '& button.Mui-selected': { color: 'white' },
           '& button': {
-            minHeight: 30,
-            height: 30,
+            minHeight: 32,
+            height: 32,
             width: 30,
           },
-          height: 38,
-          minHeight: 30,
+          height: 32,
+          minHeight: 32,
         }}
         onChange={(e, nextTab) => setCurrentTabIndex(nextTab)}
       >
@@ -256,14 +258,39 @@ export default function VizmapperView(props: {
         <Tab label={<Typography variant="caption">Edges</Typography>} />
         <Tab label={<Typography variant="caption">Network</Typography>} />
       </Tabs>
-      <Box sx={{ display: 'flex', p: 0.5, ml: 1 }}>
-        <Box sx={{ width: 24, textAlign: 'center', mr: 1.5, fontSize: 12 }}>
-          Def.
+      <Box sx={{ display: 'flex', p: 0.5, ml: 1, minHeight: '36px' }}>
+        <Box
+          sx={{
+            width: TAB_TEXT_WIDTH,
+            textAlign: 'center',
+            mr: 1.5,
+            fontSize: 12,
+            transform: `rotate(${TAB_ROTATE_DEGREE}deg)`,
+          }}
+        >
+          Default
         </Box>
-        <Box sx={{ width: 24, textAlign: 'center', mr: 1.5, fontSize: 12 }}>
-          Map.
+        <Box
+          sx={{
+            width: TAB_TEXT_WIDTH,
+            textAlign: 'center',
+            mr: 1.5,
+            fontSize: 12,
+            transform: `rotate(${TAB_ROTATE_DEGREE}deg)`,
+          }}
+        >
+          Mapping
         </Box>
-        <Box sx={{ width: 24, textAlign: 'center', fontSize: 12 }}>Byp.</Box>
+        <Box
+          sx={{
+            width: TAB_TEXT_WIDTH,
+            textAlign: 'center',
+            fontSize: 12,
+            transform: `rotate(${TAB_ROTATE_DEGREE}deg)`,
+          }}
+        >
+          Bypass
+        </Box>
       </Box>
       <Divider />
       <div hidden={currentTabIndex !== 0}>

--- a/src/components/Workspace/NetworkBrowserPanel/WorkspaceNamePanel.tsx
+++ b/src/components/Workspace/NetworkBrowserPanel/WorkspaceNamePanel.tsx
@@ -41,7 +41,7 @@ export const WorkspaceNamePanel = () => {
     <Box
       sx={{
         width: '100%',
-        height: '3em',
+        height: '42px',
         backgroundColor: background,
         color: textColor,
         p: theme.spacing(1),
@@ -64,7 +64,9 @@ export const WorkspaceNamePanel = () => {
             width: '100%',
           }}
         >
-          <Typography variant="body1">Name:</Typography>
+          <Typography sx={{ ml: 0.5 }} variant="body1">
+            Name:
+          </Typography>
           {isEditing ? (
             <TextField
               value={workspace.name}
@@ -77,7 +79,15 @@ export const WorkspaceNamePanel = () => {
               sx={{
                 p: 0,
                 width: '100%',
-                paddingLeft: '1em',
+                paddingLeft: '0.6em',
+                '& .MuiOutlinedInput-root': {
+                  backgroundColor: background,
+                  color: textColor,
+                  padding: '0 8px', // Inner padding for text
+                },
+                '& .MuiOutlinedInput-input': {
+                  padding: '4px 0', // Adjust padding for a smaller height
+                },
               }}
               inputProps={{
                 style: {

--- a/src/components/Workspace/SidePanel/OpenRightPanelButton.tsx
+++ b/src/components/Workspace/SidePanel/OpenRightPanelButton.tsx
@@ -19,7 +19,7 @@ const buttonStyleOpen = {
 
 const buttonStyleClose = {
   position: 'absolute',
-  top: '15px',
+  top: '8px',
   left: '5px',
   border: '1px solid #999999',
   zIndex: 1000,

--- a/src/components/Workspace/SidePanel/SidePanel.tsx
+++ b/src/components/Workspace/SidePanel/SidePanel.tsx
@@ -29,17 +29,40 @@ export const SidePanel = (): JSX.Element => {
         padding: 0,
       }}
     >
-      <Tabs
-        value={value}
-        onChange={handleChange}
-        variant="scrollable"
-        scrollButtons="auto"
-        sx={{ margin: 0, paddingLeft: '2em' }}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          p: 0,
+          paddingLeft: '2.5em',
+          m: 0,
+        }}
       >
-        {tabContents.map((tabContent, index) => (
-          <Tab key={index} label={tabContent.props.label} />
-        ))}
-      </Tabs>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            '& button': {
+              height: '2.5em',
+              minHeight: '2.5em',
+            },
+            height: '2.5em',
+            minHeight: '2.5em',
+            flexGrow: 1,
+            margin: 0,
+          }}
+        >
+          {tabContents.map((tabContent, index) => (
+            <Tab key={index} label={tabContent.props.label} />
+          ))}
+        </Tabs>
+      </Box>
+
       <Box
         sx={{
           width: '100%',


### PR DESCRIPTION
**1. Reduced the height of` Layout Tools `**
**2. Reduced the height of `Workspace Name`**(aligning with the height of the above` “NODES”, “EDGES” “NETWORK" Tabs`)

|Now | Before|
| -----| ----- |
|<img width="436" alt="image" src="https://github.com/user-attachments/assets/072b7e09-5cf2-4052-80a0-07aa801ccc08">|<img width="436" alt="image" src="https://github.com/user-attachments/assets/810f0c26-00a4-4d6e-892b-ff2f89725e12">|

**3. Reduced height of `“NODES”, “EDGES” “NETWORK" Tabs`** (aligning with the height of the `“NODES”, “EDGES” “NETWORK" Tabs` in Table Browser)
**4. Increased the height of` Def. Map. Byp. bar` and rotated the text**

|Now | Before|
| -----| ----- |
|<img width="436" alt="image" src="https://github.com/user-attachments/assets/595b68c7-b5a6-4f89-a44b-68f34c161dfd">|<img width="436" alt="image" src="https://github.com/user-attachments/assets/36e813eb-669a-42e1-8553-7edefbdbae3b">|

**5. Reduced the height of `“NETWORK VIEW”, “CELL VIEW” and “SUB NETWORK VIEWER” tab`**(aligning with the left side bar)
|||
| -----| ----- |
|Now |<img width="787" alt="image" src="https://github.com/user-attachments/assets/72940cd5-facf-41b4-adf3-d01c5be0e0e0">|
|Before| <img width="787" alt="image" src="https://github.com/user-attachments/assets/6074883a-6e39-405e-9a8e-9889a3fbd426">|
