### PR TITLE
Render customized min/max value

### DIFF
--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -98,15 +98,35 @@ const toRangeAndDomain = <T extends VisualPropertyValueType>(
 const getMapper = <T extends VisualPropertyValueType>(
   cm: ContinuousMappingFunction,
 ): Mapper => {
-  const { controlPoints, defaultValue } = cm
+  const { min, max, controlPoints, defaultValue } = cm
+  const minValue = min.value as number
+  const maxValue = max.value as number
+  const minVpValue = min.vpValue as T
+  const maxVpValue = max.vpValue as T
   const [domain, range] = toRangeAndDomain<T>(controlPoints)
   const d3Mapper = d3Scale.scaleLinear<T>().domain(domain).range(range)
-  d3Mapper.clamp(true) // make sure the value outside the domain is clamped to the range
+  d3Mapper.clamp(true)
   const mapper = (attrValue: ValueType): VisualPropertyValueType => {
     if (attrValue !== undefined) {
-      return d3Mapper(attrValue as number)
+      const numericAttrValue = attrValue as number
+      const isLessThanMin =
+        (min.inclusive ?? false)
+          ? numericAttrValue <= minValue
+          : numericAttrValue < minValue
+      const isGreaterThanMax =
+        (max.inclusive ?? false)
+          ? numericAttrValue >= maxValue
+          : numericAttrValue > maxValue
+      if (isGreaterThanMax) {
+        return maxVpValue
+      } else if (isLessThanMin) {
+        return minVpValue
+      } else {
+        return d3Mapper(numericAttrValue)
+      }
     }
     return defaultValue
   }
+
   return mapper
 }


### PR DESCRIPTION
Now cytoscape-web could read the customized settings for out-of-bound values in continuous mapping.