### PR TITLE
Adjustment on the Postion of Table Browser Icons' Tooltip 

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -503,7 +503,20 @@ export default function TableBrowser(props: {
             bgColor: '#d9d9d9',
           }}
         >
-          <Tooltip title="Sort Ascending" placement="top">
+          <Tooltip
+            title="Sort Ascending"
+            placement="bottom"
+            PopperProps={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -24],
+                  },
+                },
+              ],
+            }}
+          >
             <Button
               sx={{ mr: 1 }}
               onClick={() => {
@@ -522,7 +535,20 @@ export default function TableBrowser(props: {
               <SortAscIcon />
             </Button>
           </Tooltip>
-          <Tooltip title="Sort Descending" placement="top">
+          <Tooltip
+            title="Sort Descending"
+            placement="bottom"
+            PopperProps={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -24],
+                  },
+                },
+              ],
+            }}
+          >
             <Button
               sx={{ mr: 1 }}
               onClick={() => {
@@ -540,7 +566,20 @@ export default function TableBrowser(props: {
               <SortDescIcon />
             </Button>
           </Tooltip>
-          <Tooltip title="Duplicate column" placement="top">
+          <Tooltip
+            title="Duplicate column"
+            placement="bottom"
+            PopperProps={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -24],
+                  },
+                },
+              ],
+            }}
+          >
             <Button
               sx={{ mr: 1 }}
               onClick={() => {
@@ -563,12 +602,38 @@ export default function TableBrowser(props: {
               <DuplicateIcon />
             </Button>
           </Tooltip>
-          <Tooltip title="Rename column" placement="top">
+          <Tooltip
+            title="Rename column"
+            placement="bottom"
+            PopperProps={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -24],
+                  },
+                },
+              ],
+            }}
+          >
             <Button sx={{ mr: 1 }} onClick={() => setShowEditColumnForm(true)}>
               <EditIcon />
             </Button>
           </Tooltip>
-          <Tooltip title="Delete column" placement="top">
+          <Tooltip
+            title="Delete column"
+            placement="bottom"
+            PopperProps={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, -24],
+                  },
+                },
+              ],
+            }}
+          >
             <Button
               color="error"
               onClick={() => {
@@ -729,7 +794,20 @@ export default function TableBrowser(props: {
 
   const tableBrowserToolbar = (
     <Box sx={{ height: TOOLBAR_HEIGHT, display: 'flex', alignItems: 'center' }}>
-      <Tooltip title="Search" placement="top">
+      <Tooltip
+        title="Search"
+        placement="bottom"
+        PopperProps={{
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [0, -24],
+              },
+            },
+          ],
+        }}
+      >
         <Button
           sx={{ mr: 1 }}
           disabled={tables[props.currentNetworkId] === undefined}
@@ -738,7 +816,20 @@ export default function TableBrowser(props: {
           <span className="icon">&#82;</span>
         </Button>
       </Tooltip>
-      <Tooltip title="Insert New Column" placement="top">
+      <Tooltip
+        title="Insert New Column"
+        placement="bottom"
+        PopperProps={{
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [0, -24],
+              },
+            },
+          ],
+        }}
+      >
         <Button
           sx={{ mr: 1 }}
           disabled={tables[props.currentNetworkId] === undefined}
@@ -747,7 +838,20 @@ export default function TableBrowser(props: {
           <span className="icon">&#8209;</span>
         </Button>
       </Tooltip>
-      <Tooltip title="Import Table from File ..." placement="top">
+      <Tooltip
+        title="Import Table from File ..."
+        placement="bottom"
+        PopperProps={{
+          modifiers: [
+            {
+              name: 'offset',
+              options: {
+                offset: [0, -24],
+              },
+            },
+          ],
+        }}
+      >
         <Button
           disabled={tables[props.currentNetworkId] === undefined}
           sx={{ mr: 1 }}

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/ExportNetworkToImageMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/ExportNetworkToImageMenuItem.tsx
@@ -61,7 +61,7 @@ export const ExportImage = (props: ExportImageProps): ReactElement => {
       }}
       PaperProps={{
         sx: {
-          minHeight: 300,
+          height: 'auto',
         },
       }}
       fullWidth
@@ -97,8 +97,8 @@ export const ExportImage = (props: ExportImageProps): ReactElement => {
             }}
             InputLabelProps={{
               shrink: true,
-            }}>
-          </TextField>
+            }}
+          ></TextField>
         </Box>
         {currentExportForm}
       </DialogContent>

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm.tsx
@@ -78,10 +78,15 @@ export const PdfExportForm = (props: ExportImageFormatProps): ReactElement => {
   )
 
   return (
-    <Box sx={{
-      mt: 1, height: 500, display: 'flex',
-      flexDirection: 'column', justifyContent: 'space-between',
-    }}>
+    <Box
+      sx={{
+        mt: 1,
+        height: 425,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+      }}
+    >
       <Box>
         <Box sx={{ mb: 1 }}>
           <FormControlLabel

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/PngExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/PngExportForm.tsx
@@ -248,10 +248,15 @@ export const PngExportForm = (props: ExportImageFormatProps): ReactElement => {
     setZoom(newZoom)
   }
   return (
-    <Box sx={{
-      mt: 1, height: 500, display: 'flex',
-      flexDirection: 'column', justifyContent: 'space-between',
-    }}>
+    <Box
+      sx={{
+        mt: 1,
+        height: 425,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+      }}
+    >
       <Box>
         <Box sx={{ mb: 0.25 }}>
           <FormControlLabel
@@ -275,7 +280,7 @@ export const PngExportForm = (props: ExportImageFormatProps): ReactElement => {
             label="Transparent background"
           />
         </Box>
-        <Box sx={{ mb: 1 }} >
+        <Box sx={{ mb: 1 }}>
           <Typography variant="subtitle1" style={{ margin: '0 0 5px 0' }}>
             File Type
           </Typography>

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
@@ -37,10 +37,15 @@ export const SvgExportForm = (props: ExportImageFormatProps): ReactElement => {
   )
 
   return (
-    <Box sx={{
-      mt: 1, height: 500, display: 'flex',
-      flexDirection: 'column', justifyContent: 'space-between',
-    }}>
+    <Box
+      sx={{
+        mt: 1,
+        height: 425,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+      }}
+    >
       <Box>
         <Box>
           <FormControlLabel


### PR DESCRIPTION
Jira: [CW-341](https://cytoscape.atlassian.net/browse/CW-341)
The previous version would prevent users from clicking the tab. The adjustment makes it smoother to switch from icons to tabs or other buttons.
|||
|-----|-----|
|Now|<img width="793" alt="image" src="https://github.com/user-attachments/assets/14edbaa4-6d41-48cc-aa1d-e97fd66aa55e">|
|Before|<img width="793" alt="image" src="https://github.com/user-attachments/assets/45292708-57a4-403d-8c9b-6970e6f0da67">|

[CW-341]: https://cytoscape.atlassian.net/browse/CW-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ