### PR TITLE
removed 2.0 from title of app. Fix for CW-368

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Cytoscape Web 2.0</title>
+    <title>Cytoscape Web</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Dropped `2.0` from App title. 