### PR TITLE
CP renderer will be deleted in the manager instead of the panel

### DIFF
--- a/src/features/HierarchyViewer/components/MainPanel.tsx
+++ b/src/features/HierarchyViewer/components/MainPanel.tsx
@@ -7,11 +7,7 @@ import { IdType } from '../../../models/IdType'
 import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore'
 import { HcxMetaData } from '../model/HcxMetaData'
-import { getHcxProps } from '../utils/hierarchy-util'
-import {
-  NdexNetworkProperty,
-  NdexNetworkSummary,
-} from '../../../models/NetworkSummaryModel'
+import { getHcxMetadata } from '../utils/hierarchy-util'
 import { ValueType } from '../../../models/TableModel'
 import { NetworkView } from '../../../models/ViewModel'
 import { useTableStore } from '../../../store/TableStore'
@@ -28,7 +24,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import FilterPanel from './FilterPanel/FilterPanel'
 import { DuplicateNodeSeparator } from './CustomLayout/DataBuilderUtil'
 import { useSubNetworkStore } from '../store/SubNetworkStore'
-import { set } from 'lodash'
 
 export const RENDERER_TAG: string = 'secondary'
 export interface Query {
@@ -71,7 +66,6 @@ export const MainPanel = (): JSX.Element => {
     (state) => state.summaries[currentNetworkId],
   )
   const addRenderer = useRendererStore((state) => state.add)
-  const deleteRenderer = useRendererStore((state) => state.delete)
   const renderers = useRendererStore((state) => state.renderers)
 
   const setRootNetworkId = useSubNetworkStore((state) => state.setRootNetworkId)
@@ -98,38 +92,18 @@ export const MainPanel = (): JSX.Element => {
   }
 
   const checkDataType = (): void => {
-    // Check if the current network is a hierarchy
-    if (networkSummary === undefined) {
-      return
-    }
-    const summary: NdexNetworkSummary = networkSummary
-    const networkProps: NdexNetworkProperty[] = summary.properties
-    if (networkProps === undefined || networkProps.length === 0) {
-      setIsHierarchy(false)
-      setMetadata(undefined)
-      return
-    }
-
-    const networkPropObj: Record<string, ValueType> = networkProps.reduce<{
-      [key: string]: ValueType
-    }>((acc, prop) => {
-      acc[prop.predicateString] = prop.value
-      return acc
-    }, {})
-    const metadata: HcxMetaData | undefined = getHcxProps(networkPropObj)
+    const metadata: HcxMetaData | undefined = getHcxMetadata(networkSummary)
 
     if (metadata !== undefined) {
       setIsHierarchy(true)
       setMetadata(metadata)
+      // Add the CP renderer if it does not exist
       if (renderers.circlePacking === undefined) {
         addRenderer(CirclePackingRenderer)
       }
     } else {
       setIsHierarchy(false)
       setMetadata(undefined)
-      if (renderers.circlePacking !== undefined) {
-        deleteRenderer(renderers.circlePacking.id)
-      }
     }
   }
 

--- a/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
+++ b/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
@@ -20,6 +20,7 @@ import {
   deleteVisualStyleFromDb,
   getAllNetworkKeys,
 } from '../../../store/persist/db'
+import { useRendererStore } from '../../../store/RendererStore'
 
 /**
  *  Switch the panel state based on the network meta data
@@ -39,6 +40,9 @@ export const useHierarchyViewerManager = (): void => {
   const activeNetworkView = useUiStateStore(
     (state) => state.ui.activeNetworkView,
   )
+
+  const deleteRenderer = useRendererStore((state) => state.delete)
+  const renderers = useRendererStore((state) => state.renderers)
 
   useEffect(() => {
     const deleteChildren = async (parentId: IdType): Promise<void> => {
@@ -117,6 +121,10 @@ export const useHierarchyViewerManager = (): void => {
       enablePopup(true)
     } else {
       enablePopup(false)
+      // Delete the CP renderer if it exists
+      if (renderers.circlePacking !== undefined) {
+        deleteRenderer(renderers.circlePacking.id)
+      }
     }
   }, [summary])
 

--- a/src/features/HierarchyViewer/utils/hierarchy-util.ts
+++ b/src/features/HierarchyViewer/utils/hierarchy-util.ts
@@ -1,6 +1,9 @@
 import { HierarchyNode } from 'd3-hierarchy'
 import { Visibility } from '../../../models/CxModel/NetworkSummary/Visibility'
-import { NdexNetworkSummary } from '../../../models/NetworkSummaryModel'
+import {
+  NdexNetworkProperty,
+  NdexNetworkSummary,
+} from '../../../models/NetworkSummaryModel'
 import { Table, ValueType } from '../../../models/TableModel'
 import { D3TreeNode } from '../components/CustomLayout/D3TreeNode'
 import { HcxMetaData } from '../model/HcxMetaData'
@@ -202,4 +205,39 @@ export const applyCpLayout = (
   })
 
   return positionMap
+}
+
+/**
+ * Check if the current network is a hierarchy or not
+ * based on the network summary
+ *
+ * @param summary - network summary
+ *
+ * @returns HCX metadata if the network is a hierarchy, otherwise undefined
+ *
+ */
+export const getHcxMetadata = (
+  summary: NdexNetworkSummary,
+): HcxMetaData | undefined => {
+  if (summary === undefined) {
+    return undefined
+  }
+  const networkProps: NdexNetworkProperty[] = summary.properties
+  if (networkProps === undefined || networkProps.length === 0) {
+    return undefined
+  }
+
+  const networkPropObj: Record<string, ValueType> = networkProps.reduce<{
+    [key: string]: ValueType
+  }>((acc, prop) => {
+    acc[prop.predicateString] = prop.value
+    return acc
+  }, {})
+  const metadata: HcxMetaData | undefined = getHcxProps(networkPropObj)
+
+  if (metadata !== undefined) {
+    return metadata
+  } else {
+    return undefined
+  }
 }


### PR DESCRIPTION
This fixes the problem of showing unnecessary CP view panel tab. The renderer will be removed in the manager, so even if the panel is closed it hides the CP tab correctly.