### PR TITLE
Wrapped Input Column parameter with tooltip. Fix for CW-381

### DIFF
--- a/src/components/ToolBar/AppMenu/menu-factory.tsx
+++ b/src/components/ToolBar/AppMenu/menu-factory.tsx
@@ -88,6 +88,7 @@ export const InputColumns = (props: AppMenuItemProps) => {
     const columnsToDisplay = isNodeType ? nodeColumns : edgeColumns
 
     return (
+      <Tooltip title={inputColumn.description ?? ''}>
       <Box
         sx={{
           display: 'flex',
@@ -118,6 +119,7 @@ export const InputColumns = (props: AppMenuItemProps) => {
           })}
         </Select>
       </Box>
+      </Tooltip>
     )
   })
 }


### PR DESCRIPTION
This adds a tooltip when a user hovers over an input column dropdown for service based apps