### PR TITLE
Fix full option in the export svg form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cytoscape-web",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscape-web",
-      "version": "1.0.0",
+      "version": "1.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@antv/g6": "^4.8.22",

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -602,12 +602,12 @@ const CyjsRenderer = ({
         }
       }
 
-      const exportSvgFunction = (): Blob => {
+      const exportSvgFunction = (fullBg: boolean): Blob => {
         if (cy !== null) {
           // @ts-expect-error-next-line
           const result = cy.svg({
             scale: 1,
-            full: true,
+            full: fullBg,
             background: 'white',
           })
 

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
@@ -67,7 +67,7 @@ export const SvgExportForm = (props: ExportImageFormatProps): ReactElement => {
           disabled={loading}
           onClick={async () => {
             setLoading(true)
-            const result = await svgFunction?.()
+            const result = await svgFunction?.(fullBg)
             const blob = new Blob([result], { type: 'image/svg+xml' })
             saveAs(blob, `${props.fileName}.svg`)
             setLoading(false)


### PR DESCRIPTION
Fixes an issue where clicking the export full network as image checkbox would not work.