### PR TITLE
Resolved isModified flag Bug

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -130,15 +130,6 @@ export default function TableBrowser(props: {
     useUiStateStore((state) => state.setPanelState)
   const { panels } = ui
   const setUi = useUiStateStore((state) => state.setUi)
-  const networkModified = useWorkspaceStore(
-    (state) => state.workspace.networkModified,
-  )
-  const networkModifiedRef = useRef(networkModified)
-
-  // Update the ref when networkModified changes
-  useEffect(() => {
-    networkModifiedRef.current = networkModified
-  }, [networkModified])
 
   const setCurrentTabIndex = (index: number): void => {
     const nextTableUi = { ...ui.tableUi, activeTabIndex: index }
@@ -215,6 +206,7 @@ export default function TableBrowser(props: {
   )
   const moveColumn = useTableStore((state) => state.moveColumn)
 
+  const workspace = useWorkspaceStore((state) => state.workspace)
   const setNetworkModified: (id: IdType, isModified: boolean) => void =
     useWorkspaceStore((state) => state.setNetworkModified)
 
@@ -231,10 +223,11 @@ export default function TableBrowser(props: {
         !_.isEqual(prev.nodeTable, next.nodeTable) ||
         !_.isEqual(prev.edgeTable, next.edgeTable)
 
+      const { networkModified } = workspace
+
       const currentNetworkIsNotModified =
-        (networkModifiedRef.current[networkId] === undefined &&
-          !(networkModifiedRef.current[networkId] ?? false)) ??
-        false
+        networkModified[networkId] === undefined ||
+        networkModified[networkId] === false
 
       // If table data changed and the network is not already marked as modified, set it to modified
       if (tableDataChanged && currentNetworkIsNotModified) {

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -160,6 +160,9 @@ const WorkSpaceEditor = (): JSX.Element => {
       if (prev === undefined || next === undefined) {
         return
       }
+
+      // primitive compare fn that does not take into account the selection/hover state
+      // this leads to the network having a 'modified' state even though nothing was modified
       const viewModelChanged =
         prev !== undefined &&
         next !== undefined &&
@@ -169,13 +172,11 @@ const WorkSpaceEditor = (): JSX.Element => {
           _.omit(next, ['selectedNodes', 'selectedEdges']),
         )
 
-      // primitive compare fn that does not take into account the selection/hover state
-      // this leads to the network having a 'modified' state even though nothing was modified
       const { networkModified } = workspace
+
       const currentNetworkIsNotModified =
-        (networkModified[currentNetworkId] === undefined &&
-          !(networkModified[currentNetworkId] ?? false)) ??
-        false
+        networkModified[currentNetworkId] === undefined ||
+        networkModified[currentNetworkId] === false
 
       if (viewModelChanged && currentNetworkIsNotModified) {
         setNetworkModified(currentNetworkId, true)


### PR DESCRIPTION
Jira Ticket:  [CW-383](https://cytoscape.atlassian.net/browse/CW-383)

It seems that previously the indicator, `currentNetworkIsNotModified`, is not determinated correctly. Now I changed it to only check whether the flag `isModified` of the current network is `undefined` or `false`:
- `undefined`: never touched by the code, the network has never been updated since it was loaded to website
- `false`: the network has been changed, but it was successfully saved to NDEx and the flag of `isModified` is set to false again by the menu item: Save the Current Network to NDEx

[CW-383]: https://cytoscape.atlassian.net/browse/CW-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ