### PR TITLE
Fix table browser selection

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -130,6 +130,8 @@ export default function TableBrowser(props: {
     useUiStateStore((state) => state.setPanelState)
   const { panels } = ui
   const setUi = useUiStateStore((state) => state.setUi)
+  const currentTabIndex = ui.tableUi.activeTabIndex
+
   const networkModified = useWorkspaceStore(
     (state) => state.workspace.networkModified,
   )
@@ -166,19 +168,20 @@ export default function TableBrowser(props: {
     string | undefined
   >(undefined)
 
-  // use the built-in state to manage the selection sothat the state is synced with the data editor
-  const [selection, setSelection] = React.useState<GridSelection>({
+  const [nodeSelection, setNodeSelection] = React.useState<GridSelection>({
     columns: CompactSelection.empty(),
     rows: CompactSelection.empty(),
   })
 
-  // Reset selection after switching table tabs
-  useEffect(() => {
-    setSelection({
-      columns: CompactSelection.empty(),
-      rows: CompactSelection.empty(),
-    })
-  }, [ui.tableUi.activeTabIndex])
+  const [edgeSelection, setEdgeSelection] = React.useState<GridSelection>({
+    columns: CompactSelection.empty(),
+    rows: CompactSelection.empty(),
+  })
+
+  const selection = currentTabIndex === 0 ? nodeSelection : edgeSelection
+  const setSelection =
+    currentTabIndex === 0 ? setNodeSelection : setEdgeSelection
+
   const [selectedCellColumn, setSelectedCellColumn] = React.useState<
     number | null
   >(null)
@@ -250,8 +253,6 @@ export default function TableBrowser(props: {
       }
     },
   )
-
-  const currentTabIndex = ui.tableUi.activeTabIndex
 
   const nodeTable = tables[networkId]?.nodeTable
   const edgeTable = tables[networkId]?.edgeTable

--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -974,7 +974,9 @@ export default function TableBrowser(props: {
           ref={nodeDataEditorRef}
           onCellClicked={onCellClicked}
           onCellContextMenu={onCellContextMenu}
+          rowSelect={'multi'}
           rowMarkers={'checkbox'}
+          rowMarkerWidth={1}
           rowMarkerStartIndex={minNodeId}
           showSearch={showSearch}
           keybindings={{ search: true }}
@@ -1003,7 +1005,9 @@ export default function TableBrowser(props: {
           ref={edgeDataEditorRef}
           onCellClicked={onCellClicked}
           onCellContextMenu={onCellContextMenu}
+          rowSelect={'multi'}
           rowMarkers={'checkbox'}
+          rowMarkerWidth={1}
           rowMarkerStartIndex={minEdgeId}
           showSearch={showSearch}
           keybindings={{ search: true }}

--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -490,7 +490,10 @@ export default function TableBrowser(props: {
         const end = Math.max(selection.rows.last() ?? 0, rowIndex)
         setSelection({
           ...selection,
-          rows: CompactSelection.fromSingleSelection(start).add([start, end]),
+          rows: CompactSelection.fromSingleSelection(start).add([
+            start,
+            end + 1,
+          ]),
         })
       } else if (event.ctrlKey || event.metaKey) {
         // Handle ctrl/cmd-click for toggle selection
@@ -504,8 +507,18 @@ export default function TableBrowser(props: {
       } else {
         // Handle single row selection
         setSelection({
-          ...selection,
-          rows: CompactSelection.fromSingleSelection(rowIndex),
+          rows: CompactSelection.fromSingleSelection(cell[1]),
+          columns: CompactSelection.empty(),
+          current: {
+            cell,
+            range: {
+              x: cell[0],
+              y: cell[1],
+              width: 1,
+              height: 1,
+            },
+            rangeStack: [],
+          },
         })
       }
 
@@ -1011,6 +1024,7 @@ export default function TableBrowser(props: {
       <TabPanel value={currentTabIndex} index={0}>
         {tableBrowserToolbar}
         <DataEditor
+          // rowSelectionBlending="mixed"
           ref={nodeDataEditorRef}
           onCellClicked={onCellClicked}
           rowSelect={'multi'}
@@ -1040,6 +1054,7 @@ export default function TableBrowser(props: {
       <TabPanel value={currentTabIndex} index={1}>
         {tableBrowserToolbar}
         <DataEditor
+          // rowSelectionBlending="mixed"
           ref={edgeDataEditorRef}
           onCellClicked={onCellClicked}
           rowSelect={'multi'}


### PR DESCRIPTION
- Fix issue where multiple rows couldnt be selected with the modifier key pressed.
- Fixed issue where selected row states would persist after performing the select nodes from selected rows operation.
- Fixed issue where selected row states would persist after changing between the node/edge table or loading a different network.
- Fixed issue where selecting edges from selected rows would continue to select nodes instead.
- Removed checkboxes as they didn't function properly and conflicted with the cell click event.