### PR TITLE
Fix issue where certain strings would be rendered as clickable URLs

### DIFF
--- a/src/utils/is-url.ts
+++ b/src/utils/is-url.ts
@@ -1,8 +1,6 @@
 export function isValidUrl(input: string): boolean {
-  try {
-    const url = new URL(input)
-    return url != null
-  } catch (e) {
-    return false
-  }
+  const urlPattern =
+    /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[a-zA-Z0-9-._~:\/?#[\]@!$&'()*+,;=]*)?$/
+
+  return urlPattern.test(input)
 }


### PR DESCRIPTION
- Update the isValidUrl function with a regex that filters for values like `test.com` `http://test.com` `https://test.com` `www.test.com`, while rejecting values like `protein`, `hgnc.symbol:TLR10, hgnc.symbol:TLR8, hgnc.symbol:TLR7, hgnc.symbol:TLR6, hgnc.symbol:TLR1, hgnc.symbol:TLR9, hgnc.symbol:TLR2, hgnc.symbol:TLR5, hgnc.symbol:TLR4, hgnc.symbol:TLR3`, `signor:SIGNOR-C124`.

To test, edit any table browser cell in any network and paste these values in.  Only the first set of values should be displayed as a clickable URL.  The other values should be rendered regular strings.