### PR TITLE
Resolved Focus-related Bugs in Merge Dialog

### DIFF
--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -540,6 +540,12 @@ const MergeDialog: React.FC<MergeDialogProps> = ({
 
   return (
     <Dialog
+      onKeyDown={(e) => {
+        e.stopPropagation()
+      }}
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
       fullScreen={fullScreen}
       maxWidth="md"
       fullWidth={true}
@@ -620,7 +626,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({
             </FormLabel>
             <RadioGroup
               aria-label="node removal policy"
-              value={strictRemoveMode}
+              value={strictRemoveMode.toString()}
               onChange={handleStrictRemoveModeChange}
               name="node-removal-options"
               style={{ marginLeft: '20px' }}
@@ -845,7 +851,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({
                 control={
                   <Checkbox
                     checked={mergeWithinNetwork}
-                    onChange={() => setMergeWithinNetwork(!mergeWithinNetwork)}
+                    onChange={(e) => setMergeWithinNetwork(e.target.checked)}
                     name="mergeWithinNetwork"
                     color="primary"
                   />
@@ -861,7 +867,7 @@ const MergeDialog: React.FC<MergeDialogProps> = ({
                   control={
                     <Checkbox
                       checked={mergeOnlyNodes}
-                      onChange={() => setMergeOnlyNodes(!mergeOnlyNodes)}
+                      onChange={(e) => setMergeOnlyNodes(e.target.checked)}
                       name="mergeOnlyNodes"
                       color="primary"
                       disabled={MergeType.intersection !== mergeOpType}

--- a/src/features/MergeNetworks/models/Impl/DifferenceMerge.ts
+++ b/src/features/MergeNetworks/models/Impl/DifferenceMerge.ts
@@ -99,7 +99,7 @@ export function differenceMerge(fromNetworks: IdType[], toNetworkId: IdType, net
         }    
     })
 
-    if (strictRemoveMode) { // subtract the node as long as it exists in the seco
+    if (strictRemoveMode) { // subtract the node as long as it exists in the second network
         for(const nodeId of unmatchedNodes){
             NetworkFn.addNode(mergedNetwork, nodeId);
         }


### PR DESCRIPTION
This resolution can solve these two bugs: [CW-393](https://cytoscape.atlassian.net/browse/CW-393) and [CW-394](https://cytoscape.atlassian.net/browse/CW-394).

It turns out the checkbox, ratio buttons and text input cannot behave properly because of a focus-related bug(When showing the dialog, the focus should be on the dialog instead of other components). This can be resolved by adding `stopPropagation` to the dialog component:
```
onKeyDown={(e) => {
  e.stopPropagation()
}}
onClick={(e) => {
  e.stopPropagation()
}}
```

[CW-393]: https://cytoscape.atlassian.net/browse/CW-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CW-394]: https://cytoscape.atlassian.net/browse/CW-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ