### PR TITLE
Unified Cancel Confirm Color

### DIFF
--- a/src/components/EmailVerification.tsx
+++ b/src/components/EmailVerification.tsx
@@ -54,10 +54,19 @@ export const EmailVerificationModal: React.FC<EmailVerificationModalProps> = ({
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onVerify} color="primary">
+        <Button
+          onClick={onVerify}
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
+        >
           Already Verified
         </Button>
-        <Button onClick={onCancel} color="error">
+        <Button onClick={onCancel} color="primary">
           Log Out
         </Button>
       </DialogActions>

--- a/src/components/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/components/SummaryPanel/NetworkPropertyPanel.tsx
@@ -64,9 +64,7 @@ export const NetworkPropertyPanel = ({
   const networkModified =
     useWorkspaceStore((state) => state.workspace.networkModified[id]) ?? false
 
-  const deleteNetwork = useWorkspaceStore(
-    (state) => state.deleteNetwork,
-  )
+  const deleteNetwork = useWorkspaceStore((state) => state.deleteNetwork)
 
   const onClickDelete = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
@@ -76,15 +74,15 @@ export const NetworkPropertyPanel = ({
   }
 
   const onConfirmDelete = () => {
-    deleteNetwork(id);
+    deleteNetwork(id)
     if (lastOpenedNetworkId && lastOpenedNetworkId !== id) {
-      setCurrentNetworkId(lastOpenedNetworkId);
+      setCurrentNetworkId(lastOpenedNetworkId)
     }
   }
 
   const onCancelDelete = () => {
     if (lastOpenedNetworkId && lastOpenedNetworkId !== id) {
-      setCurrentNetworkId(lastOpenedNetworkId);
+      setCurrentNetworkId(lastOpenedNetworkId)
     }
   }
 
@@ -122,7 +120,13 @@ export const NetworkPropertyPanel = ({
             }}
           >
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <Tooltip title={summary.isNdex ? 'A network stored in the NDEx database (ndexbio.org)' : 'A network stored on your local machine'}>
+              <Tooltip
+                title={
+                  summary.isNdex
+                    ? 'A network stored in the NDEx database (ndexbio.org)'
+                    : 'A network stored on your local machine'
+                }
+              >
                 <Chip
                   color={summary.isNdex ? 'primary' : 'success'}
                   size="small"
@@ -149,8 +153,9 @@ export const NetworkPropertyPanel = ({
               variant={'subtitle2'}
               sx={{ width: '100%', color: theme.palette.text.secondary }}
             >
-              {`N: ${nodeCount} (${networkViewModel?.selectedNodes.length ?? 0
-                }) /
+              {`N: ${nodeCount} (${
+                networkViewModel?.selectedNodes.length ?? 0
+              }) /
           E: ${edgeCount} (${networkViewModel?.selectedEdges.length ?? 0})`}
             </Typography>
 
@@ -171,7 +176,9 @@ export const NetworkPropertyPanel = ({
               <IconButton
                 size="small"
                 sx={{ width: 25, height: 25 }}
-                onClick={(e) => { onClickDelete(e) }}
+                onClick={(e) => {
+                  onClickDelete(e)
+                }}
               >
                 <DeleteIcon sx={{ fontSize: 18 }} />
               </IconButton>
@@ -191,8 +198,9 @@ export const NetworkPropertyPanel = ({
           open={openConfirmation}
           setOpen={setOpenConfirmation}
           buttonTitle="Yes (cannot be undone)"
+          isAlert={true}
         />
-      </Box >
+      </Box>
     </>
   )
 }

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -133,12 +133,23 @@ export function EditTableColumnForm(props: TableFormProps): React.ReactElement {
         ) : null}
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => props.onSubmit(value, mappingSyncSetting)}>
-          Confirm
-        </Button>
-
-        <Button color="error" onClick={props.onClose}>
+        <Button color="primary" onClick={props.onClose}>
           Cancel
+        </Button>
+        <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+          onClick={() => props.onSubmit(value, mappingSyncSetting)}
+        >
+          Confirm
         </Button>
       </DialogActions>
     </Dialog>
@@ -210,11 +221,24 @@ export function DeleteTableColumnForm(
         ) : null}
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => props.onSubmit(mappingSyncSetting)}>
-          Confirm
-        </Button>
-        <Button color="error" onClick={props.onClose}>
+        <Button color="primary" onClick={props.onClose}>
           Cancel
+        </Button>
+        <Button
+          sx={{
+            color: '#F50157',
+            backgroundColor: 'transparent',
+            '&:hover': {
+              color: '#FFFFFF',
+              backgroundColor: '#fc266f',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+          onClick={() => props.onSubmit(mappingSyncSetting)}
+        >
+          Confirm
         </Button>
       </DialogActions>
     </Dialog>
@@ -239,6 +263,16 @@ export function CreateTableColumnForm(
     </Tooltip>
   ) : (
     <Button
+      sx={{
+        color: '#FFFFFF',
+        backgroundColor: '#337ab7',
+        '&:hover': {
+          backgroundColor: '#285a9b',
+        },
+        '&:disabled': {
+          backgroundColor: 'transparent',
+        },
+      }}
       disabled={columnName === ''}
       onClick={() => props.onSubmit(columnName, valueTypeName, defaultValue)}
     >
@@ -292,10 +326,10 @@ export function CreateTableColumnForm(
       </DialogContent>
 
       <DialogActions>
-        {submitButton}
-        <Button color="error" onClick={props.onClose}>
+        <Button color="primary" onClick={props.onClose}>
           Cancel
         </Button>
+        {submitButton}
       </DialogActions>
     </Dialog>
   )

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm.tsx
@@ -185,11 +185,21 @@ export const PdfExportForm = (props: ExportImageFormatProps): ReactElement => {
         </Box>
       </Box>
       <DialogActions sx={{ pr: 1 }}>
-        <Button color="error" onClick={props.handleClose}>
+        <Button color="primary" onClick={props.handleClose}>
           Cancel
         </Button>
         <Button
           disabled={loading}
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
           onClick={async () => {
             setLoading(true)
             const result = await pdfFunction?.(

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/PngExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/PngExportForm.tsx
@@ -336,11 +336,20 @@ export const PngExportForm = (props: ExportImageFormatProps): ReactElement => {
           </Box>
         </Box>
         <DialogActions sx={{ pr: 1 }}>
-          <Button color="secondary" onClick={props.handleClose}>
+          <Button color="primary" onClick={props.handleClose}>
             Cancel
           </Button>
           <Button
-            color="primary"
+            sx={{
+              color: '#FFFFFF',
+              backgroundColor: '#337ab7',
+              '&:hover': {
+                backgroundColor: '#285a9b',
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+              },
+            }}
             disabled={loading}
             onClick={async () => {
               setLoading(true)

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
@@ -60,10 +60,20 @@ export const SvgExportForm = (props: ExportImageFormatProps): ReactElement => {
         </Box>
       </Box>
       <DialogActions sx={{ pr: 1 }}>
-        <Button color="error" onClick={props.handleClose}>
+        <Button color="primary" onClick={props.handleClose}>
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
           disabled={loading}
           onClick={async () => {
             setLoading(true)

--- a/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
@@ -445,23 +445,33 @@ export const LoadFromNdexDialog = (
       >
         <Box sx={{ pl: 2 }}>{successMessage ?? errorMessage ?? ''}</Box>
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <Button color="error" onClick={handleClose} sx={{ mr: 7 }}>
+          <Button color="primary" onClick={handleClose} sx={{ mr: 1 }}>
             Cancel
           </Button>
           <Button
+            sx={{
+              color: '#FFFFFF',
+              backgroundColor: '#337ab7',
+              '&:hover': {
+                backgroundColor: '#285a9b',
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+              },
+            }}
             disabled={selectedNetworks.length === 0}
             onClick={() => {
               setErrorMessage(undefined)
               setSuccessMessage(undefined)
               addMessage({
-                message: `Loading ${selectedNetworks.length} network(s) from NDEx`,
+                message: `Loading ${selectedNetworks.length} network${selectedNetworks.length > 1 ? 's' : ''} from NDEx`,
                 duration: 3000,
               })
               void addNDExNetworksToWorkspace(selectedNetworks)
               handleClose()
             }}
           >
-            {`Open ${selectedNetworks.length} Network(s)`}
+            {`Open ${selectedNetworks.length} Network${selectedNetworks.length > 1 ? 's' : ''}`}
           </Button>
           {/* </Box> */}
         </Box>

--- a/src/components/ToolBar/DataMenu/LoadWorkspaceDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadWorkspaceDialog.tsx
@@ -109,15 +109,27 @@ export const LoadWorkspaceDialog: React.FC<{
       } else {
         alert('Selected workspace not found')
       }
+      await fetchMyWorkspaces(ndexBaseUrl, getToken)
+        .then(setMyWorkspaces)
+        .catch((err) => {
+          console.log(err)
+        })
+      setSelectedWorkspaceId(null)
     } else {
       alert('No workspace selected')
     }
-    handleClose()
     setOpenDialog(false)
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
+    <Dialog
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      open={open}
+      onClose={handleClose}
+      fullWidth
+      maxWidth="lg"
+    >
       <DialogTitle>My Workspaces</DialogTitle>
       <DialogContent>
         {myWorkspaces.length === 0 ? (
@@ -177,17 +189,37 @@ export const LoadWorkspaceDialog: React.FC<{
           }}
         >
           <Button
-            color="error"
+            sx={{
+              color: '#F50157',
+              backgroundColor: 'transparent',
+              '&:hover': {
+                color: '#FFFFFF',
+                backgroundColor: '#fc266f',
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+              },
+            }}
             onClick={handleDeleteWorkspaceClick}
             disabled={selectedWorkspaceId == null}
           >
             Delete Workspace
           </Button>
           <Box sx={{ display: 'flex' }}>
-            <Button color="error" onClick={handleClose} sx={{ mr: 2 }}>
+            <Button color="primary" onClick={handleClose} sx={{ mr: 2 }}>
               Cancel
             </Button>
             <Button
+              sx={{
+                color: '#FFFFFF',
+                backgroundColor: '#337ab7',
+                '&:hover': {
+                  backgroundColor: '#285a9b',
+                },
+                '&:disabled': {
+                  backgroundColor: 'transparent',
+                },
+              }}
               onClick={handleOpenWorkspace}
               disabled={selectedWorkspaceId == null}
             >
@@ -204,7 +236,20 @@ export const LoadWorkspaceDialog: React.FC<{
             </DialogContent>
             <DialogActions>
               <Button onClick={handleCloseDialog}>Cancel</Button>
-              <Button color="error" onClick={handleConfirmDelete}>
+              <Button
+                sx={{
+                  color: '#F50157',
+                  backgroundColor: 'transparent',
+                  '&:hover': {
+                    color: '#FFFFFF',
+                    backgroundColor: '#fc266f',
+                  },
+                  '&:disabled': {
+                    backgroundColor: 'transparent',
+                  },
+                }}
+                onClick={handleConfirmDelete}
+              >
                 Delete
               </Button>
             </DialogActions>

--- a/src/components/ToolBar/DataMenu/RemoveAllNetworksMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/RemoveAllNetworksMenuItem.tsx
@@ -27,6 +27,7 @@ export const RemoveAllNetworksMenuItem = (
         open={open}
         setOpen={setOpen}
         buttonTitle="Yes (cannot be undone)"
+        isAlert={true}
       />
     </>
   )

--- a/src/components/ToolBar/DataMenu/RemoveNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/RemoveNetworkMenuItem.tsx
@@ -26,6 +26,7 @@ export const RemoveNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
         open={open}
         setOpen={setOpen}
         buttonTitle="Yes (cannot be undone)"
+        isAlert={true}
       />
     </>
   )

--- a/src/components/ToolBar/DataMenu/ResetLocalWorkspace.tsx
+++ b/src/components/ToolBar/DataMenu/ResetLocalWorkspace.tsx
@@ -30,6 +30,7 @@ export const ResetLocalWorkspaceMenuItem = (
         open={open}
         setOpen={setOpen}
         buttonTitle="Reset Workspace (cannot be undone)"
+        isAlert={true}
       />
     </>
   )

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -284,9 +284,36 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={saveCopyToNDEx}>Yes, create copy to NDEx</Button>
-        <Button onClick={overwriteNDExNetwork} color="error">
+        <Button
+          onClick={overwriteNDExNetwork}
+          sx={{
+            color: '#F50157',
+            backgroundColor: 'transparent',
+            '&:hover': {
+              color: '#FFFFFF',
+              backgroundColor: '#fc266f',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+        >
           No, overwrite the network in NDEx
+        </Button>
+        <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+          onClick={saveCopyToNDEx}
+        >
+          Yes, create copy to NDEx
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -177,8 +177,24 @@ export const SaveWorkspaceToNDExMenuItem = (
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCloseDialog}>Cancel</Button>
-        <Button onClick={saveWorkspaceToNDEx}>Save</Button>
+        <Button onClick={handleCloseDialog} color="primary">
+          Cancel
+        </Button>
+        <Button
+          onClick={saveWorkspaceToNDEx}
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+        >
+          Save
+        </Button>
       </DialogActions>
     </Dialog>
   )

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -1,14 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react'
-import {
-  MenuItem,
-  Box,
-  Tooltip,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-} from '@mui/material'
+import { MenuItem, Box, Tooltip } from '@mui/material'
 import { BaseMenuProps } from '../BaseMenuProps'
 // @ts-expect-error-next-line
 import { NDEx } from '@js4cytoscape/ndex-client'
@@ -29,6 +20,7 @@ import {
   saveAllNetworks,
   ndexDuplicateKeyErrorMessage,
 } from '../../../utils/ndex-utils'
+import { ConfirmationDialog } from '../../Util/ConfirmationDialog'
 
 export const SaveWorkspaceToNDExOverwriteMenuItem = (
   props: BaseMenuProps,
@@ -161,21 +153,6 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
     handleOpenDialog()
   }
 
-  const dialog = (
-    <Dialog open={openDialog} onClose={handleCloseDialog}>
-      <DialogTitle>
-        Do you want to save (overwrite) the current workspace?
-      </DialogTitle>
-      <DialogContent></DialogContent>
-      <DialogActions>
-        <Button onClick={handleCloseDialog}>Cancel</Button>
-        <Button disabled={isLoading} onClick={saveWorkspaceToNDEx}>
-          Save
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-
   const menuItem = (
     <MenuItem
       disabled={!authenticated}
@@ -194,7 +171,16 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
           <Box>{menuItem}</Box>
         </Tooltip>
       )}
-      {dialog}
+      <ConfirmationDialog
+        title="Save Workspace to NDEx"
+        message="Do you want to save/overwrite the current workspace to NDEx?"
+        onConfirm={saveWorkspaceToNDEx}
+        open={openDialog}
+        setOpen={setOpenDialog}
+        buttonTitle="Save"
+        isAlert={true}
+        confirmDisabled={isLoading}
+      />
     </>
   )
 }

--- a/src/components/ToolBar/HelpMenu/AboutCytoscapeWebMenuItem.tsx
+++ b/src/components/ToolBar/HelpMenu/AboutCytoscapeWebMenuItem.tsx
@@ -1,41 +1,48 @@
-import React from 'react';
-import { MenuItem, Dialog, DialogContent, DialogActions, Button, Typography, Box } from '@mui/material';
-import { BaseMenuProps } from '../BaseMenuProps';
-import packageInfo from '../../../../package.json';
+import React from 'react'
+import {
+  MenuItem,
+  Dialog,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+} from '@mui/material'
+import { BaseMenuProps } from '../BaseMenuProps'
+import packageInfo from '../../../../package.json'
 import { getDatabaseVersion } from '../../../store/persist/db'
 
-export const AboutCytoscapeWebMenuItem = (props: BaseMenuProps): React.ReactElement => {
-  const [open, setOpen] = React.useState(false);
+export const AboutCytoscapeWebMenuItem = (
+  props: BaseMenuProps,
+): React.ReactElement => {
+  const [open, setOpen] = React.useState(false)
 
   const handleOpenDialog = (): void => {
-    setOpen(true);
-  };
+    setOpen(true)
+  }
 
   const handleCopyInfo = () => {
-    const infoToCopy = `Version: ${packageInfo.version}\nBuild ID: ${commitHash}\nBuild Date: ${buildDate}\nCache Version: ${getDatabaseVersion()}`;
-    navigator.clipboard.writeText(infoToCopy).then(() => {
-      alert('Information copied to clipboard!');
-    }).catch((err) => {
-      console.error('Failed to copy: ', err);
-    });
-  };
+    const infoToCopy = `Version: ${packageInfo.version}\nBuild ID: ${commitHash}\nBuild Date: ${buildDate}\nCache Version: ${getDatabaseVersion()}`
+    navigator.clipboard.writeText(infoToCopy).catch((err) => {
+      console.error('Failed to copy: ', err)
+    })
+  }
 
   const handleCloseDialog = (): void => {
-    setOpen(false);
-    props.handleClose();
-  };
+    setOpen(false)
+    props.handleClose()
+  }
 
   const commitHash = process.env.REACT_APP_GIT_COMMIT
-  ? process.env.REACT_APP_GIT_COMMIT.substring(0, 7)
-  : 'N/A';  const buildDate = process.env.REACT_APP_BUILD_DATE
-  ? new Date(process.env.REACT_APP_BUILD_DATE).toLocaleString()
-  : 'N/A'; 
-  
+    ? process.env.REACT_APP_GIT_COMMIT.substring(0, 7)
+    : 'N/A'
+  const buildDate = process.env.REACT_APP_BUILD_DATE
+    ? new Date(process.env.REACT_APP_BUILD_DATE).toLocaleString()
+    : 'N/A'
+
   return (
     <>
-      <MenuItem onClick={handleOpenDialog}>
-        About Cytoscape Web
-      </MenuItem>
+      <MenuItem onClick={handleOpenDialog}>About Cytoscape Web</MenuItem>
       <Dialog open={open} onClose={handleCloseDialog}>
         <DialogContent>
           <Typography variant="h6" gutterBottom>
@@ -58,16 +65,26 @@ export const AboutCytoscapeWebMenuItem = (props: BaseMenuProps): React.ReactElem
           </Typography>
         </DialogContent>
         <DialogActions>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-          <Button onClick={handleCopyInfo} color="primary">
-            Copy
-          </Button>
           <Button onClick={handleCloseDialog} color="primary">
             Close
           </Button>
-        </Box>
+          <Button
+            onClick={handleCopyInfo}
+            sx={{
+              color: '#FFFFFF',
+              backgroundColor: '#337ab7',
+              '&:hover': {
+                backgroundColor: '#285a9b',
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+              },
+            }}
+          >
+            Copy
+          </Button>
         </DialogActions>
       </Dialog>
     </>
-  );
-};
+  )
+}

--- a/src/components/ToolBar/HelpMenu/CitationMenuItem.tsx
+++ b/src/components/ToolBar/HelpMenu/CitationMenuItem.tsx
@@ -1,10 +1,19 @@
-import { MenuItem, Dialog, DialogTitle, DialogContent, DialogActions, Button, Typography } from '@mui/material'
+import {
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from '@mui/material'
 import { ReactElement, useState } from 'react'
 import { BaseMenuProps } from '../BaseMenuProps'
 
 export const CitationMenuItem = (props: BaseMenuProps): ReactElement => {
   const [open, setOpen] = useState(false)
-  const citationText = "Shannon P, Markiel A, Ozier O, Baliga NS, Wang JT, Ramage D, Amin N, Schwikowski B, Ideker T. Cytoscape: a software environment for integrated models of biomolecular interaction networks. Genome Res, 13:11 (2498-504). 2003 Nov. PubMed ID: 14597658."
+  const citationText =
+    'Shannon P, Markiel A, Ozier O, Baliga NS, Wang JT, Ramage D, Amin N, Schwikowski B, Ideker T. Cytoscape: a software environment for integrated models of biomolecular interaction networks. Genome Res, 13:11 (2498-504). 2003 Nov. PubMed ID: 14597658.'
 
   const handleOpenDialog = (): void => {
     setOpen(true)
@@ -16,20 +25,14 @@ export const CitationMenuItem = (props: BaseMenuProps): ReactElement => {
   }
 
   const handleCopyText = (): void => {
-    navigator.clipboard.writeText(citationText)
-      .then(() => {
-        alert('Citation copied to clipboard!')
-      })
-      .catch((err) => {
-        console.error('Failed to copy text: ', err)
-      })
+    navigator.clipboard.writeText(citationText).catch((err) => {
+      console.error('Failed to copy text: ', err)
+    })
   }
 
   return (
     <>
-      <MenuItem onClick={handleOpenDialog}>
-        Citation
-      </MenuItem>
+      <MenuItem onClick={handleOpenDialog}>Citation</MenuItem>
       <Dialog open={open} onClose={handleCloseDialog}>
         <DialogTitle>Cite Cytoscape Web</DialogTitle>
         <DialogContent>
@@ -38,11 +41,23 @@ export const CitationMenuItem = (props: BaseMenuProps): ReactElement => {
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCopyText} color="primary">
-            Copy Citation
-          </Button>
           <Button onClick={handleCloseDialog} color="primary">
             Close
+          </Button>
+          <Button
+            onClick={handleCopyText}
+            sx={{
+              color: '#FFFFFF',
+              backgroundColor: '#337ab7',
+              '&:hover': {
+                backgroundColor: '#285a9b',
+              },
+              '&:disabled': {
+                backgroundColor: 'transparent',
+              },
+            }}
+          >
+            Copy Citation
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/ToolBar/LayoutMenu/LayoutOptionDialog.tsx
+++ b/src/components/ToolBar/LayoutMenu/LayoutOptionDialog.tsx
@@ -158,16 +158,18 @@ export const LayoutOptionDialog = ({
       PaperComponent={DraggablePaper}
       aria-labelledby="draggable-dialog-title"
     >
-      <DialogTitle
-        sx={{
-          padding: 1,
-        }}
-      >
-        Layout Option Editor
-      </DialogTitle>
+      <DialogTitle>Layout Option Editor</DialogTitle>
       <Divider />
 
-      <DialogContent sx={{ margin: 0, padding: 1, paddingTop: 0 }}>
+      <DialogContent
+        sx={{
+          margin: 1.5,
+          padding: 1,
+          paddingTop: 0,
+          marginTop: 0.5,
+          overflowY: 'clip',
+        }}
+      >
         <Grid container spacing={0} alignItems={'center'}>
           <Grid item md={12}>
             <LayoutSelector
@@ -176,7 +178,7 @@ export const LayoutOptionDialog = ({
               setSelected={setSelectedAlgorithm}
             />
           </Grid>
-          <Grid>
+          <Grid sx={{ paddingTop: '8px' }}>
             <FormControlLabel
               control={
                 <Checkbox
@@ -186,6 +188,7 @@ export const LayoutOptionDialog = ({
                 />
               }
               label="Set as default"
+              labelPlacement="start"
             />
           </Grid>
         </Grid>
@@ -214,10 +217,23 @@ export const LayoutOptionDialog = ({
         </List>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose} color="info">
+        <Button onClick={handleClose} color="primary">
           Close
         </Button>
-        <Button disabled={disabled} onClick={handleApply} color="secondary">
+        <Button
+          disabled={disabled}
+          onClick={handleApply}
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+        >
           Apply Layout
         </Button>
       </DialogActions>

--- a/src/components/UpdateNetworkDialog.tsx
+++ b/src/components/UpdateNetworkDialog.tsx
@@ -60,8 +60,25 @@ export const UpdateNetworkDialog = (props: {
       </DialogContent>
       <DialogActions>
         {loading && <CircularProgress />}
+        <Button
+          variant="outlined"
+          disabled={loading}
+          onClick={() => {
+            props.onClose()
+          }}
+          color="primary"
+        >
+          Cancel
+        </Button>
         {!authenticated ? (
           <Button
+            sx={{
+              color: '#FFFFFF',
+              backgroundColor: '#337ab7',
+              '&:hover': {
+                backgroundColor: '#285a9b',
+              },
+            }}
             onClick={() => {
               client
                 ?.login()
@@ -78,7 +95,13 @@ export const UpdateNetworkDialog = (props: {
         ) : (
           <>
             <Button
-              variant="outlined"
+              sx={{
+                color: '#FFFFFF',
+                backgroundColor: '#337ab7',
+                '&:hover': {
+                  backgroundColor: '#285a9b',
+                },
+              }}
               disabled={!authenticated || loading}
               onClick={async () => {
                 const parsed = parsePathName(location.pathname)
@@ -102,16 +125,6 @@ export const UpdateNetworkDialog = (props: {
             </Button>
           </>
         )}
-        <Button
-          variant="outlined"
-          disabled={loading}
-          onClick={() => {
-            props.onClose()
-          }}
-          color="error"
-        >
-          Cancel
-        </Button>
       </DialogActions>
     </Dialog>
   )

--- a/src/components/Util/ConfirmationDialog.tsx
+++ b/src/components/Util/ConfirmationDialog.tsx
@@ -13,11 +13,23 @@ interface ConfirmationDialogProps {
   buttonTitle?: string
   onConfirm: () => void
   onCancel?: () => void
+  isAlert?: boolean
+  confirmDisabled?: boolean
 }
 export const ConfirmationDialog = (
   props: ConfirmationDialogProps,
 ): JSX.Element => {
-  const { open, setOpen, message, title, buttonTitle, onConfirm, onCancel } = props
+  const {
+    open,
+    setOpen,
+    message,
+    title,
+    buttonTitle,
+    onConfirm,
+    onCancel,
+    isAlert,
+    confirmDisabled,
+  } = props
 
   const handleCancel = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.stopPropagation()
@@ -45,8 +57,25 @@ export const ConfirmationDialog = (
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCancel}>Cancel</Button>
-        <Button onClick={handleConfirm} autoFocus>
+        <Button onClick={handleCancel} color="primary">
+          Cancel
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          disabled={confirmDisabled ?? false}
+          autoFocus
+          sx={{
+            color: isAlert ? '#F50157' : '#FFFFFF',
+            backgroundColor: isAlert ? 'transparent' : '#337ab7',
+            '&:hover': {
+              color: '#FFFFFF',
+              backgroundColor: isAlert ? '#fc266f' : '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+        >
           {buttonTitle === undefined || buttonTitle === '' ? 'OK' : buttonTitle}
         </Button>
       </DialogActions>

--- a/src/components/Util/TaskStatusDialog.tsx
+++ b/src/components/Util/TaskStatusDialog.tsx
@@ -70,7 +70,9 @@ export const TaskStatusDialog = ({
         </div>
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleClose} color="primary">
+          Cancel
+        </Button>
       </DialogActions>
     </Dialog>
   )

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -17,8 +17,8 @@ import Delete from '@mui/icons-material/DisabledByDefault'
 import AddCircleIcon from '@mui/icons-material/AddCircle'
 import Palette from '@mui/icons-material/Palette'
 import EditIcon from '@mui/icons-material/Edit'
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 
 import RdBu from '../../../../../assets/RdBu.png'
 import PuOr from '../../../../../assets/PuOr.png'
@@ -48,9 +48,9 @@ import { useVisualStyleStore } from '../../../../../store/VisualStyleStore'
 import { ColorGradient } from './ColorGradient'
 import { Handle, addHandle, editHandle, removeHandle } from './Handle'
 
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
+import FormGroup from '@mui/material/FormGroup'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Checkbox from '@mui/material/Checkbox'
 
 // color mapping form for now
 export function ContinuousColorMappingForm(props: {
@@ -101,7 +101,9 @@ export function ContinuousColorMappingForm(props: {
     setEditMinMaxAnchorEl(null)
   }
 
-  const showColorPickerMenu = (event: React.MouseEvent<HTMLButtonElement>): void => {
+  const showColorPickerMenu = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ): void => {
     setColorPickerAnchorEl(event.currentTarget)
   }
 
@@ -119,27 +121,32 @@ export function ContinuousColorMappingForm(props: {
     setCreateHandleAnchorEl(null)
   }
 
-  const [isColorBlindChecked, setIsColorBlindChecked] = React.useState(false);
+  const [isColorBlindChecked, setIsColorBlindChecked] = React.useState(false)
 
-  const handleColorBlindCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    setIsColorBlindChecked(event.target.checked);
-  };
+  const handleColorBlindCheckboxChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    setIsColorBlindChecked(event.target.checked)
+  }
 
-  const [isReverseColorChecked, setIsReverseColorChecked] = React.useState(false);
+  const [isReverseColorChecked, setIsReverseColorChecked] =
+    React.useState(false)
 
-  const handleReverseColorCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    setIsReverseColorChecked(event.target.checked);
-  };
-
+  const handleReverseColorCheckboxChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    setIsReverseColorChecked(event.target.checked)
+  }
 
   const [minPalette, setMinPalette] = React.useState(min.vpValue)
-  const [middlePalette, setMiddlePalette] = React.useState(controlPoints[1].vpValue)
+  const [middlePalette, setMiddlePalette] = React.useState(
+    controlPoints[1].vpValue,
+  )
   const [maxPalette, setMaxPalette] = React.useState(max.vpValue)
   const [textPalette, setTextPalette] = React.useState('None')
 
-
-  const [buttonText, setButtonText] = React.useState(textPalette);
-  const changeButtonText = (text: string): void => setButtonText(text);
+  const [buttonText, setButtonText] = React.useState(textPalette)
+  const changeButtonText = (text: string): void => setButtonText(text)
 
   const handleColorPicker = (): void => {
     if (!isReverseColorChecked) {
@@ -151,11 +158,11 @@ export function ContinuousColorMappingForm(props: {
         ...maxState,
         vpValue: maxPalette,
       })
-      setHandle(0, min.value as number, minPalette as string);
-      setHandle(1, controlPoints[1].value as number, middlePalette as string);
-      setHandle(2, max.value as number, maxPalette as string);
-      changeButtonText(textPalette);
-      hideColorPickerMenu();
+      setHandle(0, min.value as number, minPalette as string)
+      setHandle(1, controlPoints[1].value as number, middlePalette as string)
+      setHandle(2, max.value as number, maxPalette as string)
+      changeButtonText(textPalette)
+      hideColorPickerMenu()
     } else {
       setMinState({
         ...minState,
@@ -165,11 +172,11 @@ export function ContinuousColorMappingForm(props: {
         ...maxState,
         vpValue: minPalette,
       })
-      setHandle(0, min.value as number, maxPalette as string);
-      setHandle(1, controlPoints[1].value as number, middlePalette as string);
-      setHandle(2, max.value as number, minPalette as string);
-      changeButtonText(textPalette);
-      hideColorPickerMenu();
+      setHandle(0, min.value as number, maxPalette as string)
+      setHandle(1, controlPoints[1].value as number, middlePalette as string)
+      setHandle(2, max.value as number, minPalette as string)
+      changeButtonText(textPalette)
+      hideColorPickerMenu()
     }
   }
 
@@ -200,7 +207,6 @@ export function ContinuousColorMappingForm(props: {
     range: [0, NUM_GRADIENT_STEPS * GRADIENT_STEP_WIDTH],
     domain: extent(valueDomain) as [number, number],
   })
-
 
   // map values to colors
   const colorScale = scaleLinear({
@@ -272,24 +278,22 @@ export function ContinuousColorMappingForm(props: {
     updateContinuousMapping(minState, maxState, newHandles)
   }
 
-
   const setHandle = (id: number, value: number, vpValue: string): void => {
     const newHandles = editHandle(handles, id, value, vpValue)
     setHandles(newHandles)
     updateContinuousMapping(minState, maxState, newHandles)
   }
 
-  const [colorPalette, setColorPalette] = React.useState("");
-
+  const [colorPalette, setColorPalette] = React.useState('')
 
   const handleColorPalette = (
     event: React.MouseEvent<HTMLElement>,
-    newColorPalette: string | null
+    newColorPalette: string | null,
   ): void => {
     if (newColorPalette !== null) {
-      setColorPalette(newColorPalette);
+      setColorPalette(newColorPalette)
     }
-  };
+  }
 
   // when someone changes a handle, the new handle values may contain a new min/max value
   // update the min and max accordingly
@@ -339,7 +343,6 @@ export function ContinuousColorMappingForm(props: {
   }, [maxState])
 
   return (
-
     <Paper sx={{ backgroundColor: '#D9D9D9', pb: 2 }}>
       <Paper
         sx={{
@@ -376,7 +379,9 @@ export function ContinuousColorMappingForm(props: {
             horizontal: 'center',
           }}
         >
-          <Typography align={'center'} sx={{ p: 1 }}>Set Palette</Typography>
+          <Typography align={'center'} sx={{ p: 1 }}>
+            Set Palette
+          </Typography>
           <ToggleButtonGroup
             value={colorPalette}
             onChange={handleColorPalette}
@@ -384,63 +389,142 @@ export function ContinuousColorMappingForm(props: {
             exclusive
             fullWidth={true}
           >
-            <ToggleButton value="rdbu" aria-label="RdBu" onClick={() => { setMinPalette("#b2182b"); setMiddlePalette("#f7f7f7"); setMaxPalette("#2166ac"); setTextPalette('Red-Blue') }}>
+            <ToggleButton
+              value="rdbu"
+              aria-label="RdBu"
+              onClick={() => {
+                setMinPalette('#b2182b')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#2166ac')
+                setTextPalette('Red-Blue')
+              }}
+            >
               <Tooltip title="Red-Blue" placement="right">
                 <img src={RdBu} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
-            <ToggleButton value="puor" aria-label="PuOr" onClick={() => { setMinPalette("#542788"); setMiddlePalette("#f7f7f7"); setMaxPalette("#b35806"); setTextPalette('Purple-Orange') }}>
+            <ToggleButton
+              value="puor"
+              aria-label="PuOr"
+              onClick={() => {
+                setMinPalette('#542788')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#b35806')
+                setTextPalette('Purple-Orange')
+              }}
+            >
               <Tooltip title="Purple-Orange" placement="right">
                 <img src={PuOr} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
-            <ToggleButton value="prgn" aria-label="PRGn" onClick={() => { setMinPalette("#762a83"); setMiddlePalette("#f7f7f7"); setMaxPalette("#1b7837"); setTextPalette('Purple-Red-Green') }}>
+            <ToggleButton
+              value="prgn"
+              aria-label="PRGn"
+              onClick={() => {
+                setMinPalette('#762a83')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#1b7837')
+                setTextPalette('Purple-Red-Green')
+              }}
+            >
               <Tooltip title="Purple-Red-Green" placement="right">
                 <img src={PRGn} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
             {!isColorBlindChecked && (
-              <ToggleButton value="spectral" aria-label="Spectral" onClick={() => { setMinPalette("#d53e4f"); setMiddlePalette("#ffffbf"); setMaxPalette("#3288bd"); setTextPalette('Spectral Colors') }} >
+              <ToggleButton
+                value="spectral"
+                aria-label="Spectral"
+                onClick={() => {
+                  setMinPalette('#d53e4f')
+                  setMiddlePalette('#ffffbf')
+                  setMaxPalette('#3288bd')
+                  setTextPalette('Spectral Colors')
+                }}
+              >
                 <Tooltip title="Spectral Colors" placement="right">
                   <img src={Spectral} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
             )}
 
-            <ToggleButton value="brbg" aria-label="BrBG" onClick={() => { setMinPalette("#8c510a"); setMiddlePalette("#f5f5f5"); setMaxPalette("#01665e"); setTextPalette('Brown-Blue-Green') }}>
+            <ToggleButton
+              value="brbg"
+              aria-label="BrBG"
+              onClick={() => {
+                setMinPalette('#8c510a')
+                setMiddlePalette('#f5f5f5')
+                setMaxPalette('#01665e')
+                setTextPalette('Brown-Blue-Green')
+              }}
+            >
               <Tooltip title="Brown-Blue-Green" placement="right">
                 <img src={BrBG} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
             {!isColorBlindChecked && (
-              <ToggleButton value="rdylgn" aria-label="RdYlGn" onClick={() => { setMinPalette("#d73027"); setMiddlePalette("#ffffbf"); setMaxPalette("#1a9850"); setTextPalette('Red-Yellow-Green') }}>
+              <ToggleButton
+                value="rdylgn"
+                aria-label="RdYlGn"
+                onClick={() => {
+                  setMinPalette('#d73027')
+                  setMiddlePalette('#ffffbf')
+                  setMaxPalette('#1a9850')
+                  setTextPalette('Red-Yellow-Green')
+                }}
+              >
                 <Tooltip title="Red-Yellow-Green" placement="right">
                   <img src={RdYlGn} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
             )}
 
-
-            <ToggleButton value="piyg" aria-label="PiYG" onClick={() => { setMinPalette("#c51b7d"); setMiddlePalette("#f7f7f7"); setMaxPalette("#4d9221"); setTextPalette('Magenta-Yellow-Green') }}>
+            <ToggleButton
+              value="piyg"
+              aria-label="PiYG"
+              onClick={() => {
+                setMinPalette('#c51b7d')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#4d9221')
+                setTextPalette('Magenta-Yellow-Green')
+              }}
+            >
               <Tooltip title="Magenta-Yellow-Green" placement="right">
                 <img src={PiYG} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
             {!isColorBlindChecked && (
-              <ToggleButton value="rdgy" aria-label="RdGy" onClick={() => { setMinPalette("#b2182b"); setMiddlePalette("#ffffff"); setMaxPalette("#4d4d4d"); setTextPalette('Red-Grey') }}>
+              <ToggleButton
+                value="rdgy"
+                aria-label="RdGy"
+                onClick={() => {
+                  setMinPalette('#b2182b')
+                  setMiddlePalette('#ffffff')
+                  setMaxPalette('#4d4d4d')
+                  setTextPalette('Red-Grey')
+                }}
+              >
                 <Tooltip title="Red-Grey" placement="right">
                   <img src={RdGy} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
             )}
 
-
-            <ToggleButton value="rdylbu" aria-label="RdYlBu" onClick={() => { setMinPalette("#d73027"); setMiddlePalette("#ffffbf"); setMaxPalette("#4575b4"); setTextPalette('Red-Yellow-Blue') }}>
+            <ToggleButton
+              value="rdylbu"
+              aria-label="RdYlBu"
+              onClick={() => {
+                setMinPalette('#d73027')
+                setMiddlePalette('#ffffbf')
+                setMaxPalette('#4575b4')
+                setTextPalette('Red-Yellow-Blue')
+              }}
+            >
               <Tooltip title="Red-Yellow-Blue" placement="right">
                 <img src={RdYlBu} width="15" height="150" />
               </Tooltip>
@@ -460,10 +544,26 @@ export function ContinuousColorMappingForm(props: {
             }}
           >
             <FormGroup>
-              <FormControlLabel control={<Checkbox checked={isReverseColorChecked} onChange={handleReverseColorCheckboxChange} />} label="reverse colors" />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isReverseColorChecked}
+                    onChange={handleReverseColorCheckboxChange}
+                  />
+                }
+                label="reverse colors"
+              />
             </FormGroup>
             <FormGroup>
-              <FormControlLabel control={<Checkbox checked={isColorBlindChecked} onChange={handleColorBlindCheckboxChange} />} label="colorblind-friendly" />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isColorBlindChecked}
+                    onChange={handleColorBlindCheckboxChange}
+                  />
+                }
+                label="colorblind-friendly"
+              />
             </FormGroup>
           </Paper>
           <Paper
@@ -479,16 +579,7 @@ export function ContinuousColorMappingForm(props: {
             }}
           >
             <Button
-              variant="outlined"
-              onClick={() => {
-                handleColorPicker()
-              }}
-              size="small"
-            >
-              Ok
-            </Button>
-            <Button
-              variant="outlined"
+              color="primary"
               onClick={() => {
                 hideColorPickerMenu()
               }}
@@ -496,8 +587,22 @@ export function ContinuousColorMappingForm(props: {
             >
               Cancel
             </Button>
+            <Button
+              sx={{
+                color: '#FFFFFF',
+                backgroundColor: '#337ab7',
+                '&:hover': {
+                  backgroundColor: '#285a9b',
+                },
+              }}
+              onClick={() => {
+                handleColorPicker()
+              }}
+              size="small"
+            >
+              Confirm
+            </Button>
           </Paper>
-
         </Popover>
       </Paper>
       <Box
@@ -698,8 +803,6 @@ export function ContinuousColorMappingForm(props: {
           color: '#595858',
         }}
       >
-
-
         <Button
           onClick={showCreateHandleMenu}
           variant="outlined"

--- a/src/components/Vizmapper/Forms/VisualPropertyValueForm.tsx
+++ b/src/components/Vizmapper/Forms/VisualPropertyValueForm.tsx
@@ -66,7 +66,6 @@ import {
 } from '../VisualPropertyRender/NodeLabelPosition'
 import { IdType } from '../../../models/IdType'
 import { LockColorCheckbox } from '../VisualPropertyRender/Checkbox'
-import { CancelConfirmButtonGroup } from '../VisualPropertyRender/CancelConfirmButtonGroup'
 
 const vpType2RenderMap: Record<
   VisualPropertyValueTypeName,

--- a/src/components/Vizmapper/VisualPropertyRender/Boolean.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Boolean.tsx
@@ -21,7 +21,7 @@ export function BooleanSwitch(props: {
       ></Switch>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? false)
@@ -30,6 +30,13 @@ export function BooleanSwitch(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/CancelConfirmButtonGroup.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/CancelConfirmButtonGroup.tsx
@@ -12,14 +12,25 @@ export const CancelConfirmButtonGroup = (
   return (
     <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
       <Button
-        color="error"
+        color="primary"
         onClick={() => {
           closePopover('cancel')
         }}
       >
         Cancel
       </Button>
-      <Button onClick={() => closePopover('confirm')}>Confirm</Button>
+      <Button
+        sx={{
+          color: '#FFFFFF',
+          backgroundColor: '#337ab7',
+          '&:hover': {
+            backgroundColor: '#285a9b',
+          },
+        }}
+        onClick={() => closePopover('confirm')}
+      >
+        Confirm
+      </Button>
     </Box>
   )
 }

--- a/src/components/Vizmapper/VisualPropertyRender/Color.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Color.tsx
@@ -101,7 +101,7 @@ export function ColorPicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalColorValue(currentValue ?? `#ffffff`)
@@ -110,6 +110,13 @@ export function ColorPicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localColorValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/EdgeArrowShape.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/EdgeArrowShape.tsx
@@ -118,7 +118,7 @@ export function EdgeArrowShapePicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? EdgeArrowShapeType.None)
@@ -127,6 +127,13 @@ export function EdgeArrowShapePicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/EdgeLine.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/EdgeLine.tsx
@@ -72,7 +72,7 @@ export function EdgeLinePicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? EdgeLineType.Solid)
@@ -81,6 +81,13 @@ export function EdgeLinePicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/Font.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Font.tsx
@@ -50,7 +50,7 @@ export function FontPicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? FontType.SansSerif)
@@ -59,6 +59,13 @@ export function FontPicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/NodeBorderLine.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeBorderLine.tsx
@@ -81,7 +81,7 @@ export function NodeBorderLinePicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? NodeBorderLineType.Solid)
@@ -90,6 +90,13 @@ export function NodeBorderLinePicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/NodeLabelPosition.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeLabelPosition.tsx
@@ -119,7 +119,7 @@ export function NodeLabelPositionPicker(props: {
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? DEFAULT_NODE_LABEL_POSITION)
@@ -128,6 +128,13 @@ export function NodeLabelPositionPicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/NodeShape.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/NodeShape.tsx
@@ -110,7 +110,7 @@ export function NodeShapePicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? NodeShapeType.Rectangle)
@@ -119,6 +119,13 @@ export function NodeShapePicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/Number.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Number.tsx
@@ -86,7 +86,7 @@ export function NumberInput(props: {
         }}
       >
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             setValue(String(currentValue ?? 0))
             setValueIsValid(strValueIsValid(String(currentValue ?? 0)))
@@ -96,6 +96,13 @@ export function NumberInput(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           disabled={!isValid}
           onClick={() => {
             const nextValue = Number(Number(value).toFixed(4))

--- a/src/components/Vizmapper/VisualPropertyRender/Opacity.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Opacity.tsx
@@ -51,7 +51,7 @@ export function OpacitySlider(props: {
       </Stack>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalOpacityValue(currentValue ?? 0)
@@ -60,6 +60,13 @@ export function OpacitySlider(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localOpacityValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/String.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/String.tsx
@@ -25,7 +25,7 @@ export function StringInput(props: {
       </TextField>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? '')
@@ -34,6 +34,13 @@ export function StringInput(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/components/Vizmapper/VisualPropertyRender/Visibility.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Visibility.tsx
@@ -76,7 +76,7 @@ export function VisibilityPicker(props: {
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', p: 1 }}>
         <Button
-          color="error"
+          color="primary"
           onClick={() => {
             props.closePopover('cancel')
             setLocalValue(currentValue ?? VisibilityType.Element)
@@ -85,6 +85,13 @@ export function VisibilityPicker(props: {
           Cancel
         </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
           onClick={() => {
             props.onValueChange(localValue)
             props.closePopover('confirm')

--- a/src/features/HierarchyViewer/components/Validation/HcxValidationSaveDialog.tsx
+++ b/src/features/HierarchyViewer/components/Validation/HcxValidationSaveDialog.tsx
@@ -49,10 +49,24 @@ export const HcxValidationSaveDialog = (
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button color="error" onClick={() => onClose()}>
+        <Button color="primary" onClick={() => onClose()}>
           Cancel
         </Button>
-        <Button onClick={() => onSubmit()}>Save To NDEx</Button>
+        <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
+          onClick={() => onSubmit()}
+        >
+          Save To NDEx
+        </Button>
       </DialogActions>
     </Dialog>
   )

--- a/src/features/HierarchyViewer/components/Validation/HcxValidationWarningsDialog.tsx
+++ b/src/features/HierarchyViewer/components/Validation/HcxValidationWarningsDialog.tsx
@@ -45,7 +45,9 @@ export const HcxValidationWarningsDialog = (
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => onClose()}>Close</Button>
+        <Button color="primary" onClick={() => onClose()}>
+          Close
+        </Button>
       </DialogActions>
     </Dialog>
   )

--- a/src/features/LLMQuery/components/LLMQueryOptionsMenuItem.tsx
+++ b/src/features/LLMQuery/components/LLMQueryOptionsMenuItem.tsx
@@ -63,6 +63,12 @@ export const LLMQueryOptionsMenuItem = (props: BaseMenuProps): ReactElement => {
 
   const dialog = (
     <Dialog
+      onKeyDown={(e) => {
+        e.stopPropagation()
+      }}
+      onClick={(e) => {
+        e.stopPropagation()
+      }}
       maxWidth="sm"
       fullWidth={true}
       open={showDialog}
@@ -147,7 +153,7 @@ export const LLMQueryOptionsMenuItem = (props: BaseMenuProps): ReactElement => {
           sx={{
             mt: 2,
             maxHeight: 300,
-            overflowY: 'scroll',
+            overflowY: 'auto',
             p: 2,
             whiteSpace: 'pre-line',
           }}
@@ -156,7 +162,20 @@ export const LLMQueryOptionsMenuItem = (props: BaseMenuProps): ReactElement => {
         </Box>
       </DialogContent>
       <DialogActions>
+        <Button color="primary" onClick={props.handleClose}>
+          Cancel
+        </Button>
         <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+            '&:disabled': {
+              backgroundColor: 'transparent',
+            },
+          }}
           onClick={() => {
             setShowDialog(false)
             setLLMModel(localLLMModel)
@@ -168,9 +187,6 @@ export const LLMQueryOptionsMenuItem = (props: BaseMenuProps): ReactElement => {
           }}
         >
           Confirm
-        </Button>
-        <Button color="error" onClick={props.handleClose}>
-          Cancel
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -882,19 +882,26 @@ const MergeDialog: React.FC<MergeDialogProps> = ({
         onConfirm={() => setShowError(false)}
       />
       <DialogActions>
-        <Button onClick={handleClose} color="secondary">
+        <Button onClick={handleClose} color="primary">
           Cancel
         </Button>
         {mergeTooltipIsOpen ? (
           <Tooltip title={mergeTooltipText} placement="top" arrow>
             <span>
-              <Button color="primary" disabled={true}>
-                Merge
-              </Button>
+              <Button disabled={true}>Merge</Button>
             </span>
           </Tooltip>
         ) : (
-          <Button onClick={handleMerge} color="primary">
+          <Button
+            onClick={handleMerge}
+            sx={{
+              color: '#FFFFFF',
+              backgroundColor: '#337ab7',
+              '&:hover': {
+                backgroundColor: '#285a9b',
+              },
+            }}
+          >
             Merge
           </Button>
         )}

--- a/src/features/TableDataLoader/components/CreateNetworkFromTable/TableColumnAssignmentForm.tsx
+++ b/src/features/TableDataLoader/components/CreateNetworkFromTable/TableColumnAssignmentForm.tsx
@@ -117,7 +117,9 @@ export function TableColumnAssignmentForm(props: BaseMenuProps) {
   )
 
   const ui = useUiStateStore((state) => state.ui)
-  const setVisualStyleOptions = useUiStateStore((state) => state.setVisualStyleOptions)
+  const setVisualStyleOptions = useUiStateStore(
+    (state) => state.setVisualStyleOptions,
+  )
 
   const addNewNetwork = useNetworkStore((state) => state.add)
 
@@ -220,7 +222,7 @@ export function TableColumnAssignmentForm(props: BaseMenuProps) {
     // therefore, as a temporary fix, the first operation that should be done is to set the
     // current network to be the new network id
     setCurrentNetworkId(newNetworkId)
-    setVisualStyleOptions(newNetworkId);
+    setVisualStyleOptions(newNetworkId)
     addNewNetwork(network)
     setVisualStyle(newNetworkId, visualStyle)
     setTables(newNetworkId, nodeTable, edgeTable)
@@ -457,7 +459,7 @@ export function TableColumnAssignmentForm(props: BaseMenuProps) {
           <Button
             disabled={loading}
             variant="default"
-            color="red"
+            color="primary"
             onClick={() => handleCancel()}
           >
             Cancel
@@ -468,6 +470,15 @@ export function TableColumnAssignmentForm(props: BaseMenuProps) {
             label="All row values must be valid for it's corrensponding data type.  One column must be assigned as a source or target node"
           >
             <Button
+              styles={(theme) => ({
+                root: {
+                  color: '#FFFFFF',
+                  backgroundColor: '#337ab7',
+                  '&:hover': {
+                    backgroundColor: '#285a9b',
+                  },
+                },
+              })}
               loading={loading}
               disabled={submitDisabled}
               onClick={() => handleConfirm()}

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
@@ -496,7 +496,7 @@ export function TableColumnAppendForm(props: BaseMenuProps) {
           <Button
             disabled={loading}
             variant="default"
-            color="red"
+            color="primary"
             onClick={() => handleCancel()}
           >
             Cancel
@@ -506,6 +506,15 @@ export function TableColumnAppendForm(props: BaseMenuProps) {
             label="All row values must be valid for it's corrensponding data type.  One column must be assigned as a source or target node"
           >
             <Button
+              styles={(theme) => ({
+                root: {
+                  color: '#FFFFFF',
+                  backgroundColor: '#337ab7',
+                  '&:hover': {
+                    backgroundColor: '#285a9b',
+                  },
+                },
+              })}
               loading={loading}
               disabled={submitDisabled}
               onClick={() => handleConfirm()}


### PR DESCRIPTION
### Criteria
|Item|Normal|Hovered|
|------|------|------|
|Confirm (or other actions with top priority)| <img width="88" alt="image" src="https://github.com/user-attachments/assets/7b23de98-d6bb-4eb8-a22f-81ffa95cce34">|<img width="90" alt="image" src="https://github.com/user-attachments/assets/5140e95a-f419-4a39-b1e6-d7b14b446702">|
|Cancel  (or other actions with second priority)| <img width="84" alt="image" src="https://github.com/user-attachments/assets/caa068df-e235-4215-a38d-0a9060e938f7">| <img width="84" alt="image" src="https://github.com/user-attachments/assets/439454ef-9aaf-432a-8f23-95a595d77cb7">|
| Actions with alert| <img width="78" alt="image" src="https://github.com/user-attachments/assets/733d7525-2559-481f-a868-fd74187dd54b">| <img width="75" alt="image" src="https://github.com/user-attachments/assets/dd28ca3c-2d28-41ce-9093-ad4616f29438">|

### Case I: Confirmation or Choice-Making 
Use this case when prompting users to confirm a decision or choose from available options.

Example I
<img width="200" alt="image" src="https://github.com/user-attachments/assets/7d9a75f5-fc3a-4418-ae4c-79d2170f4d26">

Example II
<img width="500" alt="image" src="https://github.com/user-attachments/assets/90b93000-5b94-4b10-bd92-2fa980aebfc5">


### Case II: Action with Alert (cannot be undone, or actions might result in data loss)
Use this case when actions cannot be undone or may result in data loss.

Example I
<img width="500" alt="image" src="https://github.com/user-attachments/assets/883b6d3e-7425-4419-9bb8-baf39be55cff">

Example II
<img width="500" alt="image" src="https://github.com/user-attachments/assets/bd7fb6a2-04bb-4d0f-8bcb-1dd39a34492f">

### Todo
There is still one place I did not handle well since it uses a different UI library, might discuss with you later @d2fong :
<img width="700" alt="image" src="https://github.com/user-attachments/assets/01521a46-d2ab-4d58-b0db-3294ea7a0995">

