### PR TITLE
Check Adding Service

### DIFF
--- a/src/components/AppManager/ServiceSettingsDialog.tsx
+++ b/src/components/AppManager/ServiceSettingsDialog.tsx
@@ -62,7 +62,11 @@ export const ServiceSettingsDialog = ({
 
     defaultServices.forEach((url: string) => {
       if (!urlSet.has(url)) {
-        addService(url)
+        try {
+          addService(url)
+        } catch (e) {
+          console.error(`Failed to add the service from ${url}. ${e}`)
+        }
       }
     })
   }, [])
@@ -76,12 +80,19 @@ export const ServiceSettingsDialog = ({
     if (trimmedUrl !== '') {
       const serviceApp = serviceApps[trimmedUrl]
       if (serviceApp !== undefined) {
-        setWarningMessage(`The service already registered: ${trimmedUrl}`)
+        setWarningMessage(`The service already registered: \"${trimmedUrl}\".`)
         return
       }
-      await addService(trimmedUrl)
+      try {
+        await addService(trimmedUrl)
+        setWarningMessage('')
+      } catch (e) {
+        setWarningMessage(
+          `Failed to add the service at \"${trimmedUrl}\" due to: ${e.message}.`,
+        )
+        console.error(`Failed to add the service from ${trimmedUrl}. ${e}`)
+      }
       setNewUrl('')
-      setWarningMessage('')
     }
   }
 

--- a/src/store/AppStore.ts
+++ b/src/store/AppStore.ts
@@ -66,16 +66,12 @@ export const useAppStore = create(
         console.warn(`Service app already registered: ${url}`)
         return
       }
-      try {
-        const serviceApp = await serviceFetcher(url)
-        await putServiceAppToDb(serviceApp)
+      const serviceApp = await serviceFetcher(url)
+      await putServiceAppToDb(serviceApp)
 
-        set((state) => {
-          state.serviceApps[url] = serviceApp
-        })
-      } catch (error) {
-        console.error(`Failed to fetch service metadata from ${url}`, error)
-      }
+      set((state) => {
+        state.serviceApps[url] = serviceApp
+      })
     },
 
     removeService: (url: string) => {

--- a/src/utils/service-fetcher.ts
+++ b/src/utils/service-fetcher.ts
@@ -12,6 +12,9 @@ export const serviceFetcher = async (url: string): Promise<ServiceApp> => {
       'Content-Type': 'application/json',
     },
   })
+  if (!response.ok) {
+    throw new Error("Failed to fetch the service metadata.")
+  }
 
   const metadata: ServiceMetadata = await response.json()
   const serviceApp: ServiceApp = {


### PR DESCRIPTION
Ticket: [CW-401](https://cytoscape.atlassian.net/browse/CW-401)

Move the try-catch block to the earliest function in the call chain instead of an intermediate function. Added the following code to check whether the metadata is fetched successfully; otherwise, the try-catch block may be bypassed, even if the fetch fails.

```
if (!response.ok) {
    throw new Error("Failed to fetch the service metadata.")
  }
```

### Example
<img width="500" alt="image" src="https://github.com/user-attachments/assets/78f712f9-6c46-4be8-aee3-7cf4a90ca201">


[CW-401]: https://cytoscape.atlassian.net/browse/CW-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ