### PR TITLE
New Opaque Aspect store

### DIFF
--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -64,6 +64,8 @@ import {
 import { GraphObjectType } from '../../models/NetworkModel'
 import { useFilterStore } from '../../store/FilterStore'
 import { useAppManager } from '../../store/hooks/useAppManager'
+import { NetworkWithView } from '../../models'
+import { useOpaqueAspectStore } from '../../store/OpaqueAspectStore'
 
 const NetworkPanel = lazy(() => import('../NetworkPanel/NetworkPanel'))
 const TableBrowser = lazy(() => import('../TableBrowser/TableBrowser'))
@@ -215,6 +217,7 @@ const WorkSpaceEditor = (): JSX.Element => {
   const addVisualStyle = useVisualStyleStore((state) => state.add)
   const addTable = useTableStore((state) => state.add)
   const addViewModel = useViewModelStore((state) => state.add)
+  const addAllOpaqueAspects = useOpaqueAspectStore((state) => state.addAll)
   const updateNodePositions: (
     networkId: IdType,
     positions: Map<IdType, [number, number, number?]>,
@@ -276,7 +279,11 @@ const WorkSpaceEditor = (): JSX.Element => {
       currentToken,
     )
     const summary = summaryMap[networkId]
-    const res = await useNdexNetwork(networkId, ndexBaseUrl, currentToken)
+    const res: NetworkWithView = await useNdexNetwork(
+      networkId,
+      ndexBaseUrl,
+      currentToken,
+    )
     const {
       network,
       nodeTable,
@@ -284,6 +291,7 @@ const WorkSpaceEditor = (): JSX.Element => {
       visualStyle,
       networkViews,
       visualStyleOptions,
+      otherAspects,
     } = res
 
     setVisualStyleOptions(networkId, visualStyleOptions)
@@ -291,6 +299,9 @@ const WorkSpaceEditor = (): JSX.Element => {
     addVisualStyle(networkId, visualStyle)
     addTable(networkId, nodeTable, edgeTable)
     addViewModel(networkId, networkViews[0])
+    if (otherAspects !== undefined) {
+      addAllOpaqueAspects(networkId, otherAspects)
+    }
 
     if (isHCX(summary)) {
       const version =

--- a/src/models/OpaqueAspectModel/OpaqueAspects.ts
+++ b/src/models/OpaqueAspectModel/OpaqueAspects.ts
@@ -1,0 +1,8 @@
+/**
+ * Generic data object to store opaque aspects
+ * defined in the CX2 model
+ *
+ */
+export interface OpaqueAspects {
+  [key: string]: any[]
+}

--- a/src/models/OpaqueAspectModel/index.ts
+++ b/src/models/OpaqueAspectModel/index.ts
@@ -1,0 +1,1 @@
+export { OpaqueAspects } from './OpaqueAspects'

--- a/src/models/StoreModel/OpaqueAspectStoreModel.ts
+++ b/src/models/StoreModel/OpaqueAspectStoreModel.ts
@@ -1,0 +1,15 @@
+import { OpaqueAspects } from '../OpaqueAspectModel'
+
+export interface OpaqueAspectState {
+  opaqueAspects: OpaqueAspects
+}
+
+export interface OpaqueAspectActions {
+  add: (aspectName: string, aspectData: any[]) => void
+  delete: (aspectName: string) => void
+  deleteAll: () => void
+
+  update: (aspectName: string, aspectData: any[]) => void
+}
+
+export type OpaqueAspectStoreModel = OpaqueAspectState & OpaqueAspectActions

--- a/src/models/StoreModel/OpaqueAspectStoreModel.ts
+++ b/src/models/StoreModel/OpaqueAspectStoreModel.ts
@@ -1,15 +1,28 @@
+import { IdType } from '../IdType'
 import { OpaqueAspects } from '../OpaqueAspectModel'
 
 export interface OpaqueAspectState {
-  opaqueAspects: OpaqueAspects
+  opaqueAspects: Record<IdType, OpaqueAspects>
 }
 
 export interface OpaqueAspectActions {
-  add: (aspectName: string, aspectData: any[]) => void
-  delete: (aspectName: string) => void
+  add: (networkId: IdType, aspectName: string, aspectData: any[]) => void
+
+  // Add multiple aspects to the store at once
+  addAll: (networkId: IdType, aspectList: Record<string, any[]>[]) => void
+
+  // Delete the entry from the store
+  delete: (networkId: IdType) => void
+
+  deleteSingleAspect: (networkId: IdType, aspectName: string) => void
+
+  // Delete all aspects for all networks
   deleteAll: () => void
 
-  update: (aspectName: string, aspectData: any[]) => void
+  // Clear all aspects for the given network
+  clearAspects: (networkId: IdType) => void
+
+  update: (networkId: IdType, aspectName: string, aspectData: any[]) => void
 }
 
 export type OpaqueAspectStoreModel = OpaqueAspectState & OpaqueAspectActions

--- a/src/store/OpaqueAspectStore.ts
+++ b/src/store/OpaqueAspectStore.ts
@@ -1,31 +1,105 @@
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 import { OpaqueAspectStoreModel } from '../models/StoreModel/OpaqueAspectStoreModel'
+import { IdType } from '../models'
+import { deleteOpaqueAspectsFromDb, putOpaqueAspectsToDb } from './persist/db'
+import { clear } from 'idb-keyval'
 
 export const useOpaqueAspectStore = create(
   immer<OpaqueAspectStoreModel>((set) => ({
     opaqueAspects: {},
-    add: (aspectName, aspectData) => {
+    add: (networkId: IdType, aspectName: string, aspectData: any[]) => {
       set((state) => {
-        state.opaqueAspects[aspectName] = aspectData
+        if (!state.opaqueAspects[networkId]) {
+          state.opaqueAspects[networkId] = {}
+        }
+        state.opaqueAspects[networkId][aspectName] = aspectData
+        void putOpaqueAspectsToDb(
+          networkId,
+          state.opaqueAspects[networkId],
+        ).then(() => {
+          console.debug(
+            'DB Update: opaque aspects store',
+            state.opaqueAspects[networkId],
+          )
+        })
         return state
       })
     },
-    delete: (aspectName) => {
+    addAll: (networkId: IdType, aspects: Record<string, any[]>[]) => {
       set((state) => {
-        delete state.opaqueAspects[aspectName]
+        if (!state.opaqueAspects[networkId]) {
+          state.opaqueAspects[networkId] = {}
+        }
+        aspects.forEach((aspect) => {
+          const [aspectName, aspectData] = Object.entries(aspect)[0]
+          state.opaqueAspects[networkId][aspectName] = aspectData
+        })
+        void putOpaqueAspectsToDb(
+          networkId,
+          state.opaqueAspects[networkId],
+        ).then(() => {
+          console.debug('DB Update: opaque aspects store')
+        })
+        return state
+      })
+    },
+    delete: (networkId: IdType) => {
+      if (networkId === undefined) {
+        return
+      }
+      set((state) => {
+        delete state.opaqueAspects[networkId]
+        return state
+      })
+      void deleteOpaqueAspectsFromDb(networkId).then(() => {
+        console.debug('DB Delete: opaque aspect for the network', networkId)
+      })
+    },
+    deleteSingleAspect: (networkId: IdType, aspectName: string) => {
+      set((state) => {
+        if (state.opaqueAspects[networkId]) {
+          delete state.opaqueAspects[networkId][aspectName]
+        }
+        void putOpaqueAspectsToDb(
+          networkId,
+          state.opaqueAspects[networkId],
+        ).then(() => {
+          console.debug('DB Update: opaque aspects store')
+        })
+        return state
+      })
+    },
+    clearAspects: (networkId: string) => {
+      set((state) => {
+        state.opaqueAspects[networkId] = {}
+        void putOpaqueAspectsToDb(networkId, {}).then(() => {
+          console.debug('DB Update: opaque aspects cleared for ', networkId)
+        })
         return state
       })
     },
     deleteAll: () => {
       set((state) => {
         state.opaqueAspects = {}
+        void clear().then(() => {
+          console.debug('DB Clear: opaque aspects')
+        })
         return state
       })
     },
-    update: (aspectName, aspectData) => {
+    update: (networkId: IdType, aspectName: string, aspectData: any[]) => {
       set((state) => {
-        state.opaqueAspects[aspectName] = [...aspectData]
+        if (!state.opaqueAspects[networkId]) {
+          state.opaqueAspects[networkId] = {}
+        }
+        state.opaqueAspects[networkId][aspectName] = [...aspectData]
+        void putOpaqueAspectsToDb(
+          networkId,
+          state.opaqueAspects[networkId],
+        ).then(() => {
+          console.debug('DB Update: opaque aspects updated for ', networkId)
+        })
         return state
       })
     },

--- a/src/store/OpaqueAspectStore.ts
+++ b/src/store/OpaqueAspectStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { OpaqueAspectStoreModel } from '../models/StoreModel/OpaqueAspectStoreModel'
+
+export const useOpaqueAspectStore = create(
+  immer<OpaqueAspectStoreModel>((set) => ({
+    opaqueAspects: {},
+    add: (aspectName, aspectData) => {
+      set((state) => {
+        state.opaqueAspects[aspectName] = aspectData
+        return state
+      })
+    },
+    delete: (aspectName) => {
+      set((state) => {
+        delete state.opaqueAspects[aspectName]
+        return state
+      })
+    },
+    deleteAll: () => {
+      set((state) => {
+        state.opaqueAspects = {}
+        return state
+      })
+    },
+    update: (aspectName, aspectData) => {
+      set((state) => {
+        state.opaqueAspects[aspectName] = [...aspectData]
+        return state
+      })
+    },
+  })),
+)

--- a/src/store/hooks/useNdexNetwork.ts
+++ b/src/store/hooks/useNdexNetwork.ts
@@ -36,6 +36,7 @@ export const useNdexNetwork = async (
         visualStyle: cache.visualStyle,
         networkViews: cache.networkViews,
         visualStyleOptions: cache.visualStyleOptions,
+        otherAspects: cache.otherAspects,
       }
     }
   } catch (error) {

--- a/src/store/hooks/useWorkspaceManager.ts
+++ b/src/store/hooks/useWorkspaceManager.ts
@@ -8,6 +8,7 @@ import { useVisualStyleStore } from '../VisualStyleStore'
 import { useWorkspaceStore } from '../WorkspaceStore'
 import { useUiStateStore } from '../UiStateStore'
 import { useHcxValidatorStore } from '../../features/HierarchyViewer/store/HcxValidatorStore'
+import { useOpaqueAspectStore } from '../OpaqueAspectStore'
 
 /**
  * Based on the changes in the workspace store, this hook will
@@ -28,6 +29,7 @@ export const useWorkspaceManager = (): void => {
   const deleteAllViews = useViewModelStore((state) => state.deleteAll)
   const deleteAllVisualStyles = useVisualStyleStore((state) => state.deleteAll)
   const deleteAllTables = useTableStore((state) => state.deleteAll)
+  const deleteAspects = useOpaqueAspectStore((state) => state.delete)
   const deleteNetworkModifiedStatus = useWorkspaceStore(
     (state) => state.deleteNetworkModifiedStatus,
   )
@@ -59,6 +61,7 @@ export const useWorkspaceManager = (): void => {
     deleteVisualStyle(deleted)
     deleteTables(deleted)
     deleteNetworkModifiedStatus(deleted)
+    deleteAspects(deleted)
 
     if (activeNetworkView === deleted) {
       setActiveNetworkView('')

--- a/src/utils/CachedData.ts
+++ b/src/utils/CachedData.ts
@@ -11,4 +11,5 @@ export interface CachedData {
   visualStyle?: VisualStyle
   networkViews?: NetworkView[]
   visualStyleOptions?: VisualStyleOptions
+  otherAspects?: any[]
 }


### PR DESCRIPTION
The CX2 reader now register optional opaque aspects to its data store. It can be accessible via _useOpaqueAspectsStore_.

Also, this change includes a new entry in the DB schema, and its version has been updated to v4.