### PR TITLE
Disable the layout menu items when the workspace is empty

### DIFF
--- a/src/components/ToolBar/LayoutMenu/LayoutOptionDialog.tsx
+++ b/src/components/ToolBar/LayoutMenu/LayoutOptionDialog.tsx
@@ -39,6 +39,7 @@ interface LayoutOptionDialogProps {
   network: Network
   open: boolean
   setOpen: (open: boolean) => void
+  allDisabled: boolean
 }
 
 export const LayoutOptionDialog = ({
@@ -46,6 +47,7 @@ export const LayoutOptionDialog = ({
   afterLayout,
   open,
   setOpen,
+  allDisabled,
 }: LayoutOptionDialogProps): JSX.Element => {
   const preferredLayout: LayoutAlgorithm = useLayoutStore(
     (state) => state.preferredLayout,
@@ -153,6 +155,8 @@ export const LayoutOptionDialog = ({
 
   return (
     <Dialog
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
       open={open}
       onClose={handleClose}
       PaperComponent={DraggablePaper}
@@ -221,7 +225,7 @@ export const LayoutOptionDialog = ({
           Close
         </Button>
         <Button
-          disabled={disabled}
+          disabled={allDisabled || disabled}
           onClick={handleApply}
           sx={{
             color: '#FFFFFF',

--- a/src/components/ToolBar/LayoutMenu/index.tsx
+++ b/src/components/ToolBar/LayoutMenu/index.tsx
@@ -63,9 +63,10 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
 
   //disable layouts for cell view, meaning
   const disabled =
-    isHCX(summary) && // the current network is a hierarchy
-    currentNetworkId === targetNetworkId && // the hierarchy network is the active view
-    cellViewIsSelected // the cell view tab is selected
+    (isHCX(summary) && // the current network is a hierarchy
+      currentNetworkId === targetNetworkId && // the hierarchy network is the active view
+      cellViewIsSelected) || // the cell view tab is selected
+    targetNetworkId === '' // no network is selected
 
   const { label } = props
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)

--- a/src/components/ToolBar/LayoutMenu/index.tsx
+++ b/src/components/ToolBar/LayoutMenu/index.tsx
@@ -1,6 +1,5 @@
 import Button from '@mui/material/Button'
-import Menu from '@mui/material/Menu'
-import { Box, Divider, MenuItem, Tooltip } from '@mui/material'
+import { Box, Divider, Tooltip, MenuItem } from '@mui/material'
 import { useRef, useState } from 'react'
 import { LayoutEngine } from '../../../models/LayoutModel/LayoutEngine'
 import { useViewModelStore } from '../../../store/ViewModelStore'
@@ -61,8 +60,8 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
 
   const cellViewIsSelected = activeNetworkViewTabIndex === 1
 
-  //disable layouts for cell view, meaning
-  const disabled =
+  //disable all the layout menu items
+  const allDisabled =
     (isHCX(summary) && // the current network is a hierarchy
       currentNetworkId === targetNetworkId && // the hierarchy network is the active view
       cellViewIsSelected) || // the cell view tab is selected
@@ -72,21 +71,18 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
 
-  const handleOpenDropdownMenu = (
-    event: React.MouseEvent<HTMLButtonElement>,
-  ): void => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const op = useRef(null)
+  const menuRef = useRef(null)
 
   const handleClose = (): void => {
-    ;(op.current as any)?.hide()
     setAnchorEl(null)
+    const menuRefCurrent = menuRef.current as any
+    menuRefCurrent.hide()
   }
 
   const handleOpenDialog = (open: boolean): void => {
     setAnchorEl(null)
+    const menuRefCurrent = menuRef.current as any
+    menuRefCurrent.hide()
     setOpenDialog(open)
   }
 
@@ -131,30 +127,53 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
     })
 
     return [
-      ...layoutMenuItems.map((menuItem: any) => {
-        return {
-          label: menuItem.label,
-          template: (
-            <Tooltip
-              arrow
-              placement={'right'}
-              title={menuItem.description}
-              key={menuItem.key}
-            >
-              <MenuItem
+      ...(allDisabled
+        ? [
+            {
+              label: '',
+              template: (
+                <Tooltip
+                  arrow
+                  placement="right"
+                  title={
+                    targetNetworkId === ''
+                      ? 'Layouts are disabled since the network view is empty'
+                      : 'Layouts cannot be applied to the current network view'
+                  }
+                >
+                  <Box>
+                    {layoutMenuItems.map((menuItem: any) => (
+                      <MenuItem key={menuItem.key} disabled={true}>
+                        {menuItem.label}
+                      </MenuItem>
+                    ))}
+                  </Box>
+                </Tooltip>
+              ),
+            },
+          ]
+        : layoutMenuItems.map((menuItem: any) => ({
+            label: menuItem.label,
+            template: (
+              <Tooltip
+                arrow
+                placement={'right'}
+                title={menuItem.description}
                 key={menuItem.key}
-                disabled={menuItem.disabled}
-                onClick={() => {
-                  handleClose()
-                  menuItem.onClick()
-                }}
               >
-                {menuItem.label}
-              </MenuItem>
-            </Tooltip>
-          ),
-        }
-      }),
+                <MenuItem
+                  key={menuItem.key}
+                  disabled={menuItem.disabled}
+                  onClick={() => {
+                    handleClose()
+                    menuItem.onClick()
+                  }}
+                >
+                  {menuItem.label}
+                </MenuItem>
+              </Tooltip>
+            ),
+          }))),
       {
         label: '',
         template: <Divider />,
@@ -162,7 +181,12 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
       {
         label: 'Settings...',
         template: (
-          <MenuItem onClick={() => handleOpenDialog(true)}>
+          <MenuItem
+            onClick={() => {
+              handleClose()
+              handleOpenDialog(true)
+            }}
+          >
             Settings...
           </MenuItem>
         ),
@@ -170,45 +194,28 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
     ]
   }
 
-  const innerButton = disabled ? (
-    <Tooltip title="Layouts cannot be applied to the current network view">
-      <Box>
-        <Button
-          sx={{
-            color: 'white',
-            textTransform: 'none',
-          }}
-          id={label}
-          aria-controls={open ? 'basic-menu' : undefined}
-          aria-haspopup="true"
-          aria-expanded={open ? 'true' : undefined}
-          onClick={(e) => (op.current as any)?.toggle(e)}
-          disabled
-        >
-          {label}
-        </Button>
-      </Box>
-    </Tooltip>
-  ) : (
-    <Button
-      sx={{
-        color: 'white',
-        textTransform: 'none',
-      }}
-      id={label}
-      aria-controls={open ? 'basic-menu' : undefined}
-      aria-haspopup="true"
-      aria-expanded={open ? 'true' : undefined}
-      onClick={(e) => (op.current as any)?.toggle(e)}
-    >
-      {label}
-    </Button>
-  )
-
   return (
     <PrimeReactProvider>
-      {innerButton}
-      <OverlayPanel ref={op} unstyled>
+      <Button
+        sx={{
+          color: 'white',
+          textTransform: 'none',
+        }}
+        id={label}
+        aria-controls={open ? 'basic-menu' : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : undefined}
+        onClick={(e) => {
+          if (menuRef.current === null) {
+            return
+          }
+          const menuRefCurrent = menuRef.current as any
+          menuRefCurrent.toggle(e)
+        }}
+      >
+        {label}
+      </Button>
+      <OverlayPanel ref={menuRef} unstyled>
         <TieredMenu model={getMenuItems()} />
       </OverlayPanel>
       <LayoutOptionDialog
@@ -216,6 +223,7 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
         network={target}
         open={openDialog}
         setOpen={setOpenDialog}
+        allDisabled={allDisabled}
       />
     </PrimeReactProvider>
   )

--- a/src/features/LLMQuery/components/RunLLMQueryMenuItem.tsx
+++ b/src/features/LLMQuery/components/RunLLMQueryMenuItem.tsx
@@ -1,4 +1,5 @@
 import { MenuItem, Tooltip, Box } from '@mui/material'
+import { Menu } from 'primereact/menu'
 import { ReactElement, useContext } from 'react'
 import { BaseMenuProps } from '../../../components/ToolBar/BaseMenuProps'
 import { IdType } from '../../../models/IdType'
@@ -188,7 +189,7 @@ export const RunLLMQueryMenuItem = (props: BaseMenuProps): ReactElement => {
         ? 'Enter your Open AI API key in the Analysis -> LLM Query Options menu item to run LLM queries'
         : 'LLM query is only available for HCX networks'
     return (
-      <Tooltip title={tooltipTitle}>
+      <Tooltip arrow title={tooltipTitle} placement="right">
         <Box>{menuItem}</Box>
       </Tooltip>
     )


### PR DESCRIPTION
Jira Ticket: [CW-413](https://cytoscape.atlassian.net/browse/CW-413)

- Disable the layout menu items when the workspace is empty
- Always enable the root menu button and only disable the layout menu items when necessary (users can have access to the layout settings)

[CW-413]: https://cytoscape.atlassian.net/browse/CW-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ