### PR TITLE
New UI state for custom tab name has been added.

### DIFF
--- a/src/components/NetworkPanel/NetworkTabs.tsx
+++ b/src/components/NetworkPanel/NetworkTabs.tsx
@@ -27,6 +27,10 @@ export const NetworkTabs = ({
   )
   const setSelected = useUiStateStore((state) => state.setNetworkViewTabIndex)
 
+  const customNetworkTabName = useUiStateStore(
+    (state) => state.ui.customNetworkTabName,
+  )
+
   const boxRef = useRef<HTMLDivElement>(null)
   const [boxSize, setBoxSize] = useState<{ w: number; h: number }>({
     w: 0,
@@ -87,9 +91,16 @@ export const NetworkTabs = ({
           onChange={handleChange}
         >
           {rendererList.map((renderer: Renderer, index: number) => {
-            return (
-              <Tab sx={{ height: '40px' }} key={index} label={renderer.name} />
-            )
+            let label: string = renderer.name ?? 'Renderer'
+            if (customNetworkTabName !== undefined) {
+              if (
+                customNetworkTabName[renderer.id] !== undefined &&
+                customNetworkTabName[renderer.id] !== ''
+              ) {
+                label = customNetworkTabName[renderer.id]
+              }
+            }
+            return <Tab sx={{ height: '40px' }} key={index} label={label} />
           })}
         </Tabs>
       </Box>

--- a/src/features/HierarchyViewer/components/MainPanel.tsx
+++ b/src/features/HierarchyViewer/components/MainPanel.tsx
@@ -24,6 +24,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import FilterPanel from './FilterPanel/FilterPanel'
 import { DuplicateNodeSeparator } from './CustomLayout/DataBuilderUtil'
 import { useSubNetworkStore } from '../store/SubNetworkStore'
+import { useUiStateStore } from '../../../store/UiStateStore'
+import { use } from 'cytoscape'
+import { DEFAULT_RENDERER_ID } from '../../../store/DefaultRenderer'
 
 export const RENDERER_TAG: string = 'secondary'
 export interface Query {
@@ -72,6 +75,17 @@ export const MainPanel = (): JSX.Element => {
   const setRootNetworkHost = useSubNetworkStore(
     (state) => state.setRootNetworkHost,
   )
+  const setCustomNetworkTabName = useUiStateStore(
+    (state) => state.setCustomNetworkTabName,
+  )
+
+  useEffect(() => {
+    setCustomNetworkTabName(DEFAULT_RENDERER_ID, 'Tree View')
+    // clear the name when the component is unmounted
+    return () => {
+      setCustomNetworkTabName(DEFAULT_RENDERER_ID, '')
+    }
+  }, [])
 
   const CirclePackingRenderer: Renderer = {
     id: CP_RENDERER_ID,

--- a/src/models/StoreModel/UiStateStoreModel.ts
+++ b/src/models/StoreModel/UiStateStoreModel.ts
@@ -34,6 +34,8 @@ export interface UiStateAction {
     arrowColorMatchesEdge: boolean,
   ) => void
   setNetworkViewTabIndex: (index: number) => void
+
+  setCustomNetworkTabName: (rendererId: IdType, name: string) => void
 }
 
 export type UiStateStore = UiState & UiStateAction

--- a/src/models/UiModel/Ui.ts
+++ b/src/models/UiModel/Ui.ts
@@ -33,4 +33,7 @@ export interface Ui {
   // Visual editor properties
   visualStyleOptions: Record<IdType, VisualStyleOptions>
   networkViewUi: NetworkViewUIState
+
+  // Custom network tab name
+  customNetworkTabName?: Record<string, string>
 }

--- a/src/store/UiStateStore.ts
+++ b/src/store/UiStateStore.ts
@@ -238,5 +238,14 @@ export const useUiStateStore = create(
         return state
       })
     },
+    setCustomNetworkTabName: (rendererId: IdType, name: string) => {
+      set((state) => {
+        if (!state.ui.customNetworkTabName) {
+          state.ui.customNetworkTabName = {}
+        }
+        state.ui.customNetworkTabName[rendererId] = name
+        return state
+      })
+    },
   })),
 )


### PR DESCRIPTION
When multiple views are available, the developers can set custom tab name if they need. For now, it is used by the hierarchy viewer and it sets network tab name to "Tree View."