### PR TITLE
Continuous mapping values fix

### DIFF
--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ColorGradient.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ColorGradient.tsx
@@ -3,6 +3,8 @@ import { Box } from '@mui/material'
 import { color } from 'd3-color'
 import { AxisBottom } from '@visx/axis'
 import { ScaleLinear } from 'd3-scale'
+import { ContinuousMappingFunction, ValueType } from 'src/models'
+import { getMapper } from '../../../../../models/VisualStyleModel/impl/MapperFactory'
 
 export interface ColorGradiientProps {
   numSteps: number
@@ -14,6 +16,7 @@ export interface ColorGradiientProps {
   verticalPadding: number
   valuePixelScale: ScaleLinear<number, number>
   colorScale: ScaleLinear<string, string>
+  cm: ContinuousMappingFunction
 }
 
 export function ColorGradient(props: ColorGradiientProps): React.ReactElement {
@@ -27,7 +30,10 @@ export function ColorGradient(props: ColorGradiientProps): React.ReactElement {
     verticalPadding,
     valuePixelScale,
     colorScale,
+    cm,
   } = props
+
+  const mapper = getMapper(cm)
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -35,7 +41,9 @@ export function ColorGradient(props: ColorGradiientProps): React.ReactElement {
         .fill(0)
         .map((_, i) => {
           const value = valuePixelScale.invert(i * stepWidth)
-          const stepColor = color(colorScale(value))?.formatHex() ?? '#000000'
+          const stepColor =
+            color(mapper(value as ValueType) as string)?.formatHex() ??
+            '#000000'
 
           return (
             <Box

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -669,8 +669,13 @@ export function ContinuousColorMappingForm(props: {
                   const gradientPositionX =
                     e.clientX - e.currentTarget.getBoundingClientRect().x
 
-                  const newHandleValue =
-                    valuePixelScale.invert(gradientPositionX)
+                  const newHandleValue = Math.max(
+                    minState.value as number,
+                    Math.min(
+                      valuePixelScale.invert(gradientPositionX),
+                      maxState.value as number,
+                    ),
+                  )
                   const newHandleVpValue =
                     color(colorScale(newHandleValue))?.formatHex() ?? '#000000'
 

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -51,6 +51,7 @@ import { Handle, addHandle, editHandle, removeHandle } from './Handle'
 import FormGroup from '@mui/material/FormGroup'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Checkbox from '@mui/material/Checkbox'
+import { MantineProvider, NumberInput } from '@mantine/core'
 
 // color mapping form for now
 export function ContinuousColorMappingForm(props: {
@@ -377,625 +378,557 @@ export function ContinuousColorMappingForm(props: {
   }, [maxState])
 
   return (
-    <Paper sx={{ backgroundColor: '#D9D9D9', pb: 2 }}>
-      <Paper
-        sx={{
-          display: 'flex',
-          p: 1,
-          m: 1,
-          ml: 3,
-          mr: 3,
-          justifyContent: 'center',
-          backgroundColor: '#fcfffc',
-          color: '#595858',
-        }}
-      >
-        Current Palette:&ensp;
-        <Button
-          onClick={showColorPickerMenu}
-          variant="outlined"
-          sx={{ color: '#63a5e8' }}
-          size="small"
-          startIcon={<Palette />}
-        >
-          {buttonText}
-        </Button>
-        <Popover
-          open={createColorPickerAnchorEl != null}
-          anchorEl={createColorPickerAnchorEl}
-          onClose={hideColorPickerMenu}
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-        >
-          <Typography align={'center'} sx={{ p: 1 }}>
-            Set Palette
-          </Typography>
-          <ToggleButtonGroup
-            value={colorPalette}
-            onChange={handleColorPalette}
-            orientation="horizontal"
-            exclusive
-            fullWidth={true}
-          >
-            <ToggleButton
-              value="rdbu"
-              aria-label="RdBu"
-              onClick={() => {
-                setMinPalette('#b2182b')
-                setMiddlePalette('#f7f7f7')
-                setMaxPalette('#2166ac')
-                setTextPalette('Red-Blue')
-              }}
-            >
-              <Tooltip title="Red-Blue" placement="right">
-                <img src={RdBu} width="15" height="150" />
-              </Tooltip>
-            </ToggleButton>
-
-            <ToggleButton
-              value="puor"
-              aria-label="PuOr"
-              onClick={() => {
-                setMinPalette('#542788')
-                setMiddlePalette('#f7f7f7')
-                setMaxPalette('#b35806')
-                setTextPalette('Purple-Orange')
-              }}
-            >
-              <Tooltip title="Purple-Orange" placement="right">
-                <img src={PuOr} width="15" height="150" />
-              </Tooltip>
-            </ToggleButton>
-
-            <ToggleButton
-              value="prgn"
-              aria-label="PRGn"
-              onClick={() => {
-                setMinPalette('#762a83')
-                setMiddlePalette('#f7f7f7')
-                setMaxPalette('#1b7837')
-                setTextPalette('Purple-Red-Green')
-              }}
-            >
-              <Tooltip title="Purple-Red-Green" placement="right">
-                <img src={PRGn} width="15" height="150" />
-              </Tooltip>
-            </ToggleButton>
-
-            {!isColorBlindChecked && (
-              <ToggleButton
-                value="spectral"
-                aria-label="Spectral"
-                onClick={() => {
-                  setMinPalette('#d53e4f')
-                  setMiddlePalette('#ffffbf')
-                  setMaxPalette('#3288bd')
-                  setTextPalette('Spectral Colors')
-                }}
-              >
-                <Tooltip title="Spectral Colors" placement="right">
-                  <img src={Spectral} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-            )}
-
-            <ToggleButton
-              value="brbg"
-              aria-label="BrBG"
-              onClick={() => {
-                setMinPalette('#8c510a')
-                setMiddlePalette('#f5f5f5')
-                setMaxPalette('#01665e')
-                setTextPalette('Brown-Blue-Green')
-              }}
-            >
-              <Tooltip title="Brown-Blue-Green" placement="right">
-                <img src={BrBG} width="15" height="150" />
-              </Tooltip>
-            </ToggleButton>
-
-            {!isColorBlindChecked && (
-              <ToggleButton
-                value="rdylgn"
-                aria-label="RdYlGn"
-                onClick={() => {
-                  setMinPalette('#d73027')
-                  setMiddlePalette('#ffffbf')
-                  setMaxPalette('#1a9850')
-                  setTextPalette('Red-Yellow-Green')
-                }}
-              >
-                <Tooltip title="Red-Yellow-Green" placement="right">
-                  <img src={RdYlGn} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-            )}
-
-            <ToggleButton
-              value="piyg"
-              aria-label="PiYG"
-              onClick={() => {
-                setMinPalette('#c51b7d')
-                setMiddlePalette('#f7f7f7')
-                setMaxPalette('#4d9221')
-                setTextPalette('Magenta-Yellow-Green')
-              }}
-            >
-              <Tooltip title="Magenta-Yellow-Green" placement="right">
-                <img src={PiYG} width="15" height="150" />
-              </Tooltip>
-            </ToggleButton>
-
-            {!isColorBlindChecked && (
-              <ToggleButton
-                value="rdgy"
-                aria-label="RdGy"
-                onClick={() => {
-                  setMinPalette('#b2182b')
-                  setMiddlePalette('#ffffff')
-                  setMaxPalette('#4d4d4d')
-                  setTextPalette('Red-Grey')
-                }}
-              >
-                <Tooltip title="Red-Grey" placement="right">
-                  <img src={RdGy} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-            )}
-
-            <ToggleButton
-              value="rdylbu"
-              aria-label="RdYlBu"
-              onClick={() => {
-                setMinPalette('#d73027')
-                setMiddlePalette('#ffffbf')
-                setMaxPalette('#4575b4')
-                setTextPalette('Red-Yellow-Blue')
-              }}
-            >
-              <Tooltip title="Red-Yellow-Blue" placement="right">
-                <img src={RdYlBu} width="15" height="150" />
-              </Tooltip>
-            </ToggleButton>
-          </ToggleButtonGroup>
-
-          <Paper
-            sx={{
-              display: 'flex',
-              p: 1,
-              m: 1,
-              ml: 3,
-              mr: 3,
-              justifyContent: 'space-evenly',
-              backgroundColor: '#fcfffc',
-              color: '#595858',
-            }}
-          >
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={isReverseColorChecked}
-                    onChange={handleReverseColorCheckboxChange}
-                  />
-                }
-                label="reverse colors"
-              />
-            </FormGroup>
-            <FormGroup>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={isColorBlindChecked}
-                    onChange={handleColorBlindCheckboxChange}
-                  />
-                }
-                label="colorblind-friendly"
-              />
-            </FormGroup>
-          </Paper>
-          <Paper
-            sx={{
-              display: 'flex',
-              p: 1,
-              m: 1,
-              ml: 3,
-              mr: 3,
-              justifyContent: 'space-evenly',
-              backgroundColor: '#fcfffc',
-              color: '#595858',
-            }}
-          >
-            <Button
-              variant="outlined"
-              onClick={() => {
-                handleColorPicker()
-              }}
-              size="small"
-            >
-              Ok
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={() => {
-                hideColorPickerMenu()
-              }}
-              size="small"
-            >
-              Cancel
-            </Button>
-          </Paper>
-        </Popover>
-      </Paper>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          pt: 11.5,
-          mb: 3,
-          justifyContent: 'center',
-        }}
-      >
+    <MantineProvider>
+      <Paper sx={{ backgroundColor: '#D9D9D9', pb: 2 }}>
         <Paper
           sx={{
             display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            position: 'relative',
-            userSelect: 'none',
-            pb: 6,
+            p: 1,
+            m: 1,
+            ml: 3,
+            mr: 3,
+            justifyContent: 'center',
+            backgroundColor: '#fcfffc',
+            color: '#595858',
           }}
-          elevation={4}
         >
-          <Box sx={{ p: 1.5 }}>
-            <Tooltip
-              title="Click to add new handle"
-              placement="top"
-              followCursor
+          Current Palette:&ensp;
+          <Button
+            onClick={showColorPickerMenu}
+            variant="outlined"
+            sx={{ color: '#63a5e8' }}
+            size="small"
+            startIcon={<Palette />}
+          >
+            {buttonText}
+          </Button>
+          <Popover
+            open={createColorPickerAnchorEl != null}
+            anchorEl={createColorPickerAnchorEl}
+            onClose={hideColorPickerMenu}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <Typography align={'center'} sx={{ p: 1 }}>
+              Set Palette
+            </Typography>
+            <ToggleButtonGroup
+              value={colorPalette}
+              onChange={handleColorPalette}
+              orientation="horizontal"
+              exclusive
+              fullWidth={true}
             >
-              <Paper
-                sx={{
-                  display: 'flex',
-                  position: 'relative',
-                  '&:hover': { cursor: 'copy' },
-                }}
-                onClickCapture={(e) => {
-                  const gradientPositionX =
-                    e.clientX - e.currentTarget.getBoundingClientRect().x
-
-                  const newHandleValue =
-                    valuePixelScale.invert(gradientPositionX)
-                  const newHandleVpValue =
-                    color(colorScale(newHandleValue))?.formatHex() ?? '#000000'
-
-                  createHandle(newHandleValue, newHandleVpValue)
+              <ToggleButton
+                value="rdbu"
+                aria-label="RdBu"
+                onClick={() => {
+                  setMinPalette('#b2182b')
+                  setMiddlePalette('#f7f7f7')
+                  setMaxPalette('#2166ac')
+                  setTextPalette('Red-Blue')
                 }}
               >
-                <ColorGradient
-                  numSteps={NUM_GRADIENT_STEPS}
-                  stepWidth={GRADIENT_STEP_WIDTH}
-                  height={GRADIENT_HEIGHT}
-                  domainLabel={m.attribute}
-                  axisOffsetLeft={GRADIENT_AXIS_OFFSET_LEFT}
-                  horizontalPadding={GRADIENT_AXIS_HORIZONTAL_PADDING}
-                  verticalPadding={GRADIENT_AXIS_VERTICAL_PADDING}
-                  valuePixelScale={valuePixelScale}
-                  colorScale={colorScale}
-                />
-              </Paper>
-            </Tooltip>
-            {handles.map((h) => {
-              return (
-                <Draggable
-                  key={h.id}
-                  bounds="parent"
-                  axis="x"
-                  handle=".handle"
-                  onStart={(e) => {
-                    setlastDraggedHandleId(h.id)
-                  }}
-                  onStop={(e) => {
-                    setlastDraggedHandleId(h.id)
-                  }}
-                  onDrag={(e, data) => {
-                    const newValue = valuePixelScale.invert(data.x)
-                    setHandle(h.id, newValue, h.vpValue as string)
-                  }}
-                  position={{
-                    x: valuePixelScale(h.value as number),
-                    y: 0,
+                <Tooltip title="Red-Blue" placement="right">
+                  <img src={RdBu} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+
+              <ToggleButton
+                value="puor"
+                aria-label="PuOr"
+                onClick={() => {
+                  setMinPalette('#542788')
+                  setMiddlePalette('#f7f7f7')
+                  setMaxPalette('#b35806')
+                  setTextPalette('Purple-Orange')
+                }}
+              >
+                <Tooltip title="Purple-Orange" placement="right">
+                  <img src={PuOr} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+
+              <ToggleButton
+                value="prgn"
+                aria-label="PRGn"
+                onClick={() => {
+                  setMinPalette('#762a83')
+                  setMiddlePalette('#f7f7f7')
+                  setMaxPalette('#1b7837')
+                  setTextPalette('Purple-Red-Green')
+                }}
+              >
+                <Tooltip title="Purple-Red-Green" placement="right">
+                  <img src={PRGn} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+
+              {!isColorBlindChecked && (
+                <ToggleButton
+                  value="spectral"
+                  aria-label="Spectral"
+                  onClick={() => {
+                    setMinPalette('#d53e4f')
+                    setMiddlePalette('#ffffbf')
+                    setMaxPalette('#3288bd')
+                    setTextPalette('Spectral Colors')
                   }}
                 >
-                  <Box
-                    sx={{
-                      width: 2,
-                      height: 1,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      position: 'absolute',
-                      zIndex: lastDraggedHandleId === h.id ? 3 : 1,
+                  <Tooltip title="Spectral Colors" placement="right">
+                    <img src={Spectral} width="15" height="150" />
+                  </Tooltip>
+                </ToggleButton>
+              )}
+
+              <ToggleButton
+                value="brbg"
+                aria-label="BrBG"
+                onClick={() => {
+                  setMinPalette('#8c510a')
+                  setMiddlePalette('#f5f5f5')
+                  setMaxPalette('#01665e')
+                  setTextPalette('Brown-Blue-Green')
+                }}
+              >
+                <Tooltip title="Brown-Blue-Green" placement="right">
+                  <img src={BrBG} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+
+              {!isColorBlindChecked && (
+                <ToggleButton
+                  value="rdylgn"
+                  aria-label="RdYlGn"
+                  onClick={() => {
+                    setMinPalette('#d73027')
+                    setMiddlePalette('#ffffbf')
+                    setMaxPalette('#1a9850')
+                    setTextPalette('Red-Yellow-Green')
+                  }}
+                >
+                  <Tooltip title="Red-Yellow-Green" placement="right">
+                    <img src={RdYlGn} width="15" height="150" />
+                  </Tooltip>
+                </ToggleButton>
+              )}
+
+              <ToggleButton
+                value="piyg"
+                aria-label="PiYG"
+                onClick={() => {
+                  setMinPalette('#c51b7d')
+                  setMiddlePalette('#f7f7f7')
+                  setMaxPalette('#4d9221')
+                  setTextPalette('Magenta-Yellow-Green')
+                }}
+              >
+                <Tooltip title="Magenta-Yellow-Green" placement="right">
+                  <img src={PiYG} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+
+              {!isColorBlindChecked && (
+                <ToggleButton
+                  value="rdgy"
+                  aria-label="RdGy"
+                  onClick={() => {
+                    setMinPalette('#b2182b')
+                    setMiddlePalette('#ffffff')
+                    setMaxPalette('#4d4d4d')
+                    setTextPalette('Red-Grey')
+                  }}
+                >
+                  <Tooltip title="Red-Grey" placement="right">
+                    <img src={RdGy} width="15" height="150" />
+                  </Tooltip>
+                </ToggleButton>
+              )}
+
+              <ToggleButton
+                value="rdylbu"
+                aria-label="RdYlBu"
+                onClick={() => {
+                  setMinPalette('#d73027')
+                  setMiddlePalette('#ffffbf')
+                  setMaxPalette('#4575b4')
+                  setTextPalette('Red-Yellow-Blue')
+                }}
+              >
+                <Tooltip title="Red-Yellow-Blue" placement="right">
+                  <img src={RdYlBu} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+            </ToggleButtonGroup>
+
+            <Paper
+              sx={{
+                display: 'flex',
+                p: 1,
+                m: 1,
+                ml: 3,
+                mr: 3,
+                justifyContent: 'space-evenly',
+                backgroundColor: '#fcfffc',
+                color: '#595858',
+              }}
+            >
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={isReverseColorChecked}
+                      onChange={handleReverseColorCheckboxChange}
+                    />
+                  }
+                  label="reverse colors"
+                />
+              </FormGroup>
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={isColorBlindChecked}
+                      onChange={handleColorBlindCheckboxChange}
+                    />
+                  }
+                  label="colorblind-friendly"
+                />
+              </FormGroup>
+            </Paper>
+            <Paper
+              sx={{
+                display: 'flex',
+                p: 1,
+                m: 1,
+                ml: 3,
+                mr: 3,
+                justifyContent: 'space-evenly',
+                backgroundColor: '#fcfffc',
+                color: '#595858',
+              }}
+            >
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  handleColorPicker()
+                }}
+                size="small"
+              >
+                Ok
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  hideColorPickerMenu()
+                }}
+                size="small"
+              >
+                Cancel
+              </Button>
+            </Paper>
+          </Popover>
+        </Paper>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            pt: 11.5,
+            mb: 3,
+            justifyContent: 'center',
+          }}
+        >
+          <Paper
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              position: 'relative',
+              userSelect: 'none',
+              pb: 6,
+            }}
+            elevation={4}
+          >
+            <Box sx={{ p: 1.5 }}>
+              <Tooltip
+                title="Click to add new handle"
+                placement="top"
+                followCursor
+              >
+                <Paper
+                  sx={{
+                    display: 'flex',
+                    position: 'relative',
+                    '&:hover': { cursor: 'copy' },
+                  }}
+                  onClickCapture={(e) => {
+                    const gradientPositionX =
+                      e.clientX - e.currentTarget.getBoundingClientRect().x
+
+                    const newHandleValue =
+                      valuePixelScale.invert(gradientPositionX)
+                    const newHandleVpValue =
+                      color(colorScale(newHandleValue))?.formatHex() ??
+                      '#000000'
+
+                    createHandle(newHandleValue, newHandleVpValue)
+                  }}
+                >
+                  <ColorGradient
+                    numSteps={NUM_GRADIENT_STEPS}
+                    stepWidth={GRADIENT_STEP_WIDTH}
+                    height={GRADIENT_HEIGHT}
+                    domainLabel={m.attribute}
+                    axisOffsetLeft={GRADIENT_AXIS_OFFSET_LEFT}
+                    horizontalPadding={GRADIENT_AXIS_HORIZONTAL_PADDING}
+                    verticalPadding={GRADIENT_AXIS_VERTICAL_PADDING}
+                    valuePixelScale={valuePixelScale}
+                    colorScale={colorScale}
+                    cm={m}
+                  />
+                </Paper>
+              </Tooltip>
+              {handles.map((h) => {
+                return (
+                  <Draggable
+                    key={h.id}
+                    bounds="parent"
+                    axis="x"
+                    handle=".handle"
+                    onStart={(e) => {
+                      setlastDraggedHandleId(h.id)
+                    }}
+                    onStop={(e) => {
+                      setlastDraggedHandleId(h.id)
+                    }}
+                    onDrag={(e, data) => {
+                      const newValue = valuePixelScale.invert(data.x)
+                      setHandle(h.id, newValue, h.vpValue as string)
+                    }}
+                    position={{
+                      x: valuePixelScale(h.value as number),
+                      y: 0,
                     }}
                   >
-                    <Paper
-                      elevation={4}
+                    <Box
                       sx={{
-                        p: 0.5,
-                        position: 'relative',
-                        top: -195,
+                        width: 2,
+                        height: 1,
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',
-                        border: '0.5px solid #03082d',
+                        position: 'absolute',
                         zIndex: lastDraggedHandleId === h.id ? 3 : 1,
                       }}
                     >
-                      {handles.length >= 3 ? (
-                        <Delete
-                          onClick={() => {
-                            deleteHandle(h.id)
-                          }}
-                          sx={{
-                            position: 'absolute',
-                            top: -10,
-                            right: -10,
-                            color: '#03082d',
-                            fontSize: 22,
-                            '&:hover': {
-                              cursor: 'pointer',
-                              color: '#3d0303',
-                            },
-                          }}
-                        />
-                      ) : (
-                        <Delete
-                          sx={{
-                            position: 'absolute',
-                            top: -10,
-                            right: -10,
-                            color: 'rgba(0, 0, 0, 0.3)',
-                            fontSize: 22,
-                            pointerEvents: 'none',
-                          }}
-                        />
-                      )}
-
-                      <Box sx={{ pl: 1.8, pr: 1.8 }}>
-                        <VisualPropertyValueForm
-                          currentValue={h.vpValue ?? null}
-                          visualProperty={props.visualProperty}
-                          currentNetworkId={props.currentNetworkId}
-                          onValueChange={(newValue) => {
-                            setHandle(
-                              h.id,
-                              h.value as number,
-                              newValue as string,
-                            )
-                          }}
-                        />
-                      </Box>
-                      <TextField
-                        sx={{ width: 50, mt: 1 }}
-                        inputProps={{
-                          sx: { p: 0.5, fontSize: 14, width: 50 },
-                          inputMode: 'numeric',
-                          pattern: '[0-9]*',
-                          step: 0.1,
+                      <Paper
+                        elevation={4}
+                        sx={{
+                          p: 0.5,
+                          position: 'relative',
+                          top: -195,
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          border: '0.5px solid #03082d',
+                          zIndex: lastDraggedHandleId === h.id ? 3 : 1,
                         }}
-                        onChange={(e) => {
-                          const newVal = Number(e.target.value)
+                      >
+                        {handles.length >= 3 ? (
+                          <Delete
+                            onClick={() => {
+                              deleteHandle(h.id)
+                            }}
+                            sx={{
+                              position: 'absolute',
+                              top: -10,
+                              right: -10,
+                              color: '#03082d',
+                              fontSize: 22,
+                              '&:hover': {
+                                cursor: 'pointer',
+                                color: '#3d0303',
+                              },
+                            }}
+                          />
+                        ) : (
+                          <Delete
+                            sx={{
+                              position: 'absolute',
+                              top: -10,
+                              right: -10,
+                              color: 'rgba(0, 0, 0, 0.3)',
+                              fontSize: 22,
+                              pointerEvents: 'none',
+                            }}
+                          />
+                        )}
 
-                          if (!isNaN(newVal)) {
-                            setHandle(h.id, newVal, h.vpValue as string)
-                          }
+                        <Box sx={{ pl: 1.8, pr: 1.8 }}>
+                          <VisualPropertyValueForm
+                            currentValue={h.vpValue ?? null}
+                            visualProperty={props.visualProperty}
+                            currentNetworkId={props.currentNetworkId}
+                            onValueChange={(newValue) => {
+                              setHandle(
+                                h.id,
+                                h.value as number,
+                                newValue as string,
+                              )
+                            }}
+                          />
+                        </Box>
+                        <TextField
+                          sx={{ width: 50, mt: 1 }}
+                          inputProps={{
+                            sx: { p: 0.5, fontSize: 14, width: 50 },
+                            inputMode: 'numeric',
+                            pattern: '[0-9]*',
+                            step: 0.1,
+                          }}
+                          onChange={(e) => {
+                            const newVal = Number(e.target.value)
+
+                            if (!isNaN(newVal)) {
+                              setHandle(h.id, newVal, h.vpValue as string)
+                            }
+                          }}
+                          value={h.value as number}
+                        />
+                      </Paper>
+                      <IconButton
+                        className="handle"
+                        size="large"
+                        sx={{
+                          position: 'relative',
+                          top: -220,
+                          '&:hover': { cursor: 'col-resize' },
                         }}
-                        value={h.value as number}
-                      />
-                    </Paper>
-                    <IconButton
-                      className="handle"
-                      size="large"
-                      sx={{
-                        position: 'relative',
-                        top: -220,
-                        '&:hover': { cursor: 'col-resize' },
-                      }}
-                    >
-                      <ArrowDropDownIcon
-                        sx={{ fontSize: '40px', color: '#03082d', zIndex: 3 }}
-                      />
-                    </IconButton>
-                  </Box>
-                </Draggable>
-              )
-            })}
-            <Tooltip title="Set color value for values under the minimum.">
-              <Box
-                sx={{
-                  width: 2,
-                  height: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  position: 'relative',
-                  top: -65,
-                  left: -20,
-                }}
-              >
-                <VisualPropertyValueForm
-                  currentValue={m.ltMinVpValue}
-                  visualProperty={props.visualProperty}
-                  currentNetworkId={props.currentNetworkId}
-                  onValueChange={(newValue) => {
-                    updateContinuousMapping(
-                      min,
-                      max,
-                      handles,
-                      newValue,
-                      m.gtMaxVpValue,
-                    )
+                      >
+                        <ArrowDropDownIcon
+                          sx={{ fontSize: '40px', color: '#03082d', zIndex: 3 }}
+                        />
+                      </IconButton>
+                    </Box>
+                  </Draggable>
+                )
+              })}
+              <Tooltip title="Set color value for values under the minimum.">
+                <Box
+                  sx={{
+                    width: 2,
+                    height: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    position: 'relative',
+                    top: -65,
+                    left: -20,
                   }}
-                />
-              </Box>
-            </Tooltip>
-            <Tooltip title="Set color value for values over the maximum.">
-              <Box
-                sx={{
-                  width: 2,
-                  height: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  position: 'relative',
-                  top: -95,
-                  left: 580,
-                }}
-              >
-                <VisualPropertyValueForm
-                  currentValue={m.gtMaxVpValue}
-                  visualProperty={props.visualProperty}
-                  currentNetworkId={props.currentNetworkId}
-                  onValueChange={(newValue) => {
-                    updateContinuousMapping(
-                      min,
-                      max,
-                      handles,
-                      m.ltMinVpValue,
-                      newValue,
-                    )
+                >
+                  <VisualPropertyValueForm
+                    currentValue={m.ltMinVpValue}
+                    visualProperty={props.visualProperty}
+                    currentNetworkId={props.currentNetworkId}
+                    onValueChange={(newValue) => {
+                      updateContinuousMapping(
+                        min,
+                        max,
+                        handles,
+                        newValue,
+                        m.gtMaxVpValue,
+                      )
+                    }}
+                  />
+                </Box>
+              </Tooltip>
+              <Tooltip title="Set color value for values over the maximum.">
+                <Box
+                  sx={{
+                    width: 2,
+                    height: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    position: 'relative',
+                    top: -95,
+                    left: 580,
                   }}
-                />
-              </Box>
-            </Tooltip>
-          </Box>
-        </Paper>
-      </Box>
+                >
+                  <VisualPropertyValueForm
+                    currentValue={m.gtMaxVpValue}
+                    visualProperty={props.visualProperty}
+                    currentNetworkId={props.currentNetworkId}
+                    onValueChange={(newValue) => {
+                      updateContinuousMapping(
+                        min,
+                        max,
+                        handles,
+                        m.ltMinVpValue,
+                        newValue,
+                      )
+                    }}
+                  />
+                </Box>
+              </Tooltip>
+            </Box>
+          </Paper>
+        </Box>
 
-      <Paper
-        sx={{
-          display: 'flex',
-          p: 1,
-          m: 1,
-          ml: 3,
-          mr: 3,
-          justifyContent: 'space-evenly',
-          backgroundColor: '#fcfffc',
-          color: '#595858',
-        }}
-      >
-        <Button
-          onClick={showCreateHandleMenu}
-          variant="outlined"
-          sx={{ color: '#63a5e8' }}
-          size="small"
-          startIcon={<AddCircleIcon />}
-        >
-          New Handle
-        </Button>
-        <Popover
-          open={createHandleAnchorEl != null}
-          anchorEl={createHandleAnchorEl}
-          onClose={hideCreateHandleMenu}
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
+        <Paper
+          sx={{
+            display: 'flex',
+            p: 1,
+            m: 1,
+            ml: 3,
+            mr: 3,
+            justifyContent: 'space-evenly',
+            backgroundColor: '#fcfffc',
+            color: '#595858',
           }}
         >
-          <Box
-            sx={{
-              p: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              width: 180,
+          <Button
+            onClick={showCreateHandleMenu}
+            variant="outlined"
+            sx={{ color: '#63a5e8' }}
+            size="small"
+            startIcon={<AddCircleIcon />}
+          >
+            New Handle
+          </Button>
+          <Popover
+            open={createHandleAnchorEl != null}
+            anchorEl={createHandleAnchorEl}
+            onClose={hideCreateHandleMenu}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
             }}
           >
-            <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
-              <TextField
-                sx={{ mb: 1 }}
-                variant="outlined"
-                size="small"
-                label={m.attribute}
-                inputProps={{
-                  inputMode: 'numeric',
-                  pattern: '[0-9]*',
-                  step: 0.1,
-                }}
-                onChange={(e) => {
-                  const newValue = Number(e.target.value)
-                  if (!isNaN(newValue)) {
-                    setAddHandleFormValue(newValue)
-                  }
-                }}
-                value={addHandleFormValue}
-              />
-              <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                <Typography variant="body2">
-                  {props.visualProperty.displayName}
-                </Typography>
-              </Box>
-              <VisualPropertyValueForm
-                currentValue={addHandleFormVpValue}
-                visualProperty={props.visualProperty}
-                currentNetworkId={props.currentNetworkId}
-                onValueChange={(newValue) => {
-                  setAddHandleFormVpValue(newValue as string)
-                }}
-              />
-            </Box>
-            <Button
-              variant="outlined"
-              onClick={() => {
-                createHandle(addHandleFormValue, addHandleFormVpValue as string)
-                hideCreateHandleMenu()
+            <Box
+              sx={{
+                p: 1,
+                display: 'flex',
+                flexDirection: 'column',
+                width: 180,
               }}
-              size="small"
             >
-              Add Handle
-            </Button>
-          </Box>
-        </Popover>
-        <Button
-          onClick={showMinMaxMenu}
-          sx={{ color: '#63a5e8' }}
-          variant="outlined"
-          size="small"
-          startIcon={<EditIcon />}
-        >
-          Set Min and Max
-        </Button>
-        <Popover
-          open={editMinMaxAnchorEl != null}
-          onClose={hideMinMaxMenu}
-          anchorEl={editMinMaxAnchorEl}
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-        >
-          <Box sx={{ p: 1 }}>
-            <Box>
-              <Typography variant="body1">{m.attribute}</Typography>
-
               <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
                 <TextField
                   sx={{ mb: 1 }}
                   variant="outlined"
                   size="small"
-                  label="Min"
+                  label={m.attribute}
                   inputProps={{
                     inputMode: 'numeric',
                     pattern: '[0-9]*',
@@ -1004,39 +937,114 @@ export function ContinuousColorMappingForm(props: {
                   onChange={(e) => {
                     const newValue = Number(e.target.value)
                     if (!isNaN(newValue)) {
-                      setMinState({
-                        ...minState,
-                        value: newValue,
-                      })
+                      setAddHandleFormValue(newValue)
                     }
                   }}
-                  value={minState.value}
+                  value={addHandleFormValue}
                 />
-                <TextField
-                  value={maxState.value}
-                  variant="outlined"
-                  size="small"
-                  label="Max"
-                  inputProps={{
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
-                  }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
-                      setMaxState({
-                        ...maxState,
-                        value: newValue,
-                      })
-                    }
+                <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <Typography variant="body2">
+                    {props.visualProperty.displayName}
+                  </Typography>
+                </Box>
+                <VisualPropertyValueForm
+                  currentValue={addHandleFormVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    setAddHandleFormVpValue(newValue as string)
                   }}
                 />
               </Box>
+              <Button
+                variant="outlined"
+                onClick={() => {
+                  createHandle(
+                    addHandleFormValue,
+                    addHandleFormVpValue as string,
+                  )
+                  hideCreateHandleMenu()
+                }}
+                size="small"
+              >
+                Add Handle
+              </Button>
             </Box>
-          </Box>
-        </Popover>
+          </Popover>
+          <Button
+            onClick={showMinMaxMenu}
+            sx={{ color: '#63a5e8' }}
+            variant="outlined"
+            size="small"
+            startIcon={<EditIcon />}
+          >
+            Set Min and Max
+          </Button>
+          <Popover
+            open={editMinMaxAnchorEl != null}
+            onClose={hideMinMaxMenu}
+            anchorEl={editMinMaxAnchorEl}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <Box sx={{ p: 1 }}>
+              <Box>
+                <Typography variant="body1">{m.attribute}</Typography>
+
+                <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
+                  <TextField
+                    sx={{ mb: 1 }}
+                    variant="outlined"
+                    size="small"
+                    label="Min"
+                    inputProps={{
+                      inputMode: 'numeric',
+                      pattern: '[0-9]*',
+                      step: 0.1,
+                    }}
+                    onChange={(e) => {
+                      const newValue = Number(e.target.value)
+                      if (!isNaN(newValue)) {
+                        setMinState({
+                          ...minState,
+                          value: newValue,
+                        })
+                      }
+                    }}
+                    value={minState.value}
+                  />
+                  <TextField
+                    value={maxState.value}
+                    variant="outlined"
+                    size="small"
+                    label="Max"
+                    inputProps={{
+                      inputMode: 'numeric',
+                      pattern: '[0-9]*',
+                      step: 0.1,
+                    }}
+                    onChange={(e) => {
+                      const newValue = Number(e.target.value)
+                      if (!isNaN(newValue)) {
+                        setMaxState({
+                          ...maxState,
+                          value: newValue,
+                        })
+                      }
+                    }}
+                  />
+                </Box>
+              </Box>
+            </Box>
+          </Popover>
+        </Paper>
       </Paper>
-    </Paper>
+    </MantineProvider>
   )
 }

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -5,10 +5,8 @@ import {
   Typography,
   Paper,
   Popover,
-  TextField,
   IconButton,
   Tooltip,
-  ButtonBase,
 } from '@mui/material'
 import { scaleLinear } from '@visx/scale'
 import { extent } from 'd3-array'
@@ -52,121 +50,7 @@ import { Handle, addHandle, editHandle, removeHandle } from './Handle'
 import FormGroup from '@mui/material/FormGroup'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Checkbox from '@mui/material/Checkbox'
-import { MantineProvider, NumberInput } from '@mantine/core'
-
-// A button that displays a number input value, the user can click this button to open up a dropdown form that allows the user to input a number and cancel/confirm
-function ExpandableNumberInput(props: {
-  value: number
-  onConfirm: (value: number) => void
-  // setHandle: (id: number, value: number, vpValue: string) => void
-  min?: number
-  max?: number
-}): React.ReactElement {
-  const { value, onConfirm } = props
-  const [localValue, setLocalValue] = React.useState<number>(value as number)
-  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null)
-
-  React.useEffect(() => {
-    setLocalValue(value as number)
-  }, [value])
-
-  const handleCancel = () => {
-    setLocalValue(value as number)
-    hidePopover()
-  }
-
-  const handleConfirm = () => {
-    onConfirm(localValue)
-    hidePopover()
-  }
-
-  const showPopover = (event: React.MouseEvent<HTMLButtonElement>): void => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  const hidePopover = (): void => {
-    setAnchorEl(null)
-  }
-
-  const isValid = (value: number): boolean => {
-    if (props.min != null && value < props.min) {
-      return false
-    }
-    if (props.max != null && value > props.max) {
-      return false
-    }
-    return true
-  }
-
-  return (
-    <>
-      <ButtonBase onClick={(e) => showPopover(e)}>
-        <Box
-          sx={{
-            width: 50,
-            zIndex: 4,
-            mt: 1,
-            '&:hover': {
-              pointer: 'cursor',
-            },
-            overflow: 'hidden',
-            border: '1px solid #d6d6d6',
-            borderRadius: '4px',
-          }}
-        >
-          {value}
-        </Box>
-      </ButtonBase>
-
-      <Popover
-        open={anchorEl != null}
-        anchorEl={anchorEl}
-        onClose={hidePopover}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
-        }}
-      >
-        <NumberInput
-          error={
-            !isValid(localValue)
-              ? `Value must be between ${props.min} and ${props.max}`
-              : null
-          }
-          min={props.min}
-          max={props.max}
-          value={localValue as number}
-          decimalScale={2}
-          onChange={(newValue) => {
-            if (typeof newValue === 'string') {
-              setLocalValue(0)
-            } else {
-              setLocalValue(newValue)
-            }
-          }}
-        />
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <Button color="error" onClick={handleCancel}>
-            Cancel
-          </Button>
-          <Button disabled={!isValid(localValue)} onClick={handleConfirm}>
-            Confirm
-          </Button>
-        </Box>
-      </Popover>
-    </>
-  )
-}
+import { ExpandableNumberInput } from './ExpandableNumberInput'
 
 // color mapping form for now
 export function ContinuousColorMappingForm(props: {
@@ -493,413 +377,412 @@ export function ContinuousColorMappingForm(props: {
   }, [maxState])
 
   return (
-    <MantineProvider>
-      <Paper sx={{ backgroundColor: '#D9D9D9', pb: 2, pt: 2 }}>
-        <Paper
-          sx={{
-            display: 'flex',
-            p: 1,
-            m: 1,
-            ml: 3,
-            mr: 3,
-            justifyContent: 'center',
-            backgroundColor: '#fcfffc',
-            color: '#595858',
+    <Paper sx={{ backgroundColor: '#D9D9D9', pb: 2, pt: 2 }}>
+      <Paper
+        sx={{
+          display: 'flex',
+          p: 1,
+          m: 1,
+          ml: 3,
+          mr: 3,
+          justifyContent: 'center',
+          backgroundColor: '#fcfffc',
+          color: '#595858',
+        }}
+      >
+        Current Palette:&ensp;
+        <Button
+          onClick={showColorPickerMenu}
+          variant="outlined"
+          sx={{ color: '#63a5e8' }}
+          size="small"
+          startIcon={<Palette />}
+        >
+          {buttonText}
+        </Button>
+        <Popover
+          open={createColorPickerAnchorEl != null}
+          anchorEl={createColorPickerAnchorEl}
+          onClose={hideColorPickerMenu}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
           }}
         >
-          Current Palette:&ensp;
-          <Button
-            onClick={showColorPickerMenu}
-            variant="outlined"
-            sx={{ color: '#63a5e8' }}
-            size="small"
-            startIcon={<Palette />}
+          <Typography align={'center'} sx={{ p: 1 }}>
+            Set Palette
+          </Typography>
+          <ToggleButtonGroup
+            value={colorPalette}
+            onChange={handleColorPalette}
+            orientation="horizontal"
+            exclusive
+            fullWidth={true}
           >
-            {buttonText}
-          </Button>
-          <Popover
-            open={createColorPickerAnchorEl != null}
-            anchorEl={createColorPickerAnchorEl}
-            onClose={hideColorPickerMenu}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-          >
-            <Typography align={'center'} sx={{ p: 1 }}>
-              Set Palette
-            </Typography>
-            <ToggleButtonGroup
-              value={colorPalette}
-              onChange={handleColorPalette}
-              orientation="horizontal"
-              exclusive
-              fullWidth={true}
+            <ToggleButton
+              value="rdbu"
+              aria-label="RdBu"
+              onClick={() => {
+                setMinPalette('#b2182b')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#2166ac')
+                setTextPalette('Red-Blue')
+              }}
             >
+              <Tooltip title="Red-Blue" placement="right">
+                <img src={RdBu} width="15" height="150" />
+              </Tooltip>
+            </ToggleButton>
+
+            <ToggleButton
+              value="puor"
+              aria-label="PuOr"
+              onClick={() => {
+                setMinPalette('#542788')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#b35806')
+                setTextPalette('Purple-Orange')
+              }}
+            >
+              <Tooltip title="Purple-Orange" placement="right">
+                <img src={PuOr} width="15" height="150" />
+              </Tooltip>
+            </ToggleButton>
+
+            <ToggleButton
+              value="prgn"
+              aria-label="PRGn"
+              onClick={() => {
+                setMinPalette('#762a83')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#1b7837')
+                setTextPalette('Purple-Red-Green')
+              }}
+            >
+              <Tooltip title="Purple-Red-Green" placement="right">
+                <img src={PRGn} width="15" height="150" />
+              </Tooltip>
+            </ToggleButton>
+
+            {!isColorBlindChecked && (
               <ToggleButton
-                value="rdbu"
-                aria-label="RdBu"
+                value="spectral"
+                aria-label="Spectral"
                 onClick={() => {
-                  setMinPalette('#b2182b')
-                  setMiddlePalette('#f7f7f7')
-                  setMaxPalette('#2166ac')
-                  setTextPalette('Red-Blue')
+                  setMinPalette('#d53e4f')
+                  setMiddlePalette('#ffffbf')
+                  setMaxPalette('#3288bd')
+                  setTextPalette('Spectral Colors')
                 }}
               >
-                <Tooltip title="Red-Blue" placement="right">
-                  <img src={RdBu} width="15" height="150" />
+                <Tooltip title="Spectral Colors" placement="right">
+                  <img src={Spectral} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
+            )}
 
+            <ToggleButton
+              value="brbg"
+              aria-label="BrBG"
+              onClick={() => {
+                setMinPalette('#8c510a')
+                setMiddlePalette('#f5f5f5')
+                setMaxPalette('#01665e')
+                setTextPalette('Brown-Blue-Green')
+              }}
+            >
+              <Tooltip title="Brown-Blue-Green" placement="right">
+                <img src={BrBG} width="15" height="150" />
+              </Tooltip>
+            </ToggleButton>
+
+            {!isColorBlindChecked && (
               <ToggleButton
-                value="puor"
-                aria-label="PuOr"
-                onClick={() => {
-                  setMinPalette('#542788')
-                  setMiddlePalette('#f7f7f7')
-                  setMaxPalette('#b35806')
-                  setTextPalette('Purple-Orange')
-                }}
-              >
-                <Tooltip title="Purple-Orange" placement="right">
-                  <img src={PuOr} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-
-              <ToggleButton
-                value="prgn"
-                aria-label="PRGn"
-                onClick={() => {
-                  setMinPalette('#762a83')
-                  setMiddlePalette('#f7f7f7')
-                  setMaxPalette('#1b7837')
-                  setTextPalette('Purple-Red-Green')
-                }}
-              >
-                <Tooltip title="Purple-Red-Green" placement="right">
-                  <img src={PRGn} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-
-              {!isColorBlindChecked && (
-                <ToggleButton
-                  value="spectral"
-                  aria-label="Spectral"
-                  onClick={() => {
-                    setMinPalette('#d53e4f')
-                    setMiddlePalette('#ffffbf')
-                    setMaxPalette('#3288bd')
-                    setTextPalette('Spectral Colors')
-                  }}
-                >
-                  <Tooltip title="Spectral Colors" placement="right">
-                    <img src={Spectral} width="15" height="150" />
-                  </Tooltip>
-                </ToggleButton>
-              )}
-
-              <ToggleButton
-                value="brbg"
-                aria-label="BrBG"
-                onClick={() => {
-                  setMinPalette('#8c510a')
-                  setMiddlePalette('#f5f5f5')
-                  setMaxPalette('#01665e')
-                  setTextPalette('Brown-Blue-Green')
-                }}
-              >
-                <Tooltip title="Brown-Blue-Green" placement="right">
-                  <img src={BrBG} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-
-              {!isColorBlindChecked && (
-                <ToggleButton
-                  value="rdylgn"
-                  aria-label="RdYlGn"
-                  onClick={() => {
-                    setMinPalette('#d73027')
-                    setMiddlePalette('#ffffbf')
-                    setMaxPalette('#1a9850')
-                    setTextPalette('Red-Yellow-Green')
-                  }}
-                >
-                  <Tooltip title="Red-Yellow-Green" placement="right">
-                    <img src={RdYlGn} width="15" height="150" />
-                  </Tooltip>
-                </ToggleButton>
-              )}
-
-              <ToggleButton
-                value="piyg"
-                aria-label="PiYG"
-                onClick={() => {
-                  setMinPalette('#c51b7d')
-                  setMiddlePalette('#f7f7f7')
-                  setMaxPalette('#4d9221')
-                  setTextPalette('Magenta-Yellow-Green')
-                }}
-              >
-                <Tooltip title="Magenta-Yellow-Green" placement="right">
-                  <img src={PiYG} width="15" height="150" />
-                </Tooltip>
-              </ToggleButton>
-
-              {!isColorBlindChecked && (
-                <ToggleButton
-                  value="rdgy"
-                  aria-label="RdGy"
-                  onClick={() => {
-                    setMinPalette('#b2182b')
-                    setMiddlePalette('#ffffff')
-                    setMaxPalette('#4d4d4d')
-                    setTextPalette('Red-Grey')
-                  }}
-                >
-                  <Tooltip title="Red-Grey" placement="right">
-                    <img src={RdGy} width="15" height="150" />
-                  </Tooltip>
-                </ToggleButton>
-              )}
-
-              <ToggleButton
-                value="rdylbu"
-                aria-label="RdYlBu"
+                value="rdylgn"
+                aria-label="RdYlGn"
                 onClick={() => {
                   setMinPalette('#d73027')
                   setMiddlePalette('#ffffbf')
-                  setMaxPalette('#4575b4')
-                  setTextPalette('Red-Yellow-Blue')
+                  setMaxPalette('#1a9850')
+                  setTextPalette('Red-Yellow-Green')
                 }}
               >
-                <Tooltip title="Red-Yellow-Blue" placement="right">
-                  <img src={RdYlBu} width="15" height="150" />
+                <Tooltip title="Red-Yellow-Green" placement="right">
+                  <img src={RdYlGn} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
-            </ToggleButtonGroup>
+            )}
 
-            <Paper
-              sx={{
-                display: 'flex',
-                p: 1,
-                m: 1,
-                ml: 3,
-                mr: 3,
-                justifyContent: 'space-evenly',
-                backgroundColor: '#fcfffc',
-                color: '#595858',
+            <ToggleButton
+              value="piyg"
+              aria-label="PiYG"
+              onClick={() => {
+                setMinPalette('#c51b7d')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#4d9221')
+                setTextPalette('Magenta-Yellow-Green')
               }}
             >
-              <FormGroup>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={isReverseColorChecked}
-                      onChange={handleReverseColorCheckboxChange}
-                    />
-                  }
-                  label="reverse colors"
-                />
-              </FormGroup>
-              <FormGroup>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={isColorBlindChecked}
-                      onChange={handleColorBlindCheckboxChange}
-                    />
-                  }
-                  label="colorblind-friendly"
-                />
-              </FormGroup>
-            </Paper>
-            <Paper
-              sx={{
-                display: 'flex',
-                p: 1,
-                m: 1,
-                ml: 3,
-                mr: 3,
-                justifyContent: 'space-evenly',
-                backgroundColor: '#fcfffc',
-                color: '#595858',
+              <Tooltip title="Magenta-Yellow-Green" placement="right">
+                <img src={PiYG} width="15" height="150" />
+              </Tooltip>
+            </ToggleButton>
+
+            {!isColorBlindChecked && (
+              <ToggleButton
+                value="rdgy"
+                aria-label="RdGy"
+                onClick={() => {
+                  setMinPalette('#b2182b')
+                  setMiddlePalette('#ffffff')
+                  setMaxPalette('#4d4d4d')
+                  setTextPalette('Red-Grey')
+                }}
+              >
+                <Tooltip title="Red-Grey" placement="right">
+                  <img src={RdGy} width="15" height="150" />
+                </Tooltip>
+              </ToggleButton>
+            )}
+
+            <ToggleButton
+              value="rdylbu"
+              aria-label="RdYlBu"
+              onClick={() => {
+                setMinPalette('#d73027')
+                setMiddlePalette('#ffffbf')
+                setMaxPalette('#4575b4')
+                setTextPalette('Red-Yellow-Blue')
               }}
             >
-              <Button
-                variant="outlined"
-                onClick={() => {
-                  handleColorPicker()
-                }}
-                size="small"
-              >
-                Ok
-              </Button>
-              <Button
-                variant="outlined"
-                onClick={() => {
-                  hideColorPickerMenu()
-                }}
-                size="small"
-              >
-                Cancel
-              </Button>
-            </Paper>
-          </Popover>
-        </Paper>
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            pt: 11.5,
-            mb: 3,
-            justifyContent: 'center',
-          }}
-        >
+              <Tooltip title="Red-Yellow-Blue" placement="right">
+                <img src={RdYlBu} width="15" height="150" />
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
+
           <Paper
             sx={{
               display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              position: 'relative',
-              userSelect: 'none',
-              pb: 6,
+              p: 1,
+              m: 1,
+              ml: 3,
+              mr: 3,
+              justifyContent: 'space-evenly',
+              backgroundColor: '#fcfffc',
+              color: '#595858',
             }}
-            elevation={4}
           >
-            <Box sx={{ p: 1.5 }}>
-              <Tooltip
-                title="Click to add new handle"
-                placement="top"
-                followCursor
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isReverseColorChecked}
+                    onChange={handleReverseColorCheckboxChange}
+                  />
+                }
+                label="reverse colors"
+              />
+            </FormGroup>
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isColorBlindChecked}
+                    onChange={handleColorBlindCheckboxChange}
+                  />
+                }
+                label="colorblind-friendly"
+              />
+            </FormGroup>
+          </Paper>
+          <Paper
+            sx={{
+              display: 'flex',
+              p: 1,
+              m: 1,
+              ml: 3,
+              mr: 3,
+              justifyContent: 'space-evenly',
+              backgroundColor: '#fcfffc',
+              color: '#595858',
+            }}
+          >
+            <Button
+              variant="outlined"
+              onClick={() => {
+                handleColorPicker()
+              }}
+              size="small"
+            >
+              Ok
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={() => {
+                hideColorPickerMenu()
+              }}
+              size="small"
+            >
+              Cancel
+            </Button>
+          </Paper>
+        </Popover>
+      </Paper>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          pt: 11.5,
+          mb: 3,
+          justifyContent: 'center',
+        }}
+      >
+        <Paper
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            position: 'relative',
+            userSelect: 'none',
+            pb: 6,
+          }}
+          elevation={4}
+        >
+          <Box sx={{ p: 1.5 }}>
+            <Tooltip
+              title="Click to add new handle"
+              placement="top"
+              followCursor
+            >
+              <Paper
+                sx={{
+                  display: 'flex',
+                  position: 'relative',
+                  '&:hover': { cursor: 'copy' },
+                }}
+                onClickCapture={(e) => {
+                  const gradientPositionX =
+                    e.clientX - e.currentTarget.getBoundingClientRect().x
+
+                  const newHandleValue =
+                    valuePixelScale.invert(gradientPositionX)
+                  const newHandleVpValue =
+                    color(colorScale(newHandleValue))?.formatHex() ?? '#000000'
+
+                  createHandle(newHandleValue, newHandleVpValue)
+                }}
               >
-                <Paper
-                  sx={{
-                    display: 'flex',
-                    position: 'relative',
-                    '&:hover': { cursor: 'copy' },
+                <ColorGradient
+                  numSteps={NUM_GRADIENT_STEPS}
+                  stepWidth={GRADIENT_STEP_WIDTH}
+                  height={GRADIENT_HEIGHT}
+                  domainLabel={m.attribute}
+                  axisOffsetLeft={GRADIENT_AXIS_OFFSET_LEFT}
+                  horizontalPadding={GRADIENT_AXIS_HORIZONTAL_PADDING}
+                  verticalPadding={GRADIENT_AXIS_VERTICAL_PADDING}
+                  valuePixelScale={valuePixelScale}
+                  colorScale={colorScale}
+                  cm={m}
+                />
+              </Paper>
+            </Tooltip>
+            {handles.map((h) => {
+              return (
+                <Draggable
+                  key={h.id}
+                  bounds="parent"
+                  axis="x"
+                  handle=".handle"
+                  onStart={(e) => {
+                    setlastDraggedHandleId(h.id)
                   }}
-                  onClickCapture={(e) => {
-                    const gradientPositionX =
-                      e.clientX - e.currentTarget.getBoundingClientRect().x
-
-                    const newHandleValue =
-                      valuePixelScale.invert(gradientPositionX)
-                    const newHandleVpValue =
-                      color(colorScale(newHandleValue))?.formatHex() ??
-                      '#000000'
-
-                    createHandle(newHandleValue, newHandleVpValue)
+                  onStop={(e) => {
+                    setlastDraggedHandleId(h.id)
+                  }}
+                  onDrag={(e, data) => {
+                    const newValue = valuePixelScale.invert(data.x)
+                    setHandle(h.id, newValue, h.vpValue as string)
+                  }}
+                  position={{
+                    x: valuePixelScale(h.value as number),
+                    y: 0,
                   }}
                 >
-                  <ColorGradient
-                    numSteps={NUM_GRADIENT_STEPS}
-                    stepWidth={GRADIENT_STEP_WIDTH}
-                    height={GRADIENT_HEIGHT}
-                    domainLabel={m.attribute}
-                    axisOffsetLeft={GRADIENT_AXIS_OFFSET_LEFT}
-                    horizontalPadding={GRADIENT_AXIS_HORIZONTAL_PADDING}
-                    verticalPadding={GRADIENT_AXIS_VERTICAL_PADDING}
-                    valuePixelScale={valuePixelScale}
-                    colorScale={colorScale}
-                    cm={m}
-                  />
-                </Paper>
-              </Tooltip>
-              {handles.map((h) => {
-                return (
-                  <Draggable
-                    key={h.id}
-                    bounds="parent"
-                    axis="x"
-                    handle=".handle"
-                    onStart={(e) => {
-                      setlastDraggedHandleId(h.id)
-                    }}
-                    onStop={(e) => {
-                      setlastDraggedHandleId(h.id)
-                    }}
-                    onDrag={(e, data) => {
-                      const newValue = valuePixelScale.invert(data.x)
-                      setHandle(h.id, newValue, h.vpValue as string)
-                    }}
-                    position={{
-                      x: valuePixelScale(h.value as number),
-                      y: 0,
+                  <Box
+                    onClick={() => setlastDraggedHandleId(h.id)}
+                    sx={{
+                      width: 2,
+                      height: 1,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      position: 'absolute',
+                      zIndex: lastDraggedHandleId === h.id ? 3 : 1,
                     }}
                   >
-                    <Box
-                      onClick={() => setlastDraggedHandleId(h.id)}
+                    <Paper
+                      elevation={4}
                       sx={{
-                        width: 2,
-                        height: 1,
+                        p: 0.5,
+                        position: 'relative',
+                        top: -195,
                         display: 'flex',
                         flexDirection: 'column',
                         alignItems: 'center',
-                        position: 'absolute',
+                        border: '0.5px solid #03082d',
                         zIndex: lastDraggedHandleId === h.id ? 3 : 1,
                       }}
                     >
-                      <Paper
-                        elevation={4}
-                        sx={{
-                          p: 0.5,
-                          position: 'relative',
-                          top: -195,
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          border: '0.5px solid #03082d',
-                          zIndex: lastDraggedHandleId === h.id ? 3 : 1,
-                        }}
-                      >
-                        {handles.length >= 3 ? (
-                          <Delete
-                            onClick={() => {
-                              deleteHandle(h.id)
-                            }}
-                            sx={{
-                              position: 'absolute',
-                              top: -10,
-                              right: -10,
-                              color: '#03082d',
-                              fontSize: 22,
-                              '&:hover': {
-                                cursor: 'pointer',
-                                color: '#3d0303',
-                              },
-                            }}
-                          />
-                        ) : (
-                          <Delete
-                            sx={{
-                              position: 'absolute',
-                              top: -10,
-                              right: -10,
-                              color: 'rgba(0, 0, 0, 0.3)',
-                              fontSize: 22,
-                              pointerEvents: 'none',
-                            }}
-                          />
-                        )}
+                      {handles.length >= 3 ? (
+                        <Delete
+                          onClick={() => {
+                            deleteHandle(h.id)
+                          }}
+                          sx={{
+                            position: 'absolute',
+                            top: -10,
+                            right: -10,
+                            color: '#03082d',
+                            fontSize: 22,
+                            '&:hover': {
+                              cursor: 'pointer',
+                              color: '#3d0303',
+                            },
+                          }}
+                        />
+                      ) : (
+                        <Delete
+                          sx={{
+                            position: 'absolute',
+                            top: -10,
+                            right: -10,
+                            color: 'rgba(0, 0, 0, 0.3)',
+                            fontSize: 22,
+                            pointerEvents: 'none',
+                          }}
+                        />
+                      )}
 
-                        <Box sx={{ pl: 1.8, pr: 1.8 }}>
-                          <VisualPropertyValueForm
-                            currentValue={h.vpValue ?? null}
-                            visualProperty={props.visualProperty}
-                            currentNetworkId={props.currentNetworkId}
-                            onValueChange={(newValue) => {
-                              setHandle(
-                                h.id,
-                                h.value as number,
-                                newValue as string,
-                              )
-                            }}
-                          />
-                        </Box>
+                      <Box sx={{ pl: 1.8, pr: 1.8, mb: 1 }}>
+                        <VisualPropertyValueForm
+                          currentValue={h.vpValue ?? null}
+                          visualProperty={props.visualProperty}
+                          currentNetworkId={props.currentNetworkId}
+                          onValueChange={(newValue) => {
+                            setHandle(
+                              h.id,
+                              h.value as number,
+                              newValue as string,
+                            )
+                          }}
+                        />
+                      </Box>
+                      <Box sx={{ mb: 1 }}>
                         <ExpandableNumberInput
                           value={h.value as number}
                           onConfirm={(newValue) => {
@@ -908,237 +791,235 @@ export function ContinuousColorMappingForm(props: {
                           min={minState.value as number}
                           max={maxState.value as number}
                         />
-                      </Paper>
-                      <IconButton
-                        className="handle"
-                        size="large"
-                        sx={{
-                          position: 'relative',
-                          top: -220,
-                          '&:hover': { cursor: 'col-resize' },
-                        }}
-                      >
-                        <ArrowDropDownIcon
-                          sx={{ fontSize: '40px', color: '#03082d', zIndex: 3 }}
-                        />
-                      </IconButton>
-                    </Box>
-                  </Draggable>
-                )
-              })}
-              <Tooltip title="Set color value for values under the minimum.">
-                <Box
-                  sx={{
-                    width: 2,
-                    height: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    position: 'relative',
-                    top: -65,
-                    left: -20,
+                      </Box>
+                    </Paper>
+                    <IconButton
+                      className="handle"
+                      size="large"
+                      sx={{
+                        position: 'relative',
+                        top: -220,
+                        '&:hover': { cursor: 'col-resize' },
+                      }}
+                    >
+                      <ArrowDropDownIcon
+                        sx={{ fontSize: '40px', color: '#03082d', zIndex: 3 }}
+                      />
+                    </IconButton>
+                  </Box>
+                </Draggable>
+              )
+            })}
+            <Tooltip title="Set color value for values under the minimum.">
+              <Box
+                sx={{
+                  width: 2,
+                  height: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  position: 'relative',
+                  top: -65,
+                  left: -20,
+                }}
+              >
+                <VisualPropertyValueForm
+                  currentValue={m.ltMinVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    updateContinuousMapping(
+                      min,
+                      max,
+                      handles,
+                      newValue,
+                      m.gtMaxVpValue,
+                    )
                   }}
-                >
-                  <VisualPropertyValueForm
-                    currentValue={m.ltMinVpValue}
-                    visualProperty={props.visualProperty}
-                    currentNetworkId={props.currentNetworkId}
-                    onValueChange={(newValue) => {
-                      updateContinuousMapping(
-                        min,
-                        max,
-                        handles,
-                        newValue,
-                        m.gtMaxVpValue,
-                      )
-                    }}
-                  />
-                </Box>
-              </Tooltip>
-              <Tooltip title="Set color value for values over the maximum.">
-                <Box
-                  sx={{
-                    width: 2,
-                    height: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    position: 'relative',
-                    top: -95,
-                    left: 580,
+                />
+              </Box>
+            </Tooltip>
+            <Tooltip title="Set color value for values over the maximum.">
+              <Box
+                sx={{
+                  width: 2,
+                  height: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  position: 'relative',
+                  top: -95,
+                  left: 580,
+                }}
+              >
+                <VisualPropertyValueForm
+                  currentValue={m.gtMaxVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    updateContinuousMapping(
+                      min,
+                      max,
+                      handles,
+                      m.ltMinVpValue,
+                      newValue,
+                    )
                   }}
-                >
-                  <VisualPropertyValueForm
-                    currentValue={m.gtMaxVpValue}
-                    visualProperty={props.visualProperty}
-                    currentNetworkId={props.currentNetworkId}
-                    onValueChange={(newValue) => {
-                      updateContinuousMapping(
-                        min,
-                        max,
-                        handles,
-                        m.ltMinVpValue,
-                        newValue,
-                      )
-                    }}
-                  />
-                </Box>
-              </Tooltip>
-            </Box>
-          </Paper>
-        </Box>
+                />
+              </Box>
+            </Tooltip>
+          </Box>
+        </Paper>
+      </Box>
 
-        <Paper
-          sx={{
-            display: 'flex',
-            p: 1,
-            m: 1,
-            ml: 3,
-            mr: 3,
-            justifyContent: 'space-evenly',
-            backgroundColor: '#fcfffc',
-            color: '#595858',
+      <Paper
+        sx={{
+          display: 'flex',
+          p: 1,
+          m: 1,
+          ml: 3,
+          mr: 3,
+          justifyContent: 'space-evenly',
+          backgroundColor: '#fcfffc',
+          color: '#595858',
+        }}
+      >
+        <Button
+          onClick={showCreateHandleMenu}
+          variant="outlined"
+          sx={{ color: '#63a5e8' }}
+          size="small"
+          startIcon={<AddCircleIcon />}
+        >
+          New Handle
+        </Button>
+        <Popover
+          open={createHandleAnchorEl != null}
+          anchorEl={createHandleAnchorEl}
+          onClose={hideCreateHandleMenu}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
           }}
         >
-          <Button
-            onClick={showCreateHandleMenu}
-            variant="outlined"
-            sx={{ color: '#63a5e8' }}
-            size="small"
-            startIcon={<AddCircleIcon />}
-          >
-            New Handle
-          </Button>
-          <Popover
-            open={createHandleAnchorEl != null}
-            anchorEl={createHandleAnchorEl}
-            onClose={hideCreateHandleMenu}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
+          <Box
+            sx={{
+              p: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              width: 180,
             }}
           >
-            <Box
-              sx={{
-                p: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                width: 180,
-              }}
-            >
-              <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                  }}
-                >
-                  {m.attribute}
-                  <ExpandableNumberInput
-                    value={addHandleFormValue}
-                    onConfirm={(newValue) => setAddHandleFormValue(newValue)}
-                    min={minState.value as number}
-                    max={maxState.value as number}
-                  ></ExpandableNumberInput>
-                </Box>
-                <Box
-                  sx={{
-                    mt: 1,
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                  }}
-                >
-                  {props.visualProperty.displayName}
-                  <VisualPropertyValueForm
-                    currentValue={addHandleFormVpValue}
-                    visualProperty={props.visualProperty}
-                    currentNetworkId={props.currentNetworkId}
-                    onValueChange={(newValue) => {
-                      setAddHandleFormVpValue(newValue as string)
-                    }}
-                  />
-                </Box>
-              </Box>
-              <Button
-                variant="outlined"
-                onClick={() => {
-                  createHandle(
-                    addHandleFormValue,
-                    addHandleFormVpValue as string,
-                  )
-                  hideCreateHandleMenu()
+            <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
                 }}
-                size="small"
               >
-                Add Handle
-              </Button>
-            </Box>
-          </Popover>
-          <Button
-            onClick={showMinMaxMenu}
-            sx={{ color: '#63a5e8' }}
-            variant="outlined"
-            size="small"
-            startIcon={<EditIcon />}
-          >
-            Set Min and Max
-          </Button>
-          <Popover
-            open={editMinMaxAnchorEl != null}
-            onClose={hideMinMaxMenu}
-            anchorEl={editMinMaxAnchorEl}
-            anchorOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-          >
-            <Box sx={{ p: 1 }}>
-              <Box>
-                <Typography variant="body1">{m.attribute}</Typography>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
+                {m.attribute}
+                <ExpandableNumberInput
+                  value={addHandleFormValue}
+                  onConfirm={(newValue) => setAddHandleFormValue(newValue)}
+                  min={minState.value as number}
+                  max={maxState.value as number}
+                ></ExpandableNumberInput>
+              </Box>
+              <Box
+                sx={{
+                  mt: 1,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}
+              >
+                {props.visualProperty.displayName}
+                <VisualPropertyValueForm
+                  currentValue={addHandleFormVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    setAddHandleFormVpValue(newValue as string)
                   }}
-                >
-                  {'Minimum Value'}
-                  <ExpandableNumberInput
-                    value={minState.value as number}
-                    onConfirm={(newValue) =>
-                      setMinState({ ...minState, value: newValue })
-                    }
-                  ></ExpandableNumberInput>
-                </Box>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                  }}
-                >
-                  {'Maximum Value'}
-                  <ExpandableNumberInput
-                    value={maxState.value as number}
-                    onConfirm={(newValue) =>
-                      setMaxState({ ...maxState, value: newValue })
-                    }
-                  ></ExpandableNumberInput>
-                </Box>
+                />
               </Box>
             </Box>
-          </Popover>
-        </Paper>
+            <Button
+              variant="outlined"
+              onClick={() => {
+                createHandle(addHandleFormValue, addHandleFormVpValue as string)
+                hideCreateHandleMenu()
+              }}
+              size="small"
+            >
+              Add Handle
+            </Button>
+          </Box>
+        </Popover>
+        <Button
+          onClick={showMinMaxMenu}
+          sx={{ color: '#63a5e8' }}
+          variant="outlined"
+          size="small"
+          startIcon={<EditIcon />}
+        >
+          Set Min and Max
+        </Button>
+        <Popover
+          open={editMinMaxAnchorEl != null}
+          onClose={hideMinMaxMenu}
+          anchorEl={editMinMaxAnchorEl}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        >
+          <Box sx={{ p: 1 }}>
+            <Box>
+              <Typography variant="body1">{m.attribute}</Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                {'Minimum Value'}
+                <ExpandableNumberInput
+                  value={minState.value as number}
+                  onConfirm={(newValue) =>
+                    setMinState({ ...minState, value: newValue })
+                  }
+                ></ExpandableNumberInput>
+              </Box>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  mt: 1,
+                }}
+              >
+                {'Maximum Value'}
+                <ExpandableNumberInput
+                  value={maxState.value as number}
+                  onConfirm={(newValue) =>
+                    setMaxState({ ...maxState, value: newValue })
+                  }
+                ></ExpandableNumberInput>
+              </Box>
+            </Box>
+          </Box>
+        </Popover>
       </Paper>
-    </MantineProvider>
+    </Paper>
   )
 }

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -221,6 +221,8 @@ export function ContinuousColorMappingForm(props: {
           min: ContinuousFunctionControlPoint,
           max: ContinuousFunctionControlPoint,
           handles: Handle[],
+          ltMinVpValue: VisualPropertyValueType,
+          gtMaxVpValue: VisualPropertyValueType,
         ) => {
           setContinuousMappingValues(
             props.currentNetworkId,
@@ -233,6 +235,8 @@ export function ContinuousColorMappingForm(props: {
                 vpValue: h.vpValue,
               }
             }),
+            ltMinVpValue,
+            gtMaxVpValue,
           )
         },
         200,
@@ -269,19 +273,37 @@ export function ContinuousColorMappingForm(props: {
   const createHandle = (value: number, vpValue: string): void => {
     const newHandles = addHandle(handles, value, vpValue)
     setHandles(newHandles)
-    updateContinuousMapping(min, max, newHandles)
+    updateContinuousMapping(
+      min,
+      max,
+      newHandles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }
 
   const deleteHandle = (id: number): void => {
     const newHandles = removeHandle(handles, id)
     setHandles(newHandles)
-    updateContinuousMapping(minState, maxState, newHandles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      newHandles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }
 
   const setHandle = (id: number, value: number, vpValue: string): void => {
     const newHandles = editHandle(handles, id, value, vpValue)
     setHandles(newHandles)
-    updateContinuousMapping(minState, maxState, newHandles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      newHandles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }
 
   const [colorPalette, setColorPalette] = React.useState('')
@@ -326,7 +348,13 @@ export function ContinuousColorMappingForm(props: {
     })
     setHandles(newHandles)
 
-    updateContinuousMapping(minState, maxState, handles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      handles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }, [minState])
 
   // anytime someone changes the max value, make sure all handle values are less than the max
@@ -339,7 +367,13 @@ export function ContinuousColorMappingForm(props: {
     })
     setHandles(newHandles)
 
-    updateContinuousMapping(minState, maxState, handles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      handles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }, [maxState])
 
   return (
@@ -781,6 +815,64 @@ export function ContinuousColorMappingForm(props: {
                 </Draggable>
               )
             })}
+            <Tooltip title="Set color value for values under the minimum.">
+              <Box
+                sx={{
+                  width: 2,
+                  height: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  position: 'relative',
+                  top: -65,
+                  left: -20,
+                }}
+              >
+                <VisualPropertyValueForm
+                  currentValue={m.ltMinVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    updateContinuousMapping(
+                      min,
+                      max,
+                      handles,
+                      newValue,
+                      m.gtMaxVpValue,
+                    )
+                  }}
+                />
+              </Box>
+            </Tooltip>
+            <Tooltip title="Set color value for values over the maximum.">
+              <Box
+                sx={{
+                  width: 2,
+                  height: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  position: 'relative',
+                  top: -95,
+                  left: 580,
+                }}
+              >
+                <VisualPropertyValueForm
+                  currentValue={m.gtMaxVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    updateContinuousMapping(
+                      min,
+                      max,
+                      handles,
+                      m.ltMinVpValue,
+                      newValue,
+                    )
+                  }}
+                />
+              </Box>
+            </Tooltip>
           </Box>
         </Paper>
       </Box>

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -717,6 +717,7 @@ export function ContinuousColorMappingForm(props: {
                     }}
                   >
                     <Box
+                      onClick={() => setlastDraggedHandleId(h.id)}
                       sx={{
                         width: 2,
                         height: 1,

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -17,8 +17,8 @@ import Delete from '@mui/icons-material/DisabledByDefault'
 import AddCircleIcon from '@mui/icons-material/AddCircle'
 import Palette from '@mui/icons-material/Palette'
 import EditIcon from '@mui/icons-material/Edit'
-import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 
 import RdBu from '../../../../../assets/RdBu.png'
 import PuOr from '../../../../../assets/PuOr.png'
@@ -48,9 +48,9 @@ import { useVisualStyleStore } from '../../../../../store/VisualStyleStore'
 import { ColorGradient } from './ColorGradient'
 import { Handle, addHandle, editHandle, removeHandle } from './Handle'
 
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
+import FormGroup from '@mui/material/FormGroup'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Checkbox from '@mui/material/Checkbox'
 
 // color mapping form for now
 export function ContinuousColorMappingForm(props: {
@@ -101,7 +101,9 @@ export function ContinuousColorMappingForm(props: {
     setEditMinMaxAnchorEl(null)
   }
 
-  const showColorPickerMenu = (event: React.MouseEvent<HTMLButtonElement>): void => {
+  const showColorPickerMenu = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ): void => {
     setColorPickerAnchorEl(event.currentTarget)
   }
 
@@ -119,27 +121,32 @@ export function ContinuousColorMappingForm(props: {
     setCreateHandleAnchorEl(null)
   }
 
-  const [isColorBlindChecked, setIsColorBlindChecked] = React.useState(false);
+  const [isColorBlindChecked, setIsColorBlindChecked] = React.useState(false)
 
-  const handleColorBlindCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    setIsColorBlindChecked(event.target.checked);
-  };
+  const handleColorBlindCheckboxChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    setIsColorBlindChecked(event.target.checked)
+  }
 
-  const [isReverseColorChecked, setIsReverseColorChecked] = React.useState(false);
+  const [isReverseColorChecked, setIsReverseColorChecked] =
+    React.useState(false)
 
-  const handleReverseColorCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    setIsReverseColorChecked(event.target.checked);
-  };
-
+  const handleReverseColorCheckboxChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ): void => {
+    setIsReverseColorChecked(event.target.checked)
+  }
 
   const [minPalette, setMinPalette] = React.useState(min.vpValue)
-  const [middlePalette, setMiddlePalette] = React.useState(controlPoints[1].vpValue)
+  const [middlePalette, setMiddlePalette] = React.useState(
+    controlPoints[1].vpValue,
+  )
   const [maxPalette, setMaxPalette] = React.useState(max.vpValue)
   const [textPalette, setTextPalette] = React.useState('None')
 
-
-  const [buttonText, setButtonText] = React.useState(textPalette);
-  const changeButtonText = (text: string): void => setButtonText(text);
+  const [buttonText, setButtonText] = React.useState(textPalette)
+  const changeButtonText = (text: string): void => setButtonText(text)
 
   const handleColorPicker = (): void => {
     if (!isReverseColorChecked) {
@@ -151,11 +158,11 @@ export function ContinuousColorMappingForm(props: {
         ...maxState,
         vpValue: maxPalette,
       })
-      setHandle(0, min.value as number, minPalette as string);
-      setHandle(1, controlPoints[1].value as number, middlePalette as string);
-      setHandle(2, max.value as number, maxPalette as string);
-      changeButtonText(textPalette);
-      hideColorPickerMenu();
+      setHandle(0, min.value as number, minPalette as string)
+      setHandle(1, controlPoints[1].value as number, middlePalette as string)
+      setHandle(2, max.value as number, maxPalette as string)
+      changeButtonText(textPalette)
+      hideColorPickerMenu()
     } else {
       setMinState({
         ...minState,
@@ -165,11 +172,11 @@ export function ContinuousColorMappingForm(props: {
         ...maxState,
         vpValue: minPalette,
       })
-      setHandle(0, min.value as number, maxPalette as string);
-      setHandle(1, controlPoints[1].value as number, middlePalette as string);
-      setHandle(2, max.value as number, minPalette as string);
-      changeButtonText(textPalette);
-      hideColorPickerMenu();
+      setHandle(0, min.value as number, maxPalette as string)
+      setHandle(1, controlPoints[1].value as number, middlePalette as string)
+      setHandle(2, max.value as number, minPalette as string)
+      changeButtonText(textPalette)
+      hideColorPickerMenu()
     }
   }
 
@@ -200,7 +207,6 @@ export function ContinuousColorMappingForm(props: {
     range: [0, NUM_GRADIENT_STEPS * GRADIENT_STEP_WIDTH],
     domain: extent(valueDomain) as [number, number],
   })
-
 
   // map values to colors
   const colorScale = scaleLinear({
@@ -272,24 +278,22 @@ export function ContinuousColorMappingForm(props: {
     updateContinuousMapping(minState, maxState, newHandles)
   }
 
-
   const setHandle = (id: number, value: number, vpValue: string): void => {
     const newHandles = editHandle(handles, id, value, vpValue)
     setHandles(newHandles)
     updateContinuousMapping(minState, maxState, newHandles)
   }
 
-  const [colorPalette, setColorPalette] = React.useState("");
-
+  const [colorPalette, setColorPalette] = React.useState('')
 
   const handleColorPalette = (
     event: React.MouseEvent<HTMLElement>,
-    newColorPalette: string | null
+    newColorPalette: string | null,
   ): void => {
     if (newColorPalette !== null) {
-      setColorPalette(newColorPalette);
+      setColorPalette(newColorPalette)
     }
-  };
+  }
 
   // when someone changes a handle, the new handle values may contain a new min/max value
   // update the min and max accordingly
@@ -339,7 +343,6 @@ export function ContinuousColorMappingForm(props: {
   }, [maxState])
 
   return (
-
     <Paper sx={{ backgroundColor: '#D9D9D9', pb: 2 }}>
       <Paper
         sx={{
@@ -376,7 +379,9 @@ export function ContinuousColorMappingForm(props: {
             horizontal: 'center',
           }}
         >
-          <Typography align={'center'} sx={{ p: 1 }}>Set Palette</Typography>
+          <Typography align={'center'} sx={{ p: 1 }}>
+            Set Palette
+          </Typography>
           <ToggleButtonGroup
             value={colorPalette}
             onChange={handleColorPalette}
@@ -384,63 +389,142 @@ export function ContinuousColorMappingForm(props: {
             exclusive
             fullWidth={true}
           >
-            <ToggleButton value="rdbu" aria-label="RdBu" onClick={() => { setMinPalette("#b2182b"); setMiddlePalette("#f7f7f7"); setMaxPalette("#2166ac"); setTextPalette('Red-Blue') }}>
+            <ToggleButton
+              value="rdbu"
+              aria-label="RdBu"
+              onClick={() => {
+                setMinPalette('#b2182b')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#2166ac')
+                setTextPalette('Red-Blue')
+              }}
+            >
               <Tooltip title="Red-Blue" placement="right">
                 <img src={RdBu} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
-            <ToggleButton value="puor" aria-label="PuOr" onClick={() => { setMinPalette("#542788"); setMiddlePalette("#f7f7f7"); setMaxPalette("#b35806"); setTextPalette('Purple-Orange') }}>
+            <ToggleButton
+              value="puor"
+              aria-label="PuOr"
+              onClick={() => {
+                setMinPalette('#542788')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#b35806')
+                setTextPalette('Purple-Orange')
+              }}
+            >
               <Tooltip title="Purple-Orange" placement="right">
                 <img src={PuOr} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
-            <ToggleButton value="prgn" aria-label="PRGn" onClick={() => { setMinPalette("#762a83"); setMiddlePalette("#f7f7f7"); setMaxPalette("#1b7837"); setTextPalette('Purple-Red-Green') }}>
+            <ToggleButton
+              value="prgn"
+              aria-label="PRGn"
+              onClick={() => {
+                setMinPalette('#762a83')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#1b7837')
+                setTextPalette('Purple-Red-Green')
+              }}
+            >
               <Tooltip title="Purple-Red-Green" placement="right">
                 <img src={PRGn} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
             {!isColorBlindChecked && (
-              <ToggleButton value="spectral" aria-label="Spectral" onClick={() => { setMinPalette("#d53e4f"); setMiddlePalette("#ffffbf"); setMaxPalette("#3288bd"); setTextPalette('Spectral Colors') }} >
+              <ToggleButton
+                value="spectral"
+                aria-label="Spectral"
+                onClick={() => {
+                  setMinPalette('#d53e4f')
+                  setMiddlePalette('#ffffbf')
+                  setMaxPalette('#3288bd')
+                  setTextPalette('Spectral Colors')
+                }}
+              >
                 <Tooltip title="Spectral Colors" placement="right">
                   <img src={Spectral} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
             )}
 
-            <ToggleButton value="brbg" aria-label="BrBG" onClick={() => { setMinPalette("#8c510a"); setMiddlePalette("#f5f5f5"); setMaxPalette("#01665e"); setTextPalette('Brown-Blue-Green') }}>
+            <ToggleButton
+              value="brbg"
+              aria-label="BrBG"
+              onClick={() => {
+                setMinPalette('#8c510a')
+                setMiddlePalette('#f5f5f5')
+                setMaxPalette('#01665e')
+                setTextPalette('Brown-Blue-Green')
+              }}
+            >
               <Tooltip title="Brown-Blue-Green" placement="right">
                 <img src={BrBG} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
             {!isColorBlindChecked && (
-              <ToggleButton value="rdylgn" aria-label="RdYlGn" onClick={() => { setMinPalette("#d73027"); setMiddlePalette("#ffffbf"); setMaxPalette("#1a9850"); setTextPalette('Red-Yellow-Green') }}>
+              <ToggleButton
+                value="rdylgn"
+                aria-label="RdYlGn"
+                onClick={() => {
+                  setMinPalette('#d73027')
+                  setMiddlePalette('#ffffbf')
+                  setMaxPalette('#1a9850')
+                  setTextPalette('Red-Yellow-Green')
+                }}
+              >
                 <Tooltip title="Red-Yellow-Green" placement="right">
                   <img src={RdYlGn} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
             )}
 
-
-            <ToggleButton value="piyg" aria-label="PiYG" onClick={() => { setMinPalette("#c51b7d"); setMiddlePalette("#f7f7f7"); setMaxPalette("#4d9221"); setTextPalette('Magenta-Yellow-Green') }}>
+            <ToggleButton
+              value="piyg"
+              aria-label="PiYG"
+              onClick={() => {
+                setMinPalette('#c51b7d')
+                setMiddlePalette('#f7f7f7')
+                setMaxPalette('#4d9221')
+                setTextPalette('Magenta-Yellow-Green')
+              }}
+            >
               <Tooltip title="Magenta-Yellow-Green" placement="right">
                 <img src={PiYG} width="15" height="150" />
               </Tooltip>
             </ToggleButton>
 
             {!isColorBlindChecked && (
-              <ToggleButton value="rdgy" aria-label="RdGy" onClick={() => { setMinPalette("#b2182b"); setMiddlePalette("#ffffff"); setMaxPalette("#4d4d4d"); setTextPalette('Red-Grey') }}>
+              <ToggleButton
+                value="rdgy"
+                aria-label="RdGy"
+                onClick={() => {
+                  setMinPalette('#b2182b')
+                  setMiddlePalette('#ffffff')
+                  setMaxPalette('#4d4d4d')
+                  setTextPalette('Red-Grey')
+                }}
+              >
                 <Tooltip title="Red-Grey" placement="right">
                   <img src={RdGy} width="15" height="150" />
                 </Tooltip>
               </ToggleButton>
             )}
 
-
-            <ToggleButton value="rdylbu" aria-label="RdYlBu" onClick={() => { setMinPalette("#d73027"); setMiddlePalette("#ffffbf"); setMaxPalette("#4575b4"); setTextPalette('Red-Yellow-Blue') }}>
+            <ToggleButton
+              value="rdylbu"
+              aria-label="RdYlBu"
+              onClick={() => {
+                setMinPalette('#d73027')
+                setMiddlePalette('#ffffbf')
+                setMaxPalette('#4575b4')
+                setTextPalette('Red-Yellow-Blue')
+              }}
+            >
               <Tooltip title="Red-Yellow-Blue" placement="right">
                 <img src={RdYlBu} width="15" height="150" />
               </Tooltip>
@@ -460,10 +544,26 @@ export function ContinuousColorMappingForm(props: {
             }}
           >
             <FormGroup>
-              <FormControlLabel control={<Checkbox checked={isReverseColorChecked} onChange={handleReverseColorCheckboxChange} />} label="reverse colors" />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isReverseColorChecked}
+                    onChange={handleReverseColorCheckboxChange}
+                  />
+                }
+                label="reverse colors"
+              />
             </FormGroup>
             <FormGroup>
-              <FormControlLabel control={<Checkbox checked={isColorBlindChecked} onChange={handleColorBlindCheckboxChange} />} label="colorblind-friendly" />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={isColorBlindChecked}
+                    onChange={handleColorBlindCheckboxChange}
+                  />
+                }
+                label="colorblind-friendly"
+              />
             </FormGroup>
           </Paper>
           <Paper
@@ -497,7 +597,6 @@ export function ContinuousColorMappingForm(props: {
               Cancel
             </Button>
           </Paper>
-
         </Popover>
       </Paper>
       <Box
@@ -698,8 +797,6 @@ export function ContinuousColorMappingForm(props: {
           color: '#595858',
         }}
       >
-
-
         <Button
           onClick={showCreateHandleMenu}
           variant="outlined"

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -32,6 +32,7 @@ import { useVisualStyleStore } from '../../../../../store/VisualStyleStore'
 
 import { Handle, addHandle, removeHandle, editHandle } from './Handle'
 import { LineChart } from './LineChart'
+import { VisualPropertyValueForm } from '../../VisualPropertyValueForm'
 
 export function ContinuousNumberMappingForm(props: {
   currentNetworkId: IdType
@@ -147,6 +148,8 @@ export function ContinuousNumberMappingForm(props: {
           min: ContinuousFunctionControlPoint,
           max: ContinuousFunctionControlPoint,
           handles: Handle[],
+          ltMinVpValue: VisualPropertyValueType,
+          gtMaxVpValue: VisualPropertyValueType,
         ) => {
           setContinuousMappingValues(
             props.currentNetworkId,
@@ -159,6 +162,8 @@ export function ContinuousNumberMappingForm(props: {
                 vpValue: h.vpValue,
               }
             }),
+            ltMinVpValue,
+            gtMaxVpValue,
           )
         },
         200,
@@ -195,19 +200,37 @@ export function ContinuousNumberMappingForm(props: {
     const newHandles = addHandle(handles, value, vpValue)
 
     setHandles(newHandles)
-    updateContinuousMapping(min, max, newHandles)
+    updateContinuousMapping(
+      min,
+      max,
+      newHandles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }
 
   const deleteHandle = (id: number): void => {
     const newHandles = removeHandle(handles, id)
     setHandles(newHandles)
-    updateContinuousMapping(minState, maxState, newHandles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      newHandles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }
 
   const setHandle = (id: number, value: number, vpValue: number): void => {
     const newHandles = editHandle(handles, id, value, vpValue)
     setHandles(newHandles)
-    updateContinuousMapping(minState, maxState, newHandles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      newHandles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }
 
   // when someone changes a handle, the new handle values may contain a new min/max value
@@ -241,7 +264,13 @@ export function ContinuousNumberMappingForm(props: {
     })
     setHandles(newHandles)
 
-    updateContinuousMapping(minState, maxState, handles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      handles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }, [minState])
 
   // anytime someone changes the max value, make sure all handle values are less than the max
@@ -254,7 +283,13 @@ export function ContinuousNumberMappingForm(props: {
     })
     setHandles(newHandles)
 
-    updateContinuousMapping(minState, maxState, handles)
+    updateContinuousMapping(
+      minState,
+      maxState,
+      handles,
+      m.ltMinVpValue,
+      m.gtMaxVpValue,
+    )
   }, [maxState])
 
   return (
@@ -277,7 +312,7 @@ export function ContinuousNumberMappingForm(props: {
         >
           <Tooltip
             title="Drag handles or change the handle values to edit the mapping"
-            placement="bottom"
+            placement="right"
           >
             <Box
               sx={{
@@ -499,6 +534,66 @@ export function ContinuousNumberMappingForm(props: {
                   </Draggable>
                 )
               })}
+              <Tooltip title="Set number value for values under the minimum.">
+                <Box
+                  sx={{
+                    width: 2,
+                    height: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    position: 'relative',
+                    bottom: -LINE_CHART_HEIGHT + 50,
+                    right: LINE_CHART_WIDTH - 25,
+                    zIndex: 1000,
+                  }}
+                >
+                  <VisualPropertyValueForm
+                    currentValue={m.ltMinVpValue}
+                    visualProperty={props.visualProperty}
+                    currentNetworkId={props.currentNetworkId}
+                    onValueChange={(newValue) => {
+                      updateContinuousMapping(
+                        min,
+                        max,
+                        handles,
+                        newValue,
+                        m.gtMaxVpValue,
+                      )
+                    }}
+                  />
+                </Box>
+              </Tooltip>
+              <Tooltip title="Set number value for values over the maximum.">
+                <Box
+                  sx={{
+                    width: 2,
+                    height: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    position: 'relative',
+                    bottom: -LINE_CHART_HEIGHT + 50,
+                    right: 25,
+                    zIndex: 1000,
+                  }}
+                >
+                  <VisualPropertyValueForm
+                    currentValue={m.gtMaxVpValue}
+                    visualProperty={props.visualProperty}
+                    currentNetworkId={props.currentNetworkId}
+                    onValueChange={(newValue) => {
+                      updateContinuousMapping(
+                        min,
+                        max,
+                        handles,
+                        m.ltMinVpValue,
+                        newValue,
+                      )
+                    }}
+                  />
+                </Box>
+              </Tooltip>
             </Box>
           </Tooltip>
         </Paper>

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -33,6 +33,7 @@ import { useVisualStyleStore } from '../../../../../store/VisualStyleStore'
 import { Handle, addHandle, removeHandle, editHandle } from './Handle'
 import { LineChart } from './LineChart'
 import { VisualPropertyValueForm } from '../../VisualPropertyValueForm'
+import { ExpandableNumberInput } from './ExpandableNumberInput'
 
 export function ContinuousNumberMappingForm(props: {
   currentNetworkId: IdType
@@ -394,7 +395,7 @@ export function ContinuousNumberMappingForm(props: {
                       <Paper
                         elevation={4}
                         sx={{
-                          p: 0.5,
+                          p: 1,
                           position: 'relative',
                           top: -HANDLE_VERTICAL_OFFSET - pixelPositionY,
                           zIndex: lastDraggedHandleId === h.id ? 3 : 1,
@@ -444,26 +445,12 @@ export function ContinuousNumberMappingForm(props: {
                             >
                               {props.visualProperty.displayName}
                             </Typography>
-                            <TextField
-                              sx={{ width: 50, ml: 0.5 }}
-                              inputProps={{
-                                sx: {
-                                  p: 0.5,
-                                  fontSize: 14,
-                                  width: 50,
-                                },
-                                inputMode: 'numeric',
-                                pattern: '[0-9]*',
-                                step: 0.1,
-                              }}
-                              onChange={(e) => {
-                                const newVal = Number(
-                                  Number(e.target.value).toFixed(2),
-                                )
+                            <ExpandableNumberInput
+                              value={h.vpValue as number}
+                              onConfirm={(newVal) => {
                                 setHandle(h.id, h.value as number, newVal)
                               }}
-                              value={h.vpValue as number}
-                            />
+                            ></ExpandableNumberInput>
                           </Box>
                           <Box
                             sx={{
@@ -486,29 +473,13 @@ export function ContinuousNumberMappingForm(props: {
                             >
                               {m.attribute}
                             </Typography>
-
-                            <TextField
-                              sx={{ width: 50, ml: 0.5 }}
-                              inputProps={{
-                                sx: {
-                                  p: 0.5,
-                                  fontSize: 14,
-                                  width: 50,
-                                },
-                                inputMode: 'numeric',
-                                pattern: '[0-9]*',
-                                step: 0.1,
-                              }}
-                              onChange={(e) => {
-                                const newVal = Number(
-                                  Number(e.target.value).toFixed(2),
-                                )
-
-                                if (!isNaN(newVal)) {
-                                  setHandle(h.id, newVal, h.vpValue as number)
-                                }
-                              }}
+                            <ExpandableNumberInput
+                              min={minState.value as number}
+                              max={maxState.value as number}
                               value={h.value as number}
+                              onConfirm={(newVal) => {
+                                setHandle(h.id, newVal, h.vpValue as number)
+                              }}
                             />
                           </Box>
                         </Box>
@@ -642,42 +613,39 @@ export function ContinuousNumberMappingForm(props: {
             }}
           >
             <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
-              <TextField
-                sx={{ mb: 1 }}
-                variant="outlined"
-                size="small"
-                label={m.attribute}
-                inputProps={{
-                  inputMode: 'numeric',
-                  pattern: '[0-9]*',
-                  step: 0.1,
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
                 }}
-                onChange={(e) => {
-                  const newValue = Number(e.target.value)
-                  if (!isNaN(newValue)) {
-                    setAddHandleFormValue(newValue)
-                  }
-                }}
-                value={addHandleFormValue}
-              />
+              >
+                {m.attribute}
+                <ExpandableNumberInput
+                  min={minState.value as number}
+                  max={maxState.value as number}
+                  value={addHandleFormValue}
+                  onConfirm={(newVal) => {
+                    setAddHandleFormValue(newVal)
+                  }}
+                ></ExpandableNumberInput>
+              </Box>
 
-              <TextField
-                variant="outlined"
-                size="small"
-                label={props.visualProperty.displayName}
-                inputProps={{
-                  inputMode: 'numeric',
-                  pattern: '[0-9]*',
-                  step: 0.1,
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
                 }}
-                onChange={(e) => {
-                  const newValue = Number(e.target.value)
-                  if (!isNaN(newValue)) {
-                    setAddHandleFormVpValue(newValue)
-                  }
-                }}
-                value={addHandleFormVpValue}
-              />
+              >
+                {props.visualProperty.displayName}
+                <ExpandableNumberInput
+                  value={addHandleFormVpValue}
+                  onConfirm={(newVal) => {
+                    setAddHandleFormVpValue(newVal)
+                  }}
+                ></ExpandableNumberInput>
+              </Box>
             </Box>
             <Button
               variant="outlined"
@@ -713,52 +681,48 @@ export function ContinuousNumberMappingForm(props: {
             horizontal: 'center',
           }}
         >
-          <Box sx={{ p: 1 }}>
+          <Box sx={{ p: 1, width: 200 }}>
             <Box>
               <Typography variant="body1">{m.attribute}</Typography>
-
-              <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
-                <TextField
-                  sx={{ mb: 1 }}
-                  variant="outlined"
-                  size="small"
-                  label="Min"
-                  inputProps={{
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
+              <Box sx={{ p: 1 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
                   }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
+                >
+                  <Typography variant="body2">Minimum Value</Typography>
+
+                  <ExpandableNumberInput
+                    value={minState.value as number}
+                    onConfirm={(newVal) => {
                       setMinState({
                         ...minState,
-                        value: newValue,
+                        value: newVal,
                       })
-                    }
+                    }}
+                  ></ExpandableNumberInput>
+                </Box>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
                   }}
-                  value={minState.value}
-                />
-                <TextField
-                  value={maxState.value}
-                  variant="outlined"
-                  size="small"
-                  label="Max"
-                  inputProps={{
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
-                  }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
+                >
+                  <Typography variant="body2">Maximum Value</Typography>
+
+                  <ExpandableNumberInput
+                    value={maxState.value as number}
+                    onConfirm={(newVal) => {
                       setMaxState({
                         ...maxState,
-                        value: newValue,
+                        value: newVal,
                       })
-                    }
-                  }}
-                />
+                    }}
+                  ></ExpandableNumberInput>
+                </Box>
               </Box>
             </Box>
           </Box>
@@ -785,25 +749,13 @@ export function ContinuousNumberMappingForm(props: {
                 }}
               >
                 <Typography variant="body2">{m.attribute}:</Typography>
-                <TextField
-                  sx={{ width: 40, ml: 0.5, mr: 0.5 }}
-                  inputProps={{
-                    sx: {
-                      p: 0.5,
-                      fontSize: 12,
-                      width: 50,
-                    },
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
-                  }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
-                      setAddHandleFormValue(newValue)
-                    }
-                  }}
+                <ExpandableNumberInput
                   value={addHandleFormValue}
+                  min={minState.value as number}
+                  max={maxState.value as number}
+                  onConfirm={(newVal) => {
+                    setAddHandleFormValue(newVal)
+                  }}
                 />
               </Box>
               <Box
@@ -818,25 +770,11 @@ export function ContinuousNumberMappingForm(props: {
                 <Typography variant="body2">
                   {props.visualProperty.displayName}:
                 </Typography>
-                <TextField
-                  sx={{ width: 40, ml: 0.5, mr: 0.5 }}
-                  inputProps={{
-                    sx: {
-                      p: 0.5,
-                      fontSize: 12,
-                      width: 50,
-                    },
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
-                  }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
-                      setAddHandleFormVpValue(newValue)
-                    }
-                  }}
+                <ExpandableNumberInput
                   value={addHandleFormVpValue}
+                  onConfirm={(newVal) => {
+                    setAddHandleFormVpValue(newVal)
+                  }}
                 />
               </Box>
             </Box>
@@ -855,50 +793,22 @@ export function ContinuousNumberMappingForm(props: {
             <Box>
               <Typography variant="body2">{m.attribute}:</Typography>
               <Box sx={{ display: 'flex' }}>
-                <TextField
-                  sx={{ width: 40, ml: 0.5, mr: 0.5 }}
-                  inputProps={{
-                    sx: {
-                      p: 0.5,
-                      fontSize: 12,
-                      width: 50,
-                    },
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
+                <ExpandableNumberInput
+                  value={minState.value as number}
+                  onConfirm={(newValue) => {
+                    setMinState({
+                      ...minState,
+                      value: newValue,
+                    })
                   }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
-                      setMinState({
-                        ...minState,
-                        value: newValue,
-                      })
-                    }
-                  }}
-                  value={minState.value}
                 />
-                <TextField
-                  value={maxState.value}
-                  sx={{ width: 40, ml: 0.5, mr: 0.5 }}
-                  inputProps={{
-                    sx: {
-                      p: 0.5,
-                      fontSize: 12,
-                      width: 50,
-                    },
-                    inputMode: 'numeric',
-                    pattern: '[0-9]*',
-                    step: 0.1,
-                  }}
-                  onChange={(e) => {
-                    const newValue = Number(e.target.value)
-                    if (!isNaN(newValue)) {
-                      setMaxState({
-                        ...maxState,
-                        value: newValue,
-                      })
-                    }
+                <ExpandableNumberInput
+                  value={maxState.value as number}
+                  onConfirm={(newValue) => {
+                    setMaxState({
+                      ...maxState,
+                      value: newValue,
+                    })
                   }}
                 />
               </Box>

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -380,6 +380,7 @@ export function ContinuousNumberMappingForm(props: {
                     }}
                   >
                     <Box
+                      onClick={() => setlastDraggedHandleId(h.id)}
                       sx={{
                         width: 2,
                         height: 1,

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ExpandableNumberInput.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ExpandableNumberInput.tsx
@@ -91,7 +91,7 @@ export function ExpandableNumberInput(props: {
           min={props.min}
           max={props.max}
           value={localValue as number}
-          decimalScale={2}
+          // decimalScale={2}
           onChange={(newValue) => {
             if (typeof newValue === 'string') {
               setLocalValue(0)

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ExpandableNumberInput.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ExpandableNumberInput.tsx
@@ -1,0 +1,120 @@
+import { MantineProvider, NumberInput } from '@mantine/core'
+import { ButtonBase, Box, Popover, Button } from '@mui/material'
+import React from 'react'
+
+// A button that displays a number input value, the user can click this button to open up a dropdown form that allows the user to input a number and cancel/confirm
+export function ExpandableNumberInput(props: {
+  value: number
+  onConfirm: (value: number) => void
+  min?: number
+  max?: number
+}): React.ReactElement {
+  const { value, onConfirm } = props
+  const [localValue, setLocalValue] = React.useState<number>(value as number)
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null)
+
+  React.useEffect(() => {
+    setLocalValue(value as number)
+  }, [value])
+
+  const handleCancel = () => {
+    setLocalValue(value as number)
+    hidePopover()
+  }
+
+  const handleConfirm = () => {
+    onConfirm(localValue)
+    hidePopover()
+  }
+
+  const showPopover = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const hidePopover = (): void => {
+    setAnchorEl(null)
+  }
+
+  const isValid = (value: number): boolean => {
+    if (props.min != null && value < props.min) {
+      return false
+    }
+    if (props.max != null && value > props.max) {
+      return false
+    }
+    return true
+  }
+
+  return (
+    <MantineProvider>
+      <ButtonBase onClick={(e) => showPopover(e)}>
+        <Box
+          sx={{
+            width: 45,
+            height: 25,
+            zIndex: 4,
+
+            '&:hover': {
+              pointer: 'cursor',
+            },
+            overflow: 'hidden',
+            border: '1px solid #d6d6d6',
+            borderRadius: '4px',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          {value.toFixed(2)}
+        </Box>
+      </ButtonBase>
+
+      <Popover
+        open={anchorEl != null}
+        anchorEl={anchorEl}
+        onClose={hidePopover}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
+        <NumberInput
+          error={
+            !isValid(localValue)
+              ? `Value must be between ${props.min} and ${props.max}`
+              : null
+          }
+          min={props.min}
+          max={props.max}
+          value={localValue as number}
+          decimalScale={2}
+          onChange={(newValue) => {
+            if (typeof newValue === 'string') {
+              setLocalValue(0)
+            } else {
+              setLocalValue(newValue)
+            }
+          }}
+        />
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Button color="error" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button disabled={!isValid(localValue)} onClick={handleConfirm}>
+            Confirm
+          </Button>
+        </Box>
+      </Popover>
+    </MantineProvider>
+  )
+}

--- a/src/models/StoreModel/VisualStyleStoreModel.ts
+++ b/src/models/StoreModel/VisualStyleStoreModel.ts
@@ -52,6 +52,8 @@ export interface UpdateVisualStyleAction {
     min: ContinuousFunctionControlPoint,
     max: ContinuousFunctionControlPoint,
     controlPoints: ContinuousFunctionControlPoint[],
+    ltMinVpValue: VisualPropertyValueType,
+    gtMaxVpValue: VisualPropertyValueType,
   ) => void
   setMapping: (
     networkId: IdType,

--- a/src/models/VisualStyleModel/VisualMappingFunction/ContinuousMappingFunction.ts
+++ b/src/models/VisualStyleModel/VisualMappingFunction/ContinuousMappingFunction.ts
@@ -13,4 +13,6 @@ export interface ContinuousMappingFunction extends VisualMappingFunction {
   min: ContinuousFunctionControlPoint
   max: ContinuousFunctionControlPoint
   controlPoints: ContinuousFunctionControlPoint[]
+  gtMaxVpValue: VisualPropertyValueType
+  ltMinVpValue: VisualPropertyValueType
 }

--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -94,7 +94,7 @@ const toRangeAndDomain = <T extends VisualPropertyValueType>(
 
   return [domain, range]
 }
-const getMapper = <T extends VisualPropertyValueType>(
+export const getMapper = <T extends VisualPropertyValueType>(
   cm: ContinuousMappingFunction,
 ): Mapper => {
   const { min, max, controlPoints, defaultValue, ltMinVpValue, gtMaxVpValue } =

--- a/src/models/VisualStyleModel/impl/MapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/MapperFactory.ts
@@ -94,15 +94,13 @@ const toRangeAndDomain = <T extends VisualPropertyValueType>(
 
   return [domain, range]
 }
-
 const getMapper = <T extends VisualPropertyValueType>(
   cm: ContinuousMappingFunction,
 ): Mapper => {
-  const { min, max, controlPoints, defaultValue } = cm
+  const { min, max, controlPoints, defaultValue, ltMinVpValue, gtMaxVpValue } =
+    cm
   const minValue = min.value as number
   const maxValue = max.value as number
-  const minVpValue = min.vpValue as T
-  const maxVpValue = max.vpValue as T
   const [domain, range] = toRangeAndDomain<T>(controlPoints)
   const d3Mapper = d3Scale.scaleLinear<T>().domain(domain).range(range)
   d3Mapper.clamp(true)
@@ -118,9 +116,9 @@ const getMapper = <T extends VisualPropertyValueType>(
           ? numericAttrValue >= maxValue
           : numericAttrValue > maxValue
       if (isGreaterThanMax) {
-        return maxVpValue
+        return gtMaxVpValue ?? max.vpValue
       } else if (isLessThanMin) {
-        return minVpValue
+        return ltMinVpValue ?? min.vpValue
       } else {
         return d3Mapper(numericAttrValue)
       }

--- a/src/models/VisualStyleModel/impl/VisualStyleFnImpl.ts
+++ b/src/models/VisualStyleModel/impl/VisualStyleFnImpl.ts
@@ -349,6 +349,12 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                   controlPoints: sortedCtrlPts,
                   visualPropertyType: vp.type,
                   defaultValue: vp.defaultValue,
+                  gtMaxVpValue: converter.valueConverter(
+                    max.vpValue as CXVisualPropertyValue,
+                  ),
+                  ltMinVpValue: converter.valueConverter(
+                    min.vpValue as CXVisualPropertyValue,
+                  ),
                 }
                 visualStyle[vpName].mapping = m
               } else {

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -137,7 +137,8 @@ export const convertContinuousMappingToCX = (
   vp: VisualProperty<VisualPropertyValueType>,
   mapping: ContinuousMappingFunction,
 ): CXContinuousMappingFunction<CXVisualPropertyValue> => {
-  const { min, max, controlPoints, attribute } = mapping
+  const { min, max, controlPoints, attribute, ltMinVpValue, gtMaxVpValue } =
+    mapping
 
   const intervals = []
 
@@ -163,14 +164,14 @@ export const convertContinuousMappingToCX = (
       map: [
         {
           max: min.value as number,
-          maxVPValue: vpToCX(vp.name, min.vpValue),
+          maxVPValue: vpToCX(vp.name, ltMinVpValue),
           includeMax: min.inclusive ?? true,
           includeMin: true, // dummy value, not actually used here
         },
         ...intervals,
         {
           min: max.value as number,
-          minVPValue: vpToCX(vp.name, max.vpValue),
+          minVPValue: vpToCX(vp.name, gtMaxVpValue),
           includeMin: max.inclusive ?? true,
           includeMax: true, // dummy value, not actually used here
         },

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -165,15 +165,15 @@ export const convertContinuousMappingToCX = (
         {
           max: min.value as number,
           maxVPValue: vpToCX(vp.name, ltMinVpValue),
-          includeMax: min.inclusive ?? true,
-          includeMin: true, // dummy value, not actually used here
+          includeMax: min.inclusive ?? false,
+          includeMin: false, // dummy value, not actually used here
         },
         ...intervals,
         {
           min: max.value as number,
           minVPValue: vpToCX(vp.name, gtMaxVpValue),
-          includeMin: max.inclusive ?? true,
-          includeMax: true, // dummy value, not actually used here
+          includeMin: max.inclusive ?? false,
+          includeMax: false, // dummy value, not actually used here
         },
       ],
       attribute,

--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -198,13 +198,13 @@ export const useVisualStyleStore = create(
             const min = {
               value: attributeValues[0],
               vpValue: DEFAULT_COLOR_SCHEME[0],
-              inclusive: true,
+              inclusive: false,
             }
 
             const max = {
               value: attributeValues[attributeValues.length - 1],
               vpValue: DEFAULT_COLOR_SCHEME[2],
-              inclusive: true,
+              inclusive: false,
             }
 
             const ctrlPts = [
@@ -233,13 +233,13 @@ export const useVisualStyleStore = create(
             const min = {
               value: attributeValues[0],
               vpValue: DEFAULT_NUMBER_RANGE[0],
-              inclusive: true,
+              inclusive: false,
             }
 
             const max = {
               value: attributeValues[attributeValues.length - 1],
               vpValue: DEFAULT_NUMBER_RANGE[1],
-              inclusive: true,
+              inclusive: false,
             }
 
             const ctrlPts = [

--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -31,27 +31,27 @@ import { VisualStyleStore } from '../models/StoreModel/VisualStyleStoreModel'
  */
 const persist =
   (config: StateCreator<VisualStyleStore>) =>
-    (
-      set: StoreApi<VisualStyleStore>['setState'],
-      get: StoreApi<VisualStyleStore>['getState'],
-      api: StoreApi<VisualStyleStore>,
-    ) =>
-      config(
-        async (args) => {
-          const currentNetworkId =
-            useWorkspaceStore.getState().workspace.currentNetworkId
+  (
+    set: StoreApi<VisualStyleStore>['setState'],
+    get: StoreApi<VisualStyleStore>['getState'],
+    api: StoreApi<VisualStyleStore>,
+  ) =>
+    config(
+      async (args) => {
+        const currentNetworkId =
+          useWorkspaceStore.getState().workspace.currentNetworkId
 
-          set(args)
-          const updated = get().visualStyles[currentNetworkId]
-          const deleted = updated === undefined
+        set(args)
+        const updated = get().visualStyles[currentNetworkId]
+        const deleted = updated === undefined
 
-          if (!deleted) {
-            await putVisualStyleToDb(currentNetworkId, updated).then(() => { })
-          }
-        },
-        get,
-        api,
-      )
+        if (!deleted) {
+          await putVisualStyleToDb(currentNetworkId, updated).then(() => {})
+        }
+      },
+      get,
+      api,
+    )
 
 export const useVisualStyleStore = create(
   immer<VisualStyleStore>(
@@ -142,6 +142,8 @@ export const useVisualStyleStore = create(
         min,
         max,
         controlPoints,
+        ltMinVpValue,
+        gtMaxVpValue,
       ) => {
         set((state) => {
           const mapping = state.visualStyles[networkId][vpName]
@@ -150,6 +152,8 @@ export const useVisualStyleStore = create(
             mapping.min = min
             mapping.max = max
             mapping.controlPoints = controlPoints
+            mapping.ltMinVpValue = ltMinVpValue
+            mapping.gtMaxVpValue = gtMaxVpValue
           }
           return state
         })
@@ -263,6 +267,8 @@ export const useVisualStyleStore = create(
               controlPoints: ctrlPts,
               visualPropertyType: type,
               defaultValue,
+              ltMinVpValue: DEFAULT_COLOR_SCHEME[0],
+              gtMaxVpValue: DEFAULT_COLOR_SCHEME[2],
             }
             // void putVisualStyleToDb(
             //   networkId,
@@ -280,6 +286,8 @@ export const useVisualStyleStore = create(
               controlPoints: ctrlPts,
               visualPropertyType: type,
               defaultValue,
+              ltMinVpValue: DEFAULT_NUMBER_RANGE[0],
+              gtMaxVpValue: DEFAULT_NUMBER_RANGE[1],
             }
             state.visualStyles[networkId][vpName].mapping = continuousMapping
           } else {

--- a/src/utils/is-url.ts
+++ b/src/utils/is-url.ts
@@ -1,8 +1,6 @@
 export function isValidUrl(input: string): boolean {
-  try {
-    const url = new URL(input)
-    return url != null
-  } catch (e) {
-    return false
-  }
+  const urlPattern =
+    /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[a-zA-Z0-9-._~:\/?#[\]@!$&'()*+,;=]*)?$/
+
+  return urlPattern.test(input)
 }


### PR DESCRIPTION
- Continuous number mapper uses ExpandableNumberInput instead of TextFields, allowing users to cancel/confirm new number values alongside min/max validation
- Various style tweaks for the color mapper and number mapper dialog.
- Fix issue where users could enter values greater than the min/max for any handle and in the new handle form.
- Change all number inputs in the continous color mapper to have cancel/confirm behaviour.  The mapping will not be updated until the user presses confirm.
- Fix issue where negative numbers and decimals couldn't be entered into the number inputs.
- Use the same render function for the color gradient in the continuous mapping form as the one that is used for color rendering in the network view.
- Users can click anywhere on any handle to bring it to the front of all other handles
- Fix issue where continuous mapping functions were not exported properly w.r.t inclusive min/max mapping values
- Add two buttons to the ends of each continuous mapping form to allow users to change the mapped value for values that fall outside the domain of the mapping.
