### PR TITLE
Mark network as modified if style changes

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -233,7 +233,7 @@ export default function TableBrowser(props: {
   // set the network to 'modified' when the table data is modified
   useTableStore.subscribe(
     (state) => state.tables[networkId],
-    (prev: TableRecord, next: TableRecord) => {
+    (next: TableRecord, prev: TableRecord) => {
       if (prev === undefined || next === undefined) {
         return
       }

--- a/src/components/Vizmapper/VisualPropertyRender/Checkbox.tsx
+++ b/src/components/Vizmapper/VisualPropertyRender/Checkbox.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Checkbox, FormControlLabel } from '@mui/material'
 import { IdType } from '../../../models/IdType'
 import { useUiStateStore } from '../../../store/UiStateStore'
+import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 
 export const LockSizeCheckbox = (props: { currentNetworkId: IdType }) => {
   const { currentNetworkId } = props
@@ -10,12 +11,16 @@ export const LockSizeCheckbox = (props: { currentNetworkId: IdType }) => {
       state.ui.visualStyleOptions[currentNetworkId]?.visualEditorProperties
         ?.nodeSizeLocked,
   )
+  const setNetworkModified: (id: IdType, isModified: boolean) => void =
+    useWorkspaceStore((state) => state.setNetworkModified)
+
   const setNodeSizeLockedState = useUiStateStore(
     (state) => state.setNodeSizeLockedState,
   )
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newStatus = event.target.checked
     setNodeSizeLockedState(currentNetworkId, newStatus)
+    setNetworkModified(currentNetworkId, true)
   }
 
   return (
@@ -39,12 +44,16 @@ export const LockColorCheckbox = (props: { currentNetworkId: IdType }) => {
       state.ui.visualStyleOptions[currentNetworkId]?.visualEditorProperties
         .arrowColorMatchesEdge,
   )
+  const setNetworkModified: (id: IdType, isModified: boolean) => void =
+    useWorkspaceStore((state) => state.setNetworkModified)
+
   const setArrowColorMatchesEdgeState = useUiStateStore(
     (state) => state.setArrowColorMatchesEdgeState,
   )
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newStatus = event.target.checked
     setArrowColorMatchesEdgeState(currentNetworkId, newStatus)
+    setNetworkModified(currentNetworkId, true)
   }
 
   return (


### PR DESCRIPTION
Ticket: [https://cytoscape.atlassian.net/browse/CW-418](https://cytoscape.atlassian.net/browse/CW-418)

Mark network as isModified when these properties change:
- VisualStyle
- VisualStyleOptions (only includes status of _nodeSizeLocked_ and _arrowColorMatchesEdge_ for now)