### PR TITLE
Simple Fix for CW-376 (missing edges)

### DIFF
--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -502,6 +502,7 @@ const CyjsRenderer = ({
     } else {
       // At least one edge is selected.
       if (displayMode === DisplayMode.SHOW_HIDE) {
+        // TODO: design a better way to show / hide edges, including multiple selection
         cy.edges().hide()
       } else {
         cy.edges().show()

--- a/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
+++ b/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
@@ -73,11 +73,6 @@ export const SubNetworkPanel = ({
   const filterConfigs = useFilterStore((state) => state.filterConfigs)
   const addFilterConfig = useFilterStore((state) => state.addFilterConfig)
 
-  const filterConfig: FilterConfig | undefined =
-    filterConfigs[DEFAULT_FILTER_NAME]
-
-  const displayMode: DisplayMode =
-    filterConfig?.displayMode ?? DisplayMode.SELECT
 
   // All networks in the main store
   const networks: Map<string, Network> = useNetworkStore(
@@ -455,6 +450,12 @@ export const SubNetworkPanel = ({
   if (queryNetwork === undefined) {
     return <MessagePanel message={`Select a subsystem`} />
   }
+  
+  const filterConfig: FilterConfig | undefined =
+    filterConfigs[queryNetwork.id]
+
+  const displayMode: DisplayMode =
+    filterConfig?.displayMode ?? DisplayMode.SELECT
 
   return (
     <Box


### PR DESCRIPTION
I've tried several ideas for show/hide edge features for filtering, but it requires major change in the renderer, so for this round, I'll keep the same mechanism, but use the normal selection mode whenever filters are not available for the interaction network.