### PR TITLE
CW-428: Moved custom tab name manager to the custom hook from the panel

### DIFF
--- a/src/features/HierarchyViewer/components/MainPanel.tsx
+++ b/src/features/HierarchyViewer/components/MainPanel.tsx
@@ -24,9 +24,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import FilterPanel from './FilterPanel/FilterPanel'
 import { DuplicateNodeSeparator } from './CustomLayout/DataBuilderUtil'
 import { useSubNetworkStore } from '../store/SubNetworkStore'
-import { useUiStateStore } from '../../../store/UiStateStore'
-import { use } from 'cytoscape'
-import { DEFAULT_RENDERER_ID } from '../../../store/DefaultRenderer'
 
 export const RENDERER_TAG: string = 'secondary'
 export interface Query {
@@ -75,17 +72,6 @@ export const MainPanel = (): JSX.Element => {
   const setRootNetworkHost = useSubNetworkStore(
     (state) => state.setRootNetworkHost,
   )
-  const setCustomNetworkTabName = useUiStateStore(
-    (state) => state.setCustomNetworkTabName,
-  )
-
-  useEffect(() => {
-    setCustomNetworkTabName(DEFAULT_RENDERER_ID, 'Tree View')
-    // clear the name when the component is unmounted
-    return () => {
-      setCustomNetworkTabName(DEFAULT_RENDERER_ID, '')
-    }
-  }, [])
 
   const CirclePackingRenderer: Renderer = {
     id: CP_RENDERER_ID,

--- a/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
+++ b/src/features/HierarchyViewer/store/useHierarchyViewerManager.tsx
@@ -21,6 +21,7 @@ import {
   getAllNetworkKeys,
 } from '../../../store/persist/db'
 import { useRendererStore } from '../../../store/RendererStore'
+import { DEFAULT_RENDERER_ID } from '../../../store/DefaultRenderer'
 
 /**
  *  Switch the panel state based on the network meta data
@@ -33,6 +34,19 @@ export const useHierarchyViewerManager = (): void => {
   const networkIds: IdType[] = useWorkspaceStore(
     (state) => state.workspace.networkIds,
   )
+
+  // For managing tab name for HCX
+  const setCustomNetworkTabName = useUiStateStore(
+    (state) => state.setCustomNetworkTabName,
+  )
+
+  useEffect(() => {
+    setCustomNetworkTabName(DEFAULT_RENDERER_ID, 'Tree View')
+    // clear the name when the component is unmounted
+    return () => {
+      setCustomNetworkTabName(DEFAULT_RENDERER_ID, '')
+    }
+  }, [])
 
   const setActiveNetworkView = useUiStateStore(
     (state) => state.setActiveNetworkView,


### PR DESCRIPTION
Moved the section to update the tab name from the panel component to manager (Custom Hook) to avoid unnecessary name change caused by destroyed component.