### PR TITLE
File download debug and array data parse in summary property

### DIFF
--- a/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
@@ -67,7 +67,7 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
     try {
       await saveNetworkToFile()
       addMessage({
-        message: 'The current network is dowloaded successfully!',
+        message: 'Downloaded the current network successfully.',
         duration: 3000,
       })
     } catch (error) {

--- a/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
@@ -19,20 +19,21 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
     (state) => state.workspace.currentNetworkId,
   )
 
+  const setErrorMessage = useUiStateStore((state) => state.setErrorMessage)
   const table = useTableStore((state) => state.tables[currentNetworkId])
 
   const summary = useNetworkSummaryStore(
     (state) => state.summaries[currentNetworkId],
   )
 
-  const viewModel: NetworkView | undefined = useViewModelStore(
-    (state) => state.getViewModel(currentNetworkId),
+  const viewModel: NetworkView | undefined = useViewModelStore((state) =>
+    state.getViewModel(currentNetworkId),
   )
   const visualStyle = useVisualStyleStore(
     (state) => state.visualStyles[currentNetworkId],
   )
   const visualStyleOptions = useUiStateStore(
-    (state) => state.ui.visualStyleOptions[currentNetworkId]
+    (state) => state.ui.visualStyleOptions[currentNetworkId],
   ) as VisualStyleOptions
 
   const network = useNetworkStore((state) =>
@@ -51,7 +52,7 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
       table.edgeTable,
       visualStyleOptions,
       viewModel,
-      `Copy of ${summary.name}`,
+      summary.name,
     )
     const link = document.createElement('a')
     link.download = `${summary.name}.cx2`
@@ -62,7 +63,12 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   }
 
   const handleSaveCurrentNetworkToFile = async (): Promise<void> => {
-    await saveNetworkToFile()
+    try {
+      await saveNetworkToFile()
+    } catch (error) {
+      console.error('Failed to download the current network as file:', error)
+      setErrorMessage('Failed to download the current network as file.')
+    }
   }
 
   const menuItem = (

--- a/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
@@ -1,5 +1,5 @@
 import { MenuItem } from '@mui/material'
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import { BaseMenuProps } from '../BaseMenuProps'
 
 import { useWorkspaceStore } from '../../../store/WorkspaceStore'
@@ -13,13 +13,14 @@ import { Network } from '../../../models/NetworkModel'
 import { NetworkView } from '../../../models/ViewModel'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import { VisualStyleOptions } from '../../../models/VisualStyleModel/VisualStyleOptions'
+import { useMessageStore } from '../../../store/MessageStore'
 
 export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   const currentNetworkId = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
 
-  const setErrorMessage = useUiStateStore((state) => state.setErrorMessage)
+  const addMessage = useMessageStore((state) => state.addMessage)
   const table = useTableStore((state) => state.tables[currentNetworkId])
 
   const summary = useNetworkSummaryStore(
@@ -65,9 +66,16 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   const handleSaveCurrentNetworkToFile = async (): Promise<void> => {
     try {
       await saveNetworkToFile()
+      addMessage({
+        message: 'The current network is dowloaded successfully!',
+        duration: 3000,
+      })
     } catch (error) {
       console.error('Failed to download the current network as file:', error)
-      setErrorMessage('Failed to download the current network as file.')
+      addMessage({
+        message: 'Failed to download the current network as file.',
+        duration: 5000,
+      })
     }
   }
 

--- a/src/models/TableModel/impl/ValueTypeImpl.ts
+++ b/src/models/TableModel/impl/ValueTypeImpl.ts
@@ -68,7 +68,7 @@ export const getDefaultValue = (dataType: ValueTypeName): ValueType => {
 // e.g. '1, 2, 3' -> [1, 2, 3]
 export const deserializeValueList = (
   type: ValueTypeName,
-  value: string | string[], // Accept both string and array
+  value: string,
 ): ValueType => {
   const deserializeFnMap: Record<ValueTypeName, (value: string) => ValueType> =
     {
@@ -89,24 +89,9 @@ export const deserializeValueList = (
       [ValueTypeName.Double]: (value: string) => +value,
     }
 
-  if (Array.isArray(value)) {
-    switch (type) {
-      case ValueTypeName.ListString:
-        return value as string[]; 
-      case ValueTypeName.ListLong:
-      case ValueTypeName.ListInteger:
-      case ValueTypeName.ListDouble:
-        return value.map((v) => +v) as ValueType; 
-      case ValueTypeName.ListBoolean:
-        return value.map((v) => v === 'true') as ValueType; 
-      default:
-        throw new Error(`Unsupported array type for deserialization: ${type}`);
-    }
-  }
-
-  const v = deserializeFnMap[type](value as string) as ListOfValueType;
-  return v;
-};
+  const v = deserializeFnMap[type](value as string) as ListOfValueType
+  return v
+}
 
 // deserializeValueList also handles single values
 export const deserializeValue = deserializeValueList

--- a/src/models/TableModel/impl/ValueTypeImpl.ts
+++ b/src/models/TableModel/impl/ValueTypeImpl.ts
@@ -68,7 +68,7 @@ export const getDefaultValue = (dataType: ValueTypeName): ValueType => {
 // e.g. '1, 2, 3' -> [1, 2, 3]
 export const deserializeValueList = (
   type: ValueTypeName,
-  value: string,
+  value: string | string[], // Accept both string and array
 ): ValueType => {
   const deserializeFnMap: Record<ValueTypeName, (value: string) => ValueType> =
     {
@@ -89,9 +89,24 @@ export const deserializeValueList = (
       [ValueTypeName.Double]: (value: string) => +value,
     }
 
-  const v = deserializeFnMap[type](value) as ListOfValueType
-  return v
-}
+  if (Array.isArray(value)) {
+    switch (type) {
+      case ValueTypeName.ListString:
+        return value as string[]; 
+      case ValueTypeName.ListLong:
+      case ValueTypeName.ListInteger:
+      case ValueTypeName.ListDouble:
+        return value.map((v) => +v) as ValueType; 
+      case ValueTypeName.ListBoolean:
+        return value.map((v) => v === 'true') as ValueType; 
+      default:
+        throw new Error(`Unsupported array type for deserialization: ${type}`);
+    }
+  }
+
+  const v = deserializeFnMap[type](value as string) as ListOfValueType;
+  return v;
+};
 
 // deserializeValueList also handles single values
 export const deserializeValue = deserializeValueList

--- a/src/store/io/exportCX.ts
+++ b/src/store/io/exportCX.ts
@@ -37,7 +37,7 @@ import {
   PassthroughMappingFunction,
 } from '../../models/VisualStyleModel/VisualMappingFunction'
 
-import { deserializeValue } from '../../models/TableModel/impl/ValueTypeImpl'
+import { deserializeValue, isListType } from '../../models/TableModel/impl/ValueTypeImpl'
 import { VisualStyleOptions } from '../../models/VisualStyleModel/VisualStyleOptions'
 
 export const exportNetworkToCx2 = (
@@ -176,10 +176,10 @@ export const exportNetworkToCx2 = (
   }
 
   summary.properties.forEach((property) => {
-    networkAttributes[0][property.predicateString] = deserializeValue(
+    networkAttributes[0][property.predicateString] = (isListType(property.dataType) && (!Array.isArray(property.value))) ? deserializeValue(
       networkAttributeDeclarations[property.predicateString].d,
       property.value as string,
-    )
+    ) : property.value
   })
 
   const nodes = network.nodes.map((node) => {


### PR DESCRIPTION
This commit can resolve two bugs: [CW-425](https://cytoscape.atlassian.net/browse/CW-425) and [CW-426](https://cytoscape.atlassian.net/browse/CW-426)

- Added a post-process function for the summary fetcher: the current fetcher function convert all data types of the summary properties to `string` type, here a post-process function is added to parse the value. (In the future this function will upgraded to V3 and would not have this problem any more.)
- Added a try-catch block for downloading the network and added message to notify the results of the download.
- During exportation to Cx2 files, only call `deserializeValue` function when necessary


[CW-425]: https://cytoscape.atlassian.net/browse/CW-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CW-426]: https://cytoscape.atlassian.net/browse/CW-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ