### PR TITLE
Fix issue where edge bypasses were not translated from CX correctly

### DIFF
--- a/src/models/VisualStyleModel/impl/VisualStyleFnImpl.ts
+++ b/src/models/VisualStyleModel/impl/VisualStyleFnImpl.ts
@@ -32,6 +32,7 @@ import {
 import { getDefaultVisualStyle } from './DefaultVisualStyle'
 import { createNewNetworkView, updateNetworkView } from './compute-view-util'
 import { VisualStyleOptions } from '../VisualStyleOptions'
+import { translateCXEdgeId } from '../../NetworkModel/impl/CyNetwork'
 
 const sortByDisplayName = (
   a: VisualProperty<VisualPropertyValueType>,
@@ -174,7 +175,7 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
           if (edgeBypassMap.has(vpName)) {
             const entry = edgeBypassMap.get(vpName) ?? new Map()
             entry.set(
-              String(id),
+              translateCXEdgeId(String(id)),
               cxVPConverter.valueConverter(
                 v[cxVPName] as CXVisualPropertyValue,
               ),
@@ -184,7 +185,7 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
             edgeBypassMap.set(
               vpName,
               new Map().set(
-                String(id),
+                translateCXEdgeId(String(id)),
                 cxVPConverter.valueConverter(
                   v[cxVPName] as CXVisualPropertyValue,
                 ),


### PR DESCRIPTION
- This led to an issue where exporting networks to CX would be invalid because the edge ids would not match the edge bypass ids.

To test:
- load the attached network in ticket CW-433 into cytoscape web
- sign in to ndex and save the network to ndex
- the network should be valid according to the ndex webapp and viewable in the network-viewer