### PR TITLE
Fix floating toolbar bug

### DIFF
--- a/src/components/FloatingToolBar/FitButton.tsx
+++ b/src/components/FloatingToolBar/FitButton.tsx
@@ -1,11 +1,12 @@
 import { Box, IconButton, Tooltip } from '@mui/material'
 import { ZoomOutMap } from '@mui/icons-material'
 import { useRendererFunctionStore } from '../../store/RendererFunctionStore'
-import { useUiStateStore } from '../../store/UiStateStore'
 import { IdType } from 'src/models'
+import { useWorkspaceStore } from '../../store/WorkspaceStore'
 
 interface FitButtonProps {
   rendererId: string
+  targetNetworkId?: IdType
   disabled?: boolean
 }
 
@@ -13,15 +14,18 @@ export const FIT_FUNCTION_NAME: string = 'fit'
 
 export const FitButton = ({
   rendererId,
+  targetNetworkId,
   disabled = false,
 }: FitButtonProps): JSX.Element => {
   const getRendererFunction = useRendererFunctionStore(
     (state) => state.getFunction,
   )
 
-  const activeNetworkId: IdType = useUiStateStore(
-    (state) => state.ui.activeNetworkView,
+  const currentNetworkId: IdType = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
   )
+
+  const networkId: IdType = targetNetworkId ?? currentNetworkId
 
   const handleClick = (): void => {
     const fitFunctionByRenderer = getRendererFunction(
@@ -31,7 +35,7 @@ export const FitButton = ({
     const fitFunctionByNetworkId = getRendererFunction(
       rendererId,
       FIT_FUNCTION_NAME,
-      activeNetworkId,
+      networkId,
     )
     const fitFunction = fitFunctionByNetworkId ?? fitFunctionByRenderer // network id functions given priority
     if (fitFunction !== undefined) {

--- a/src/components/FloatingToolBar/FloatingToolBar.tsx
+++ b/src/components/FloatingToolBar/FloatingToolBar.tsx
@@ -39,9 +39,12 @@ export const FloatingToolBar = ({
         targetNetworkId={targetNetworkId}
         disabled={isCirclePackingRenderer}
       />
-      <FitButton rendererId={rendererId} />
-      <OpenInCytoscapeButton networkLabel={networkLabel} />
-      <ShareNetworkButton />
+      <FitButton targetNetworkId={targetNetworkId} rendererId={rendererId} />
+      <OpenInCytoscapeButton
+        targetNetworkId={targetNetworkId}
+        networkLabel={networkLabel}
+      />
+      <ShareNetworkButton targetNetworkId={targetNetworkId} />
     </Box>
   )
 }

--- a/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
+++ b/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
@@ -13,23 +13,27 @@ import { useVisualStyleStore } from '../../store/VisualStyleStore'
 import { useNetworkSummaryStore } from '../../store/NetworkSummaryStore'
 import { exportNetworkToCx2 } from '../../store/io/exportCX'
 import { Network } from '../../models/NetworkModel'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useUiStateStore } from '../../store/UiStateStore'
+import { IdType } from '../../models'
 
 interface OpenInCytoscapeButtonProps {
+  targetNetworkId?: IdType
   networkLabel?: string
 }
 
 export const OpenInCytoscapeButton = ({
+  targetNetworkId,
   networkLabel,
 }: OpenInCytoscapeButtonProps): JSX.Element => {
   const [open, setOpen] = useState<boolean>(false)
   const [message, setMessage] = useState<string>('')
 
-  const ui = useUiStateStore((state) => state.ui)
-  const { activeNetworkView } = ui
+  const currentNetworkId: IdType = useWorkspaceStore(
+    (state) => state.workspace.currentNetworkId,
+  )
 
-  const [targetNetworkId, setTargetNetworkId] = useState<string>('')
+  const networkId: IdType = targetNetworkId ?? currentNetworkId
 
   const handleMessageOpen = (newMessage: string): void => {
     setMessage(newMessage)
@@ -47,39 +51,20 @@ export const OpenInCytoscapeButton = ({
   }
 
   const cyndex = new CyNDEx()
-  const currentNetworkId = useWorkspaceStore(
-    (state) => state.workspace.currentNetworkId,
-  )
 
-  useEffect(() => {
-    if (
-      activeNetworkView !== undefined &&
-      activeNetworkView !== null &&
-      activeNetworkView !== ''
-    ) {
-      setTargetNetworkId(activeNetworkView)
-    } else {
-      setTargetNetworkId(currentNetworkId)
-    }
-  }, [currentNetworkId, activeNetworkView])
+  const table = useTableStore((state) => state.tables[networkId])
 
-  const table = useTableStore((state) => state.tables[targetNetworkId])
+  const summary = useNetworkSummaryStore((state) => state.summaries[networkId])
 
-  const summary = useNetworkSummaryStore(
-    (state) => state.summaries[targetNetworkId],
-  )
-
-  const viewModel = useViewModelStore((state) =>
-    state.getViewModel(targetNetworkId),
-  )
+  const viewModel = useViewModelStore((state) => state.getViewModel(networkId))
   const visualStyle = useVisualStyleStore(
-    (state) => state.visualStyles[targetNetworkId],
+    (state) => state.visualStyles[networkId],
   )
-  const visualStyleOptions = useUiStateStore((state) =>
-    state.ui.visualStyleOptions[targetNetworkId],
+  const visualStyleOptions = useUiStateStore(
+    (state) => state.ui.visualStyleOptions[networkId],
   )
   const network = useNetworkStore((state) =>
-    state.networks.get(targetNetworkId),
+    state.networks.get(networkId),
   ) as Network
 
   const openNetworkInCytoscape = async (): Promise<void> => {

--- a/src/components/FloatingToolBar/ShareNetworkButtton.tsx
+++ b/src/components/FloatingToolBar/ShareNetworkButtton.tsx
@@ -7,6 +7,7 @@ import { Ui } from '../../models/UiModel'
 import { NetworkView } from '../../models/ViewModel'
 import { useUiStateStore } from '../../store/UiStateStore'
 import { useViewModelStore } from '../../store/ViewModelStore'
+import { IdType } from '../../models'
 
 // Selection will be encoded if the selected object count is less than this number
 const MAX_SELECTED_OBJ = 300
@@ -19,12 +20,18 @@ export const SelectionStates = {
 export type SelectionState =
   (typeof SelectionStates)[keyof typeof SelectionStates]
 
+interface ShareNetworkButtonProps {
+  targetNetworkId?: IdType
+}
+
 /**
  * Button to copy the sharable URL to clipboard
  *
  * This component watches the UI and Selection states and encode them as URL search params
  */
-export const ShareNetworkButton = (): JSX.Element => {
+export const ShareNetworkButton = ({
+  targetNetworkId,
+}: ShareNetworkButtonProps): JSX.Element => {
   // Use this as the staring point for the sharable URL
   const wsId = useWorkspaceStore((state) => state.workspace.id)
 
@@ -36,7 +43,7 @@ export const ShareNetworkButton = (): JSX.Element => {
   const [search, setSearch] = useSearchParams()
 
   const ui: Ui = useUiStateStore((state) => state.ui)
-  const { panels, activeNetworkView } = ui
+  const { panels } = ui
 
   // This will be used to watch the selection state
   const networkViewModel: NetworkView | undefined = useViewModelStore((state) =>
@@ -55,8 +62,8 @@ export const ShareNetworkButton = (): JSX.Element => {
       ...panelObj,
       activeTableBrowserTab: `${ui.tableUi.activeTabIndex}`,
     }
-    if (activeNetworkView !== currentNetworkId) {
-      searchObj.activeNetworkView = activeNetworkView
+    if (targetNetworkId) {
+      searchObj.activeNetworkView = targetNetworkId
     }
     const searchStr = new URLSearchParams(searchObj).toString()
     return searchStr


### PR DESCRIPTION
Jira: [CW-438](https://cytoscape.atlassian.net/browse/CW-438)

For an HCX network, when the active network is the main network, and the user clicks the floating toolbar in the subnetwork renderer, it will trigger the action first and then set the subnetwork as the active network view. Therefore, it still uses out-of-date `activaNetworkView` for the action.

The bug is resolved by sending the bonded networkId to the floating toolbar to avoid using `activaNetworkView`.

[CW-438]: https://cytoscape.atlassian.net/browse/CW-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ