### PR TITLE
Fix issue where uploading an unsupported file type crashes the app

### DIFF
--- a/src/components/Messages/SnackbarMessageList.tsx
+++ b/src/components/Messages/SnackbarMessageList.tsx
@@ -27,6 +27,7 @@ export const SnackbarMessageList = (): React.ReactElement => {
 
   return (
     <Snackbar
+      sx={{ zIndex: 9999999 }}
       open={open}
       onClose={handleSnackbarClose}
       autoHideDuration={messages[currentMessageIndex]?.duration ?? 5000}

--- a/src/components/ToolBar/FileUpload.tsx
+++ b/src/components/ToolBar/FileUpload.tsx
@@ -51,6 +51,7 @@ import { useUiStateStore } from '../../store/UiStateStore'
 import { Aspect } from '../../models/CxModel/Cx2/Aspect'
 import { getOptionalAspects } from '../../utils/cx-utils'
 import { useOpaqueAspectStore } from '../../store/OpaqueAspectStore'
+import { useMessageStore } from '../../store/MessageStore'
 
 interface FileUploadProps {
   show: boolean
@@ -230,18 +231,17 @@ export function FileUpload(props: FileUploadProps) {
   }
 
   const summaries = useNetworkSummaryStore((state) => state.summaries)
+  const addMessage = useMessageStore((state) => state.addMessage)
 
   const setFile = useCreateNetworkFromTableStore((state) => state.setFile)
   const setShow = useCreateNetworkFromTableStore((state) => state.setShow)
   const goToStep = useCreateNetworkFromTableStore((state) => state.goToStep)
   const setRawText = useCreateNetworkFromTableStore((state) => state.setRawText)
   const setName = useCreateNetworkFromTableStore((state) => state.setName)
-  const onFileError = () => {
-    notifications.show({
-      color: 'red',
-      title: 'Error uploading file',
-      message: 'The uploaded file is not valid',
-      autoClose: 5000,
+  const onFileError = (files: any) => {
+    addMessage({
+      duration: 5000,
+      message: `The uploaded file ${files?.[0]?.file?.name ?? ''} is not supported. ${files?.[0]?.errors?.[0]?.message ?? ''}`,
     })
   }
 
@@ -294,11 +294,12 @@ export function FileUpload(props: FileUploadProps) {
               }
             >
               <Dropzone
+                accept={['.csv', '.txt', '.tsv', '.cx2']}
                 onDrop={(files: any) => {
                   onFileDrop(files[0])
                 }}
                 onReject={(files: any) => {
-                  onFileError()
+                  onFileError(files)
                 }}
                 // maxSize={}
               >

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/TableUpload.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/TableUpload.tsx
@@ -21,17 +21,18 @@ import {
   useJoinTableToNetworkStore,
   JoinTableToNetworkStep,
 } from '../../store/joinTableToNetworkStore'
+import { useMessageStore } from '../../../../store/MessageStore'
 
 export function TableUpload(props: BaseMenuProps) {
   const setFile = useJoinTableToNetworkStore((state) => state.setFile)
   const goToStep = useJoinTableToNetworkStore((state) => state.goToStep)
   const setRawText = useJoinTableToNetworkStore((state) => state.setRawText)
-  const onFileError = () => {
-    notifications.show({
-      color: 'red',
-      title: 'Error uploading file',
-      message: 'The uploaded file is not valid',
-      autoClose: 5000,
+  const addMessage = useMessageStore((state) => state.addMessage)
+
+  const onFileError = (files: any) => {
+    addMessage({
+      duration: 5000,
+      message: `The uploaded file ${files?.[0]?.file?.name ?? ''} is not supported. ${files?.[0]?.errors?.[0]?.message ?? ''}`,
     })
   }
 
@@ -82,10 +83,10 @@ export function TableUpload(props: BaseMenuProps) {
           onFileDrop(files[0])
         }}
         onReject={(files: any) => {
-          onFileError()
+          onFileError(files)
         }}
         // maxSize={}
-        accept={['text/*']}
+        accept={['.txt', '.csv', '.tsv']}
       >
         <Group
           justify="center"


### PR DESCRIPTION
- Fix issue where the display message would not show when an unsupported file type is uploaded.


Testing:
1. Upload any file type that is not supported
2. A message should show saying the file is not supported
3. The app should not crash