### PR TITLE
Resolved that menu items overlap the divider lines

### DIFF
--- a/src/components/ToolBar/DataMenu/index.tsx
+++ b/src/components/ToolBar/DataMenu/index.tsx
@@ -27,6 +27,8 @@ import { ExportImageMenuItem } from './ExportNetworkToImage/ExportNetworkToImage
 import { fetchMyWorkspaces } from '../../../utils/ndex-utils'
 import { useCredentialStore } from '../../../store/CredentialStore'
 
+import './menuItem.css'
+
 export const DataMenu: React.FC<DropdownMenuProps> = (
   props: DropdownMenuProps,
 ) => {
@@ -85,7 +87,6 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
     },
     {
       label: 'Import',
-      style: { height: 38 },
       items: [
         {
           label: 'From File',
@@ -141,7 +142,6 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
     },
     {
       label: 'Export',
-      style: { height: 38 },
       items: [
         {
           label: 'Network to Image...',

--- a/src/components/ToolBar/DataMenu/menuItem.css
+++ b/src/components/ToolBar/DataMenu/menuItem.css
@@ -1,0 +1,6 @@
+.p-tieredmenu .p-menuitem .p-menuitem-content .p-menuitem-link {
+    padding: 0.375rem 1rem !important; 
+  }
+  .p-tieredmenu .p-menuitem .p-menuitem-content .p-menuitem-link .p-menuitem-text {
+    line-height: 1.5rem !important;
+  }


### PR DESCRIPTION
Ticket: [CW-403](https://cytoscape.atlassian.net/browse/CW-403)
- Make nested menu item have the same height as other menu items
- Make the gray background (when hovering the button) would NOT overlap with the divider line

<img width="351" alt="image" src="https://github.com/user-attachments/assets/bd4f01e5-a893-4331-93df-1f67f0812faf">


[CW-403]: https://cytoscape.atlassian.net/browse/CW-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ