### PR TITLE
Resolve the layout selection runtime error that occurs when no network is selected.

### DIFF
--- a/src/models/LayoutModel/impl/Cosmos/CosmosLayout.ts
+++ b/src/models/LayoutModel/impl/Cosmos/CosmosLayout.ts
@@ -22,6 +22,12 @@ export const CosmosLayout: LayoutEngine = {
     afterLayout: (positionMap: Map<IdType, [number, number]>) => void,
     algorithm: LayoutAlgorithm,
   ): void => {
+    // Check if nodes and edges are available, if not, return empty graph data
+    if (!nodes || !edges) {
+      alert('Please open a network first!')
+      return;
+    }
+
     const config = CosmosAlgorithms.cosmos.parameters
     const graph = new Graph(dummyContainer, config)
 

--- a/src/models/LayoutModel/impl/Cyjs/CyjsLayout.ts
+++ b/src/models/LayoutModel/impl/Cyjs/CyjsLayout.ts
@@ -17,6 +17,12 @@ export const CyjsLayout: LayoutEngine = {
     afterLayout: (positionMap: Map<IdType, [number, number]>) => void,
     algorithm: LayoutAlgorithm,
   ): void => {
+    // Check if nodes and edges are available, if not, return empty graph data
+    if (!nodes || !edges) {
+      alert('Please open a network first!')
+      return;
+    }
+
     const cy = cytoscape({
       headless: true,
       elements: {

--- a/src/models/LayoutModel/impl/G6/G6Layout.ts
+++ b/src/models/LayoutModel/impl/G6/G6Layout.ts
@@ -51,6 +51,12 @@ export const G6Layout: LayoutEngine = {
 }
 
 const transform = (nodes: Node[], edges: Edge[]): GraphData => {
+  // Check if nodes and edges are available, if not, return empty graph data
+  if(!nodes || !edges) {
+    alert('Please open a network first!')
+    return { nodes: [], edges: [] };
+  }
+
   const nodeConfigs: NodeConfig[] = nodes.map((node: Node) => ({ id: node.id }))
   const edgeConfigs: EdgeConfig[] = edges.map((edge: Edge) => ({
     source: edge.s,


### PR DESCRIPTION
**The addressed issue**
The system crashes and shows a runtime error when a layout is selected without any network being selected.

**How I resolve the issue**
To resolve this issue, I implemented a validation step in the affected layout implementations (Cosmos, Cyjs, and G6). The additional code ensures that the system verifies whether network data (nodes and edges) is available before proceeding with the layout processing.

**Maintenance Strategy used**
Corrective Maintenance: This update addresses an identified defect in the system by rectifying the issue that caused crashes. The primary goal is to improve the software's reliability and prevent it from failing under specific circumstances (e.g., attempting to use a layout algorithm without loading a network).

**Impact of changes**
1. Improved Stability: By preventing operations on undefined data, the system avoids runtime crashes, improving overall stability.
2. User Feedback: The system now provides clear feedback to the user with an alert (Please open a network first!), ensuring they understand why an action cannot proceed.
3. Performance: Early return in case of missing data optimizes performance by preventing unnecessary processing.

**Before Change:**
![image](https://github.com/user-attachments/assets/221153f5-2011-4a4d-b5b5-4e68ecc3f1d1)

**After Change:**
![image](https://github.com/user-attachments/assets/32381cac-ed43-49f3-ad5e-a41b24aae408)
