### PR TITLE
Fix opaque store bug & Add ndex summary checker & Improve cx2 exporter

### DIFF
--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -23,6 +23,7 @@ import { HcxValidationSaveDialog } from '../../../features/HierarchyViewer/compo
 import { NetworkView } from '../../../models/ViewModel'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import { useOpaqueAspectStore } from '../../../store/OpaqueAspectStore'
+import { saveCopyToNDEx as saveNetworkCopy } from '../../../utils/ndex-utils'
 
 export const CopyNetworkToNDExMenuItem = (
   props: BaseMenuProps,
@@ -76,29 +77,26 @@ export const CopyNetworkToNDExMenuItem = (
     (state) => state.setCurrentNetworkId,
   )
   const saveCopyToNDEx = async (): Promise<void> => {
-    if (viewModel === undefined) {
-      throw new Error('Could not find the current network view model.')
-    }
-
     const ndexClient = new NDEx(ndexBaseUrl)
     const accessToken = await getToken()
     ndexClient.setAuthToken(accessToken)
-    const cx = exportNetworkToCx2(
-      network,
-      visualStyle,
-      summary,
-      table.nodeTable,
-      table.edgeTable,
-      visualStyleOptions,
-      viewModel,
-      summary.isNdex ? `Copy of ${summary.name}` : summary.name,
-      opaqueAspects,
-    )
-    try {
-      const { uuid } = await ndexClient.createNetworkFromRawCX2(cx)
-      addNetworkToWorkspace(uuid as IdType)
-      setCurrentNetworkId(uuid as IdType)
 
+    try {
+      const uuid = await saveNetworkCopy(
+        ndexBaseUrl,
+        accessToken,
+        ndexClient,
+        addNetworkToWorkspace,
+        network,
+        visualStyle,
+        summary,
+        table.nodeTable,
+        table.edgeTable,
+        viewModel,
+        visualStyleOptions,
+        opaqueAspects,
+      )
+      setCurrentNetworkId(uuid as IdType)
       addMessage({
         message: `Saved a copy of the current network to NDEx with new uuid ${
           uuid as string

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -104,10 +104,15 @@ export const SaveWorkspaceToNDExMenuItem = (
       return
     }
     try {
+      const accessToken = await getToken()
+      const ndexClient = new NDEx(ndexBaseUrl)
+      ndexClient.setAuthToken(accessToken)
+
       await saveAllNetworks(
-        getToken,
-        allNetworkId,
+        accessToken,
         ndexBaseUrl,
+        ndexClient,
+        allNetworkId,
         addNetworkToWorkspace,
         networkModifiedStatus,
         updateSummary,
@@ -121,9 +126,6 @@ export const SaveWorkspaceToNDExMenuItem = (
         networkVisualStyleOpt,
         opaqueAspects,
       )
-      const ndexClient = new NDEx(ndexBaseUrl)
-      const accessToken = await getToken()
-      ndexClient.setAuthToken(accessToken)
 
       const workspace = await getWorkspaceFromDb(currentWorkspaceId)
       const response = await ndexClient.createCyWebWorkspace({

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -16,7 +16,6 @@ import { useViewModelStore } from '../../../store/ViewModelStore'
 import { KeycloakContext } from '../../../bootstrap'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import {
-  fetchMyWorkspaces,
   saveAllNetworks,
   ndexDuplicateKeyErrorMessage,
 } from '../../../utils/ndex-utils'
@@ -72,10 +71,15 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
 
   const saveWorkspaceToNDEx = async (): Promise<void> => {
     try {
+      const accessToken = await getToken()
+      const ndexClient = new NDEx(ndexBaseUrl)
+      ndexClient.setAuthToken(accessToken)
+
       await saveAllNetworks(
-        getToken,
-        allNetworkId,
+        accessToken,
         ndexBaseUrl,
+        ndexClient,
+        allNetworkId,
         addNetworkToWorkspace,
         networkModifiedStatus,
         updateSummary,
@@ -89,9 +93,6 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
         networkVisualStyleOpt,
         opaqueAspects,
       )
-      const ndexClient = new NDEx(ndexBaseUrl)
-      const accessToken = await getToken()
-      ndexClient.setAuthToken(accessToken)
 
       const workspace = await getWorkspaceFromDb(currentWorkspaceId)
       if (hasWorkspace) {

--- a/src/components/ToolBar/DataMenu/index.tsx
+++ b/src/components/ToolBar/DataMenu/index.tsx
@@ -26,7 +26,7 @@ import { OverlayPanel } from 'primereact/overlaypanel'
 import { ExportImageMenuItem } from './ExportNetworkToImage/ExportNetworkToImageMenuItem'
 import { fetchMyWorkspaces } from '../../../utils/ndex-utils'
 import { useCredentialStore } from '../../../store/CredentialStore'
-
+import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 import './menuItem.css'
 
 export const DataMenu: React.FC<DropdownMenuProps> = (
@@ -35,6 +35,7 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
   const { label } = props
   const [isLoadingWorkspace, setIsLoadingWorkspace] = useState(true)
   const [existingWorkspace, setExistingWorkspace] = useState<any[]>([])
+  const currentWorkspaceId = useWorkspaceStore((state) => state.workspace.id)
   const { ndexBaseUrl } = useContext(AppConfigContext)
   const client = useContext(KeycloakContext)
   const authenticated: boolean = client?.authenticated ?? false
@@ -64,7 +65,7 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
     } else {
       setIsLoadingWorkspace(false)
     }
-  }, [])
+  }, [currentWorkspaceId])
 
   const menuItems = [
     {

--- a/src/components/ToolBar/FileUpload.tsx
+++ b/src/components/ToolBar/FileUpload.tsx
@@ -48,10 +48,10 @@ import { useNetworkSummaryStore } from '../../store/NetworkSummaryStore'
 import { generateUniqueName } from '../../utils/network-utils'
 import { VisualStyleOptions } from '../../models/VisualStyleModel/VisualStyleOptions'
 import { useUiStateStore } from '../../store/UiStateStore'
-import { Aspect } from '../../models/CxModel/Cx2/Aspect'
 import { getOptionalAspects } from '../../utils/cx-utils'
 import { useOpaqueAspectStore } from '../../store/OpaqueAspectStore'
 import { useMessageStore } from '../../store/MessageStore'
+import { OpaqueAspects } from '../../models/OpaqueAspectModel'
 
 interface FileUploadProps {
   show: boolean
@@ -66,7 +66,7 @@ export function FileUpload(props: FileUploadProps) {
     visualStyle: VisualStyle
     networkView: NetworkView
     visualStyleOptions: VisualStyleOptions
-    otherAspects: Aspect[]
+    otherAspects: OpaqueAspects[]
   }
 
   const setCurrentNetworkId = useWorkspaceStore(
@@ -117,7 +117,7 @@ export function FileUpload(props: FileUploadProps) {
     const visualStyleOptions: VisualStyleOptions =
       VisualStyleFn.createVisualStyleOptionsFromCx(cxData)
 
-    const otherAspects: Aspect[] = getOptionalAspects(cxData)
+    const otherAspects: OpaqueAspects[] = getOptionalAspects(cxData)
 
     return {
       network,

--- a/src/components/Vizmapper/Forms/MappingForm/index.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/index.tsx
@@ -105,51 +105,54 @@ function MappingFormContent(props: {
     mappingType: MappingFunctionType,
     attribute: AttributeName,
   ): void => {
-    switch (mappingType) {
-      case MappingFunctionType.Discrete: {
-        createDiscreteMapping(
-          props.currentNetworkId,
-          props.visualProperty.name,
-          attribute,
-        )
-        break
-      }
-      case MappingFunctionType.Continuous: {
-        const attributeDataType = currentTable.columns.find(
-          (c) => c.name === attribute,
-        )?.type
-
-        if (
-          attributeDataType != null &&
-          (attributeDataType === ValueTypeName.Integer ||
-            attributeDataType === ValueTypeName.Long ||
-            attributeDataType === ValueTypeName.Double)
-        ) {
-          const attributeValues = Array.from(
-            columnValues(
-              props.currentNetworkId,
-              props.visualProperty.group as 'node' | 'edge',
-              attribute,
-            ),
-          ).sort((a, b) => (a as number) - (b as number))
-
-          createContinuousMapping(
+    const attributeDataType = currentTable.columns.find(
+      (c) => c.name === attribute,
+    )?.type
+    if (attributeDataType != null) {
+      switch (mappingType) {
+        case MappingFunctionType.Discrete: {
+          createDiscreteMapping(
             props.currentNetworkId,
             props.visualProperty.name,
-            props.visualProperty.type,
             attribute,
-            attributeValues,
+            attributeDataType,
           )
+          break
         }
-        break
-      }
-      case MappingFunctionType.Passthrough: {
-        createPassthroughMapping(
-          props.currentNetworkId,
-          props.visualProperty.name,
-          attribute,
-        )
-        break
+        case MappingFunctionType.Continuous: {
+          if (
+            attributeDataType === ValueTypeName.Integer ||
+            attributeDataType === ValueTypeName.Long ||
+            attributeDataType === ValueTypeName.Double
+          ) {
+            const attributeValues = Array.from(
+              columnValues(
+                props.currentNetworkId,
+                props.visualProperty.group as 'node' | 'edge',
+                attribute,
+              ),
+            ).sort((a, b) => (a as number) - (b as number))
+
+            createContinuousMapping(
+              props.currentNetworkId,
+              props.visualProperty.name,
+              props.visualProperty.type,
+              attribute,
+              attributeValues,
+              attributeDataType,
+            )
+          }
+          break
+        }
+        case MappingFunctionType.Passthrough: {
+          createPassthroughMapping(
+            props.currentNetworkId,
+            props.visualProperty.name,
+            attribute,
+            attributeDataType,
+          )
+          break
+        }
       }
     }
   }

--- a/src/models/NetworkWithViewModel/NetworkWithView.ts
+++ b/src/models/NetworkWithViewModel/NetworkWithView.ts
@@ -3,6 +3,7 @@ import { Table } from '../TableModel'
 import { NetworkView } from '../ViewModel'
 import { VisualStyle } from '../VisualStyleModel'
 import { VisualStyleOptions } from '../VisualStyleModel/VisualStyleOptions'
+import { OpaqueAspects } from '../OpaqueAspectModel'
 
 /**
  * An utility interface to hold all the data needed to build a network view
@@ -15,5 +16,5 @@ export interface NetworkWithView {
   visualStyle: VisualStyle
   networkViews: NetworkView[]
   visualStyleOptions?: VisualStyleOptions
-  otherAspects?: any[] // All other optional aspects found in the CX2 stream
+  otherAspects?: OpaqueAspects[] // All other optional aspects found in the CX2 stream
 }

--- a/src/models/StoreModel/VisualStyleStoreModel.ts
+++ b/src/models/StoreModel/VisualStyleStoreModel.ts
@@ -1,5 +1,5 @@
 import { IdType } from '../IdType'
-import { ValueType, AttributeName } from '../TableModel'
+import { ValueType, AttributeName, ValueTypeName } from '../TableModel'
 import {
   VisualStyle,
   VisualPropertyName,
@@ -70,16 +70,19 @@ export interface UpdateVisualStyleAction {
     vpType: VisualPropertyValueTypeName,
     attribute: AttributeName,
     attributeValues: ValueType[],
+    attributeType: ValueTypeName
   ) => void
   createDiscreteMapping: (
     networkId: IdType,
     vpName: VisualPropertyName,
     attribute: AttributeName,
+    attributeType: ValueTypeName
   ) => void
   createPassthroughMapping: (
     networkId: IdType,
     vpName: VisualPropertyName,
     attribute: AttributeName,
+    attributeType: ValueTypeName
   ) => void
   removeMapping: (networkId: IdType, vpName: VisualPropertyName) => void
   // setMapping: () // TODO

--- a/src/models/VisualStyleModel/VisualMappingFunction/VisualMappingFunction.ts
+++ b/src/models/VisualStyleModel/VisualMappingFunction/VisualMappingFunction.ts
@@ -1,4 +1,4 @@
-import { AttributeName } from '../../TableModel'
+import { AttributeName, ValueTypeName } from '../../TableModel'
 import { VisualPropertyValueType } from '../VisualPropertyValue'
 import { VisualPropertyValueTypeName } from '../VisualPropertyValueTypeName'
 import { MappingFunctionType } from './MappingFunctionType'
@@ -8,4 +8,5 @@ export interface VisualMappingFunction {
   attribute: AttributeName
   visualPropertyType: VisualPropertyValueTypeName
   defaultValue: VisualPropertyValueType
+  attributeType?: ValueTypeName 
 }

--- a/src/models/VisualStyleModel/impl/VisualStyleFnImpl.ts
+++ b/src/models/VisualStyleModel/impl/VisualStyleFnImpl.ts
@@ -255,6 +255,7 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                 visualPropertyType: vp.type,
                 attribute: cxMapping.definition.attribute,
                 defaultValue: vp.defaultValue,
+                attributeType: cxMapping.definition.type,
               }
               visualStyle[vpName].mapping = m
               break
@@ -271,6 +272,7 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                 vpValueMap,
                 visualPropertyType: vp.type,
                 defaultValue: vp.defaultValue,
+                attributeType: cxMapping.definition.type,
               }
               visualStyle[vpName].mapping = m
               break
@@ -356,6 +358,7 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                   ltMinVpValue: converter.valueConverter(
                     min.vpValue as CXVisualPropertyValue,
                   ),
+                  attributeType: cxMapping.definition.type,
                 }
                 visualStyle[vpName].mapping = m
               } else {

--- a/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
+++ b/src/models/VisualStyleModel/impl/cxVisualPropertyConverter.ts
@@ -18,6 +18,7 @@ import {
   VisualProperty,
   VisualStyle,
 } from '..'
+import { ValueTypeName } from '../../TableModel'
 
 type CXLabelPositionValueType = 'center' | 'top' | 'bottom' | 'left' | 'right'
 export interface CXLabelPositionType {
@@ -50,6 +51,7 @@ export interface CXDiscreteMappingFunction<T> {
       v: CxValue
       vp: T
     }>
+    type?: ValueTypeName
   }
 }
 
@@ -57,6 +59,7 @@ export interface CXPassthroughMappingFunction {
   type: 'PASSTHROUGH'
   definition: {
     attribute: string
+    type?: ValueTypeName
   }
 }
 
@@ -72,6 +75,7 @@ export interface CXContinuousMappingFunction<T> {
       includeMax: boolean
       includeMin: boolean
     }>
+    type?: ValueTypeName
   }
 }
 
@@ -103,6 +107,7 @@ export const convertPassthroughMappingToCX = (
   vs: VisualStyle,
   vp: VisualProperty<VisualPropertyValueType>,
   mapping: PassthroughMappingFunction,
+  isNameInTable: boolean,
 ): CXPassthroughMappingFunction => {
   const { attribute } = mapping
 
@@ -110,6 +115,7 @@ export const convertPassthroughMappingToCX = (
     type: 'PASSTHROUGH',
     definition: {
       attribute,
+      ...(isNameInTable ? {} : { type: mapping.attributeType }),
     },
   }
 }
@@ -118,6 +124,7 @@ export const convertDiscreteMappingToCX = (
   vs: VisualStyle,
   vp: VisualProperty<VisualPropertyValueType>,
   mapping: DiscreteMappingFunction,
+  isNameInTable: boolean,
 ): CXDiscreteMappingFunction<CXVisualPropertyValue> => {
   const { vpValueMap, attribute } = mapping
 
@@ -129,6 +136,7 @@ export const convertDiscreteMappingToCX = (
         v: value,
         vp: vpToCX(vp.name, vpValue),
       })),
+      ...(isNameInTable ? {} : { type: mapping.attributeType }),
     },
   }
 }
@@ -136,6 +144,7 @@ export const convertContinuousMappingToCX = (
   vs: VisualStyle,
   vp: VisualProperty<VisualPropertyValueType>,
   mapping: ContinuousMappingFunction,
+  isNameInTable: boolean,
 ): CXContinuousMappingFunction<CXVisualPropertyValue> => {
   const { min, max, controlPoints, attribute, ltMinVpValue, gtMaxVpValue } =
     mapping
@@ -177,6 +186,7 @@ export const convertContinuousMappingToCX = (
         },
       ],
       attribute,
+      ...(isNameInTable ? {} : { type: mapping.attributeType }),
     },
   }
 }

--- a/src/store/OpaqueAspectStore.ts
+++ b/src/store/OpaqueAspectStore.ts
@@ -4,6 +4,7 @@ import { OpaqueAspectStoreModel } from '../models/StoreModel/OpaqueAspectStoreMo
 import { IdType } from '../models'
 import { deleteOpaqueAspectsFromDb, putOpaqueAspectsToDb } from './persist/db'
 import { clear } from 'idb-keyval'
+import { OpaqueAspects } from '../models/OpaqueAspectModel'
 
 export const useOpaqueAspectStore = create(
   immer<OpaqueAspectStoreModel>((set) => ({
@@ -14,10 +15,8 @@ export const useOpaqueAspectStore = create(
           state.opaqueAspects[networkId] = {}
         }
         state.opaqueAspects[networkId][aspectName] = aspectData
-        void putOpaqueAspectsToDb(
-          networkId,
-          state.opaqueAspects[networkId],
-        ).then(() => {
+        const updatedOpaqueAspects = { ...state.opaqueAspects[networkId] }
+        void putOpaqueAspectsToDb(networkId, updatedOpaqueAspects).then(() => {
           console.debug(
             'DB Update: opaque aspects store',
             state.opaqueAspects[networkId],
@@ -26,7 +25,7 @@ export const useOpaqueAspectStore = create(
         return state
       })
     },
-    addAll: (networkId: IdType, aspects: Record<string, any[]>[]) => {
+    addAll: (networkId: IdType, aspects: OpaqueAspects[]) => {
       set((state) => {
         if (!state.opaqueAspects[networkId]) {
           state.opaqueAspects[networkId] = {}
@@ -35,10 +34,8 @@ export const useOpaqueAspectStore = create(
           const [aspectName, aspectData] = Object.entries(aspect)[0]
           state.opaqueAspects[networkId][aspectName] = aspectData
         })
-        void putOpaqueAspectsToDb(
-          networkId,
-          state.opaqueAspects[networkId],
-        ).then(() => {
+        const updatedOpaqueAspects = { ...state.opaqueAspects[networkId] }
+        void putOpaqueAspectsToDb(networkId, updatedOpaqueAspects).then(() => {
           console.debug('DB Update: opaque aspects store')
         })
         return state
@@ -61,10 +58,8 @@ export const useOpaqueAspectStore = create(
         if (state.opaqueAspects[networkId]) {
           delete state.opaqueAspects[networkId][aspectName]
         }
-        void putOpaqueAspectsToDb(
-          networkId,
-          state.opaqueAspects[networkId],
-        ).then(() => {
+        const updatedOpaqueAspects = { ...state.opaqueAspects[networkId] }
+        void putOpaqueAspectsToDb(networkId, updatedOpaqueAspects).then(() => {
           console.debug('DB Update: opaque aspects store')
         })
         return state
@@ -94,10 +89,8 @@ export const useOpaqueAspectStore = create(
           state.opaqueAspects[networkId] = {}
         }
         state.opaqueAspects[networkId][aspectName] = [...aspectData]
-        void putOpaqueAspectsToDb(
-          networkId,
-          state.opaqueAspects[networkId],
-        ).then(() => {
+        const updatedOpaqueAspects = { ...state.opaqueAspects[networkId] }
+        void putOpaqueAspectsToDb(networkId, updatedOpaqueAspects).then(() => {
           console.debug('DB Update: opaque aspects updated for ', networkId)
         })
         return state

--- a/src/store/io/exportCX.ts
+++ b/src/store/io/exportCX.ts
@@ -15,6 +15,7 @@ import VisualStyleFn, {
   VisualPropertyName,
   VisualProperty,
   VisualPropertyValueType,
+  NodeVisualPropertyName,
 } from '../../models/VisualStyleModel'
 
 import { translateEdgeIdToCX } from '../../models/NetworkModel/impl/CyNetwork'
@@ -96,6 +97,12 @@ export const exportNetworkToCx2 = (
   ): { [key: CXVPName]: CXVisualMappingFunction<CXVisualPropertyValue> } => {
     const { name, mapping } = vp
     const cxVPName = vpNameToCXName(name)
+    const attributeName = mapping?.attribute
+    // whether attributeName is in nodeTable or edgeTable
+    let isNameInTable = false
+    if(attributeName){
+      isNameInTable = Object.values(NodeVisualPropertyName).includes(name as NodeVisualPropertyName) ? nodeTable.columns.map((col)=>col.name).includes(attributeName) : edgeTable.columns.map((col)=>col.name).includes(attributeName)  
+    }
 
     if (mapping != null) {
       switch (mapping.type) {
@@ -104,6 +111,7 @@ export const exportNetworkToCx2 = (
             vs,
             vp,
             mapping as ContinuousMappingFunction,
+            isNameInTable
           )
           mappings[cxVPName] = convertedMapping
           break
@@ -113,6 +121,7 @@ export const exportNetworkToCx2 = (
             vs,
             vp,
             mapping as DiscreteMappingFunction,
+            isNameInTable
           )
           mappings[cxVPName] = convertedMapping
           break
@@ -122,6 +131,7 @@ export const exportNetworkToCx2 = (
             vs,
             vp,
             mapping as PassthroughMappingFunction,
+            isNameInTable
           )
           mappings[cxVPName] = convertedMapping
           break

--- a/src/store/persist/db.ts
+++ b/src/store/persist/db.ts
@@ -697,6 +697,12 @@ export const deleteServiceAppFromDb = async (url: string): Promise<void> => {
   })
 }
 
+// opaque aspects
+export interface OpaqueAspectsDB {
+  id: IdType
+  aspects: Record<string, any[]>
+}
+
 export const putOpaqueAspectsToDb = async (
   networkId: IdType,
   aspects: Record<string, any[]>,
@@ -708,7 +714,7 @@ export const putOpaqueAspectsToDb = async (
 
 export const getOpaqueAspectsFromDb = async (
   networkId: IdType,
-): Promise<Record<string, any[]> | undefined> => {
+): Promise< OpaqueAspectsDB | undefined> => {
   return await db.opaqueAspects.get({ id: networkId })
 }
 

--- a/src/utils/CachedData.ts
+++ b/src/utils/CachedData.ts
@@ -3,6 +3,7 @@ import { Table } from '../models/TableModel'
 import { NetworkView } from '../models/ViewModel'
 import { VisualStyle } from '../models/VisualStyleModel'
 import { VisualStyleOptions } from '../models/VisualStyleModel/VisualStyleOptions'
+import { OpaqueAspects } from '../models/OpaqueAspectModel'
 
 export interface CachedData {
   network?: Network
@@ -11,5 +12,5 @@ export interface CachedData {
   visualStyle?: VisualStyle
   networkViews?: NetworkView[]
   visualStyleOptions?: VisualStyleOptions
-  otherAspects?: any[]
+  otherAspects?: OpaqueAspects[]
 }

--- a/src/utils/cx-utils.ts
+++ b/src/utils/cx-utils.ts
@@ -10,6 +10,8 @@ import {
   getNetworkViewsFromDb,
   getVisualStyleFromDb,
   getUiStateFromDb,
+  getOpaqueAspectsFromDb,
+  OpaqueAspectsDB,
 } from '../store/persist/db'
 import { CachedData } from './CachedData'
 import { createNetworkAttributesFromCx } from '../models/TableModel/impl/NetworkAttributesImpl'
@@ -19,6 +21,7 @@ import { NetworkWithView } from '../models/NetworkWithViewModel'
 import { VisualStyleOptions } from '../models/VisualStyleModel/VisualStyleOptions'
 import { Ui } from '../models/UiModel'
 import { IdType } from '../models/IdType'
+import { OpaqueAspects } from '../models/OpaqueAspectModel'
 
 /**
  *
@@ -72,6 +75,10 @@ export const getCachedData = async (id: string): Promise<CachedData> => {
       uiState?.visualStyleOptions ?? {}
     // Fall back to an empty object if the visual style options are not found
     const visualStyleOptions: VisualStyleOptions = vsOptions[id] ?? {}
+    const opaqueAspects: OpaqueAspectsDB|undefined = await getOpaqueAspectsFromDb(id)
+    const otherAspects: OpaqueAspects[] = opaqueAspects
+      ? Object.entries(opaqueAspects.aspects).map(([key, value]) => ({ [key]: value }))
+      : []
     return {
       network,
       visualStyle,
@@ -79,6 +86,7 @@ export const getCachedData = async (id: string): Promise<CachedData> => {
       edgeTable: tables !== undefined ? tables.edgeTable : undefined,
       networkViews: networkViews ?? [],
       visualStyleOptions: visualStyleOptions,
+      otherAspects: otherAspects,
     }
   } catch (e) {
     console.error('Failed to restore data from IndexedDB', e)
@@ -106,7 +114,7 @@ export const createDataFromCx = async (
   )
   const visualStyleOptions: VisualStyleOptions =
     VisualStyleFn.createVisualStyleOptionsFromCx(cxData)
-  const otherAspects: Aspect[] = getOptionalAspects(cxData)
+  const otherAspects: OpaqueAspects[] = getOptionalAspects(cxData)
 
   return {
     network,
@@ -129,8 +137,8 @@ const CoreAspectTagValueSet = new Set<string>(
  * @param cx2
  * @returns Array of optional Aspects
  */
-export const getOptionalAspects = (cx2: Cx2): Aspect[] => {
-  const optionalAspects: Aspect[] = []
+export const getOptionalAspects = (cx2: Cx2): OpaqueAspects[] => {
+  const optionalAspects: OpaqueAspects[] = []
   for (const entry of cx2) {
     if (entry !== undefined) {
       const key = Object.keys(entry)[0]
@@ -139,7 +147,7 @@ export const getOptionalAspects = (cx2: Cx2): Aspect[] => {
         key !== 'status' &&
         key !== 'CXVersion'
       ) {
-        optionalAspects.push(entry as Aspect)
+        optionalAspects.push(entry as OpaqueAspects)
       }
     }
   }


### PR DESCRIPTION
This PR 
- Added an NDEx summary checker after save/update the network to NDEx sothat we can ensure NDEx accepts the network (See `src/utils/ndex-utils.ts`).
- Changed the cx2 exporter:  added the **attribute type**  to the mapping's definition when the attribute does not exist in the node/edge table (See `src/store/io/exportCX.ts`).

    (The above two changes resolved the [CW-437](https://cytoscape.atlassian.net/browse/CW-437) since its caused by the exported cx2 file of U2OS network is not accepted by NDEx)

- Added `getOpaqueAspect` in `getCachedData` function to resolve [CW-452](https://cytoscape.atlassian.net/browse/CW-452) (See `src/utils/cx-utils.ts`). Otherwise getting all cached data will never be fulfilled since the OpaqueAspect data is always missing. Then loading a local cx2 file will always trigger a `get` call to NDEx and receive 404 since obviously there is no such network in NDEx. @yihangx 

- Resolved the bug in **OpaqueStore**. 
    The screenshot of the error:
![image](https://github.com/user-attachments/assets/b1d5aa8a-5ba7-43fe-b4b3-b087f2d51db1) 
@d2fong `Zustand` store is using `immer` as middleware, which manipulates the state using a Proxy to enable immutable state updates. The issue arises when **asynchronous operations**, like `putOpaqueAspectsToDb`, `deleteOpaqueAspectsFromDb`, access state after the state proxy has been revoked and the state is passed directly to asynchronous functions or persisted while still being a proxy (See `src/store/OpaqueAspectStore.ts`). This bug further causes the mismatch of the URL and current network ID, now [CW-462](https://cytoscape.atlassian.net/browse/CW-462) and [CW-454](https://cytoscape.atlassian.net/browse/CW-454) @yihangx are also resolved. 

    An example:
```
addAll: (networkId: IdType, aspects: Record<string, any[]>[]) => {
      set((state) => {
        if (!state.opaqueAspects[networkId]) {
          state.opaqueAspects[networkId] = {}
        }
        aspects.forEach((aspect) => {
          const [aspectName, aspectData] = Object.entries(aspect)[0]
          state.opaqueAspects[networkId][aspectName] = aspectData
        })
        void putOpaqueAspectsToDb(
          networkId,
          state.opaqueAspects[networkId],  //the state is passed directly to asynchronous functions 
        ).then(() => {
          console.debug('DB Update: opaque aspects store')
        })
        return state
      })
    },
```

[CW-437]: https://cytoscape.atlassian.net/browse/CW-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CW-452]: https://cytoscape.atlassian.net/browse/CW-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CW-462]: https://cytoscape.atlassian.net/browse/CW-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ