### PR TITLE
Fixed load-workspace bug & Improved getNDExSummaryStatus

### DIFF
--- a/src/components/Messages/SnackbarMessageList.tsx
+++ b/src/components/Messages/SnackbarMessageList.tsx
@@ -9,10 +9,23 @@ export const SnackbarMessageList = (): React.ReactElement => {
   const [currentMessageIndex, setCurrentMessageIndex] = useState(0)
 
   useEffect(() => {
-    if (messages.length > 0) {
+    if (messages.length > 0 && currentMessageIndex < messages.length) {
       setOpen(true)
+    } else {
+      setOpen(false)
     }
-  }, [messages])
+  }, [messages, currentMessageIndex])
+
+  useEffect(() => {
+    if (!open && currentMessageIndex < messages.length - 1) {
+      const timer = setTimeout(() => {
+        setCurrentMessageIndex((prev) => prev + 1)
+        setOpen(true)
+      }, 300)
+
+      return () => clearTimeout(timer)
+    }
+  }, [open, currentMessageIndex, messages.length])
 
   const handleSnackbarClose = (
     event: React.SyntheticEvent,

--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -23,7 +23,11 @@ import { HcxValidationSaveDialog } from '../../../features/HierarchyViewer/compo
 import { NetworkView } from '../../../models/ViewModel'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import { useOpaqueAspectStore } from '../../../store/OpaqueAspectStore'
-import { saveCopyToNDEx as saveNetworkCopy } from '../../../utils/ndex-utils'
+import {
+  saveCopyToNDEx as saveNetworkCopy,
+  TimeOutErrorIndicator,
+  TimeOutErrorMessage,
+} from '../../../utils/ndex-utils'
 
 export const CopyNetworkToNDExMenuItem = (
   props: BaseMenuProps,
@@ -105,13 +109,19 @@ export const CopyNetworkToNDExMenuItem = (
       })
     } catch (e) {
       console.log(e)
-
-      addMessage({
-        message: `Error: Could not save a copy of the current network to NDEx. ${
-          e.message as string
-        }`,
-        duration: 3000,
-      })
+      if (e.message.includes(TimeOutErrorIndicator)) {
+        addMessage({
+          message: TimeOutErrorMessage,
+          duration: 6000,
+        })
+      } else {
+        addMessage({
+          message: `Error: Could not save a copy of the current network to NDEx. ${
+            e.message as string
+          }`,
+          duration: 3000,
+        })
+      }
     }
 
     props.handleClose()

--- a/src/components/ToolBar/DataMenu/LoadWorkspaceDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadWorkspaceDialog.tsx
@@ -75,7 +75,6 @@ export const LoadWorkspaceDialog: React.FC<{
         (workspace) => workspace.workspaceId === selectedWorkspaceId,
       )
       if (selectedWorkspace) {
-        deleteAllNetworks()
         resetWorksapce().then(() => {
           setWorkSpace({
             name: selectedWorkspace.name,

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -27,7 +27,7 @@ import { useViewModelStore } from '../../../store/ViewModelStore'
 import { KeycloakContext } from '../../../bootstrap'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import {
-  ndexDuplicateKeyErrorMessage,
+  NdexDuplicateKeyErrorMessage,
   saveAllNetworks,
 } from '../../../utils/ndex-utils'
 import { useOpaqueAspectStore } from '../../../store/OpaqueAspectStore'
@@ -144,7 +144,7 @@ export const SaveWorkspaceToNDExMenuItem = (
         duration: 3000,
       })
     } catch (e) {
-      if (e.response?.data?.message?.includes(ndexDuplicateKeyErrorMessage)) {
+      if (e.response?.data?.message?.includes(NdexDuplicateKeyErrorMessage)) {
         addMessage({
           message:
             'This workspace name already exists. Please enter a unique workspace name',
@@ -152,7 +152,7 @@ export const SaveWorkspaceToNDExMenuItem = (
         })
       } else {
         addMessage({
-          message: `Error: Could not save workspace to NDEx. ${e.message as string}`,
+          message: `Error: Could not save workspace to NDEx.`,
           duration: 5000,
         })
       }

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -17,7 +17,7 @@ import { KeycloakContext } from '../../../bootstrap'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import {
   saveAllNetworks,
-  ndexDuplicateKeyErrorMessage,
+  NdexDuplicateKeyErrorMessage,
 } from '../../../utils/ndex-utils'
 import { ConfirmationDialog } from '../../Util/ConfirmationDialog'
 import { useOpaqueAspectStore } from '../../../store/OpaqueAspectStore'
@@ -116,7 +116,7 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
         duration: 3000,
       })
     } catch (e) {
-      if (e.response?.data?.message?.includes(ndexDuplicateKeyErrorMessage)) {
+      if (e.response?.data?.message?.includes(NdexDuplicateKeyErrorMessage)) {
         addMessage({
           message:
             'This workspace name already exists. Please enter a unique workspace name',
@@ -124,7 +124,7 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
         })
       } else {
         addMessage({
-          message: `Error: Could not save workspace to NDEx. ${e.message as string}`,
+          message: `Error: Could not save workspace to NDEx.`,
           duration: 5000,
         })
       }


### PR DESCRIPTION
This PR consists of two parts:
#### 1. Fix the load-workspace bug ([CW-472](https://cytoscape.atlassian.net/browse/CW-472))
It is a bug that triggers a database error when loading a workspace (it will firstly clear the current workspace and then load the target workspace). 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/fd1ead19-7655-4477-907b-5cb63d82e39e" />

This is resolved by a simple fix by deleting **the redundant line** in the `handleOpenWorkspace` function: 
```
deleteAllNetworks()
```

#### 2. Improved the `getNDExSummaryStatus` function

`getNDExSummaryStatus`: As required by Jing, the retry times of fetching summary info from NDEx is increased to 13 times and the intervals are adjusted accordingly.

A new special error message, `NDEx_TIMEOUT_ERROR,` is also added to denote that on the NDEx side it reaches the maximum expected time to process the network. Correspondingly, a checker for this error is added in the `try-catch` blocks of the saveNetwork functions.

In addition, message snackbar is improved so that it can display several messages in sequence.


[CW-472]: https://cytoscape.atlassian.net/browse/CW-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ