### PR TITLE
'Set Network isModified' Debug

### DIFF
--- a/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
@@ -25,6 +25,7 @@ import { removePTags } from '../../utils/remove-p-tags'
 import { ReactElement } from 'react'
 import { MantineProvider } from '@mantine/core'
 import '@mantine/tiptap/styles.css'
+import { useWorkspaceStore } from '../../store/WorkspaceStore'
 
 interface NetworkPropertyEditorProps {
   anchorEl?: HTMLElement
@@ -36,12 +37,17 @@ export const NetworkPropertyEditor = (
 ): ReactElement => {
   const { anchorEl, onClose, summary } = props
   const open = anchorEl !== undefined
+  const updateNetworkSummary = useNetworkSummaryStore((state) => state.update)
+  const setNetworkModified = useWorkspaceStore(
+    (state) => state.setNetworkModified,
+  )
 
   const editor = useEditor({
     onUpdate: debounce(({ editor }) => {
       updateNetworkSummary(summary.externalId, {
         description: editor.getHTML(),
       })
+      setNetworkModified(summary.externalId, true)
     }, 200),
     extensions: [
       StarterKit,
@@ -55,7 +61,6 @@ export const NetworkPropertyEditor = (
     content: removePTags(summary.description ?? ''),
   })
 
-  const updateNetworkSummary = useNetworkSummaryStore((state) => state.update)
   return (
     <Popover
       open={open}
@@ -91,6 +96,7 @@ export const NetworkPropertyEditor = (
               updateNetworkSummary(summary.externalId, {
                 name: e.target.value,
               })
+              setNetworkModified(summary.externalId, true)
             }}
           ></TextField>
           <TextField
@@ -98,11 +104,12 @@ export const NetworkPropertyEditor = (
             label="Version"
             sx={{ width: '20%', fontSize: 12 }}
             value={summary.version}
-            onChange={(e) =>
+            onChange={(e) => {
               updateNetworkSummary(summary.externalId, {
                 version: e.target.value,
               })
-            }
+              setNetworkModified(summary.externalId, true)
+            }}
           />
         </Box>
 

--- a/src/components/SummaryPanel/NdexNetworkPropertyTable.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyTable.tsx
@@ -40,6 +40,9 @@ const NdexNetworkPropertyTable = (): React.ReactElement => {
   >(networkProperties.map((p) => ({ ...p, valueIsValid: true })))
 
   const updateNetworkSummary = useNetworkSummaryStore((state) => state.update)
+  const setNetworkModified = useWorkspaceStore(
+    (state) => state.setNetworkModified,
+  )
 
   const updateNetworkPropertyType = (
     index: number,
@@ -60,6 +63,7 @@ const NdexNetworkPropertyTable = (): React.ReactElement => {
         ({ valueIsValid, ...ndexNetworkProperty }) => ndexNetworkProperty,
       ),
     })
+    setNetworkModified(currentNetworkId, true)
   }
 
   const updateNetworkPropertyName = (index: number, name: string): void => {
@@ -75,6 +79,7 @@ const NdexNetworkPropertyTable = (): React.ReactElement => {
         ({ valueIsValid, ...ndexNetworkProperty }) => ndexNetworkProperty,
       ),
     })
+    setNetworkModified(currentNetworkId, true)
   }
 
   const updateNetworkPropertyValue = (
@@ -105,6 +110,7 @@ const NdexNetworkPropertyTable = (): React.ReactElement => {
           ({ valueIsValid, ...ndexNetworkProperty }) => ndexNetworkProperty,
         ),
       })
+      setNetworkModified(currentNetworkId, true)
     }
   }
 
@@ -135,6 +141,7 @@ const NdexNetworkPropertyTable = (): React.ReactElement => {
         ({ valueIsValid, ...ndexNetworkProperty }) => ndexNetworkProperty,
       ),
     })
+    setNetworkModified(currentNetworkId, true)
   }
 
   const deleteNetworkProperty = (index: number): void => {
@@ -148,6 +155,7 @@ const NdexNetworkPropertyTable = (): React.ReactElement => {
         ({ valueIsValid, ...ndexNetworkProperty }) => ndexNetworkProperty,
       ),
     })
+    setNetworkModified(currentNetworkId, true)
   }
 
   return (

--- a/src/components/TableBrowser/NetworkInfoPanel.tsx
+++ b/src/components/TableBrowser/NetworkInfoPanel.tsx
@@ -16,8 +16,6 @@ import { useNetworkSummaryStore } from '../../store/NetworkSummaryStore'
 import { useWorkspaceStore } from '../../store/WorkspaceStore'
 import parse from 'html-react-parser'
 import React from 'react'
-import { IdType, NdexNetworkSummary } from '../../models'
-import _ from 'lodash'
 
 export function NetworkPropertyTable(): React.ReactElement {
   const currentNetworkId = useWorkspaceStore(
@@ -60,10 +58,6 @@ export default function NetworkInfoPanel(props: {
   const networkInfo = useNetworkSummaryStore(
     (state) => state.summaries[currentNetworkId],
   )
-  const workspace = useWorkspaceStore((state) => state.workspace)
-  const setNetworkModified: (id: IdType, isModified: boolean) => void =
-    useWorkspaceStore((state) => state.setNetworkModified)
-
   const properties = networkInfo?.properties ?? []
 
   const containsHtmlAnchor = (text: string) => {
@@ -82,24 +76,7 @@ export default function NetworkInfoPanel(props: {
   const capitalizeFirstLetter = (string: string): string => {
     return string.charAt(0).toUpperCase() + string.slice(1)
   }
-  useNetworkSummaryStore.subscribe((next, prev) => {
-    const prevSummary = prev.summaries[currentNetworkId]
-    const nextSummary = next.summaries[currentNetworkId]
-    if (prevSummary === undefined || nextSummary === undefined) {
-      return
-    }
-    const summaryDataChanged = !_.isEqual(prevSummary, nextSummary)
-    const { networkModified } = workspace
 
-    const currentNetworkIsNotModified =
-      networkModified[currentNetworkId] === undefined ||
-      networkModified[currentNetworkId] === false
-
-    // If table data changed and the network is not already marked as modified, set it to modified
-    if (summaryDataChanged && currentNetworkIsNotModified) {
-      setNetworkModified(currentNetworkId, true)
-    }
-  })
   return (
     <Box sx={{ height: props.height, overflow: 'auto', pl: 1, pr: 1 }}>
       <Box sx={{ mt: 1, display: 'flex', alignItems: 'center' }}>


### PR DESCRIPTION
### Changes Made
- Reverse the previous [fix](https://github.com/cytoscape/cytoscape-web/pull/390). It was intended to listen to the changes on the network property at one single place, but this is bound to the UI, so as long as the user does not open the 'network' panel in the bottom, it would not be triggered successfully.
    -  src/components/TableBrowser/NetworkInfoPanel.tsx
- Added `setNetworkModified` after every `updateNetworkSummary` in the NdexNetworkProperty Dialog
    - src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
    - src/components/SummaryPanel/NdexNetworkPropertyTable.tsx


### To Test

1. Choose a network that does not have the red mark. Click the 'pencil' icon to edit network properties , as shown below:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/00e02d8e-12e9-4538-b8d7-3bc48ba21098" />

2. After the click, the dialog would show and make some changes in the dialog(update the network name, description, version or properties) :

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4bef1032-fe07-4af8-8bf3-fc14fdd5501f" />

3. Click away to close the dialog and the network should have the 'red' dirty mark.

### Related bugs to resolve
- [Changes on network description/version cannot be saved to NDEx](https://cytoscape.atlassian.net/browse/CW-477)
- [Networks that do not have layout would be marked as isModified once loaded](https://cytoscape.atlassian.net/browse/CW-483)