### PR TITLE
Improve User Experience on Data Menu

### DIFF
--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -104,7 +104,7 @@ export const CopyNetworkToNDExMenuItem = (
         viewModel,
         visualStyleOptions,
         opaqueAspects,
-        true,
+        false, // keep the original network
       )
       setCurrentNetworkId(uuid as IdType)
       addMessage({
@@ -150,6 +150,7 @@ export const CopyNetworkToNDExMenuItem = (
     }
   }
 
+  const enabled = authenticated && currentNetworkId !== ''
   const menuItem = (
     <Box
       sx={{
@@ -160,15 +161,15 @@ export const CopyNetworkToNDExMenuItem = (
     >
       <MenuItem
         sx={{ flexBasis: '100%', flexGrow: 3 }}
-        disabled={!authenticated}
+        disabled={!enabled}
         onClick={handleClick}
       >
-        {'Save Current Network to NDEx as...'}
+        Save Copy to NDEx
       </MenuItem>
     </Box>
   )
 
-  if (authenticated) {
+  if (enabled) {
     return (
       <>
         {menuItem}
@@ -182,8 +183,16 @@ export const CopyNetworkToNDExMenuItem = (
     )
   } else {
     return (
-      <Tooltip title="Login to save a copy of the current network to NDEx">
-        <Box>{menuItem}</Box>
+      <Tooltip
+        arrow
+        placement="right"
+        title={
+          currentNetworkId !== ''
+            ? 'Login to save a copy of the current network to NDEx'
+            : ''
+        }
+      >
+        {menuItem}
       </Tooltip>
     )
   }

--- a/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/DownloadNetworkMenuItem.tsx
@@ -21,7 +21,6 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   const currentNetworkId = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
-
   const addMessage = useMessageStore((state) => state.addMessage)
   const table = useTableStore((state) => state.tables[currentNetworkId])
 
@@ -89,8 +88,11 @@ export const DownloadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   }
 
   const menuItem = (
-    <MenuItem onClick={handleSaveCurrentNetworkToFile}>
-      Download Current Network as File (.cx2)
+    <MenuItem
+      disabled={currentNetworkId === ''}
+      onClick={handleSaveCurrentNetworkToFile}
+    >
+      Download Network as File (.cx2)
     </MenuItem>
   )
   return <>{menuItem}</>

--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/ExportNetworkToImageMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/ExportNetworkToImageMenuItem.tsx
@@ -114,10 +114,10 @@ export const ExportImage = (props: ExportImageProps): ReactElement => {
 export const ExportImageMenuItem = (props: BaseMenuProps): ReactElement => {
   const [show, setShow] = useState(false)
 
-  const workspace = useWorkspaceStore((state) => state.workspace)
+  const networkIds = useWorkspaceStore((state) => state.workspace.networkIds)
   const menuItem = (
     <MenuItem
-      disabled={workspace.networkIds.length === 0}
+      disabled={networkIds.length === 0}
       component="label"
       onClick={() => setShow(true)}
     >

--- a/src/components/ToolBar/DataMenu/ImportNetworkFromFileMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/ImportNetworkFromFileMenuItem.tsx
@@ -9,7 +9,7 @@ export const UploadNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
 
   const menuItem = (
     <MenuItem component="label" onClick={() => setShow(true)}>
-      Network from File
+      Network from File...
     </MenuItem>
   )
 

--- a/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexDialog.tsx
@@ -134,7 +134,11 @@ export const LoadFromNdexDialog = (
   const myNetworksTab = authenticated ? (
     <Tab label={<Typography>My Networks</Typography>}></Tab>
   ) : (
-    <Tooltip title="Login to NDEx to access your networks">
+    <Tooltip
+      arrow
+      placement="right"
+      title="Login to NDEx to access your networks"
+    >
       <Box>
         <Tab disabled label={<Typography>My Networks</Typography>}></Tab>
       </Box>

--- a/src/components/ToolBar/DataMenu/LoadFromNdexMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/LoadFromNdexMenuItem.tsx
@@ -17,7 +17,9 @@ export const LoadFromNdexMenuItem = (props: BaseMenuProps): ReactElement => {
 
   return (
     <>
-      <MenuItem onClick={handleOpenDialog}>Open Network(s) from NDEx</MenuItem>
+      <MenuItem onClick={handleOpenDialog}>
+        Open Network(s) from NDEx...
+      </MenuItem>
       <LoadFromNdexDialog open={openDialog} handleClose={handleCloseDialog} />
     </>
   )

--- a/src/components/ToolBar/DataMenu/LoadWorkspaceMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/LoadWorkspaceMenuItem.tsx
@@ -20,7 +20,11 @@ export const LoadWorkspaceMenuItem = (props: BaseMenuProps): ReactElement => {
 
   return (
     <>
-      <Tooltip title={authenticated ? '' : 'Login to see your own workspace'}>
+      <Tooltip
+        arrow
+        placement="right"
+        title={authenticated ? '' : 'Login to see your own workspace'}
+      >
         <Box>
           <MenuItem disabled={!authenticated} onClick={handleOpenDialog}>
             Open Workspace from NDEx...

--- a/src/components/ToolBar/DataMenu/OpenNetworkInCytoscapeMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/OpenNetworkInCytoscapeMenuItem.tsx
@@ -101,17 +101,22 @@ export const OpenNetworkInCytoscapeMenuItem = ({
     return ua.includes('safari') && !ua.includes('chrome')
   }, [])
 
+  const disabled = isSafari || currentNetworkId === ''
   const menuItem = (
-    <MenuItem onClick={handleOpenNetworkInCytoscape} disabled={isSafari}>
-      Open Copy of Current Network in Cytoscape
+    <MenuItem onClick={handleOpenNetworkInCytoscape} disabled={disabled}>
+      Open Network in Cytoscape Desktop
     </MenuItem>
   )
 
   return (
     <Tooltip
+      arrow
+      placement="right"
       title={
-        isSafari
-          ? 'This feature is not available on Safari'
+        disabled
+          ? isSafari && currentNetworkId !== ''
+            ? 'This feature is not available on Safari'
+            : ''
           : 'Download and open Cytoscape to open network'
       }
     >

--- a/src/components/ToolBar/DataMenu/RemoveAllNetworksMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/RemoveAllNetworksMenuItem.tsx
@@ -8,6 +8,7 @@ export const RemoveAllNetworksMenuItem = (
   props: BaseMenuProps,
 ): ReactElement => {
   const [open, setOpen] = useState(false)
+  const networkIds = useWorkspaceStore((state) => state.workspace.networkIds)
   const deleteAllNetworks = useWorkspaceStore(
     (state) => state.deleteAllNetworks,
   )
@@ -19,7 +20,12 @@ export const RemoveAllNetworksMenuItem = (
 
   return (
     <>
-      <MenuItem onClick={() => setOpen(true)}>Remove All Networks</MenuItem>
+      <MenuItem
+        disabled={networkIds.length === 0}
+        onClick={() => setOpen(true)}
+      >
+        Remove All Networks
+      </MenuItem>
       <ConfirmationDialog
         title="Remove All Networks"
         message="Do you really want to delete all networks from this workspace?"

--- a/src/components/ToolBar/DataMenu/RemoveNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/RemoveNetworkMenuItem.tsx
@@ -6,7 +6,7 @@ import { ConfirmationDialog } from '../../Util/ConfirmationDialog'
 
 export const RemoveNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   const [open, setOpen] = useState<boolean>(false)
-
+  const networkIds = useWorkspaceStore((state) => state.workspace.networkIds)
   const deleteCurrentNetwork = useWorkspaceStore(
     (state) => state.deleteCurrentNetwork,
   )
@@ -18,7 +18,12 @@ export const RemoveNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
 
   return (
     <>
-      <MenuItem onClick={() => setOpen(true)}>Remove Current Network</MenuItem>
+      <MenuItem
+        disabled={networkIds.length === 0}
+        onClick={() => setOpen(true)}
+      >
+        Remove Current Network
+      </MenuItem>
       <ConfirmationDialog
         title="Remove Current Network"
         message="Do you really want to delete this network?"

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -231,21 +231,27 @@ export const SaveWorkspaceToNDExMenuItem = (
     </Dialog>
   )
 
+  const enabled = authenticated && allNetworkId.length > 0
+
   const menuItem = (
-    <MenuItem disabled={!authenticated} onClick={handleSaveWorkspaceToNDEx}>
+    <MenuItem disabled={!enabled} onClick={handleSaveWorkspaceToNDEx}>
       Save Workspace as...
     </MenuItem>
   )
 
   return (
     <>
-      {authenticated ? (
+      {enabled ? (
         menuItem
       ) : (
         <Tooltip
           arrow
           placement="right"
-          title="Login to save a copy of the current workspace to NDEx"
+          title={
+            allNetworkId.length > 0
+              ? 'Login to save a copy of the current workspace to NDEx'
+              : ''
+          }
         >
           <Box>{menuItem}</Box>
         </Tooltip>

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -233,7 +233,7 @@ export const SaveWorkspaceToNDExMenuItem = (
 
   const menuItem = (
     <MenuItem disabled={!authenticated} onClick={handleSaveWorkspaceToNDEx}>
-      Save Workspace As...
+      Save Workspace as...
     </MenuItem>
   )
 
@@ -242,7 +242,11 @@ export const SaveWorkspaceToNDExMenuItem = (
       {authenticated ? (
         menuItem
       ) : (
-        <Tooltip title="Login to save a copy of the current workspace to NDEx">
+        <Tooltip
+          arrow
+          placement="right"
+          title="Login to save a copy of the current workspace to NDEx"
+        >
           <Box>{menuItem}</Box>
         </Tooltip>
       )}

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -145,37 +145,42 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
     handleOpenDialog()
   }
 
+  const enabled = authenticated && allNetworkId.length > 0
+
   const menuItem = (
-    <MenuItem
-      disabled={!authenticated}
-      onClick={handleSaveCurrentNetworkToNDEx}
-    >
+    <MenuItem disabled={!enabled} onClick={handleSaveCurrentNetworkToNDEx}>
       Save Workspace
     </MenuItem>
   )
 
   return (
     <>
-      {authenticated ? (
-        menuItem
+      {enabled ? (
+        <>
+          {menuItem}
+          <ConfirmationDialog
+            title="Save Workspace to NDEx"
+            message="Do you want to save/overwrite the current workspace to NDEx?"
+            onConfirm={saveWorkspaceToNDEx}
+            open={openDialog}
+            setOpen={setOpenDialog}
+            buttonTitle="Save"
+            isAlert={true}
+          />
+        </>
       ) : (
         <Tooltip
           arrow
           placement="right"
-          title="Login to save/overwrite the current workspace to NDEx"
+          title={
+            allNetworkId.length > 0
+              ? 'Login to save/overwrite the current workspace to NDEx'
+              : ''
+          }
         >
           <Box>{menuItem}</Box>
         </Tooltip>
       )}
-      <ConfirmationDialog
-        title="Save Workspace to NDEx"
-        message="Do you want to save/overwrite the current workspace to NDEx?"
-        onConfirm={saveWorkspaceToNDEx}
-        open={openDialog}
-        setOpen={setOpenDialog}
-        buttonTitle="Save"
-        isAlert={true}
-      />
     </>
   )
 }

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -159,7 +159,11 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
       {authenticated ? (
         menuItem
       ) : (
-        <Tooltip title="Login to save/overwrite the current workspace to NDEx">
+        <Tooltip
+          arrow
+          placement="right"
+          title="Login to save/overwrite the current workspace to NDEx"
+        >
           <Box>{menuItem}</Box>
         </Tooltip>
       )}

--- a/src/components/ToolBar/LayoutMenu/index.tsx
+++ b/src/components/ToolBar/LayoutMenu/index.tsx
@@ -157,7 +157,7 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
             template: (
               <Tooltip
                 arrow
-                placement={'right'}
+                placement="right"
                 title={menuItem.description}
                 key={menuItem.key}
               >

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/JoinTableToNetworkMenuItem.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/JoinTableToNetworkMenuItem.tsx
@@ -27,7 +27,7 @@ export const JoinTableToNetworkMenuItem = (
           setShow(true)
         }}
       >
-        Table from File
+        Table from File...
       </MenuItem>
     </>
   )

--- a/src/utils/ndex-utils.ts
+++ b/src/utils/ndex-utils.ts
@@ -119,6 +119,7 @@ export const saveCopyToNDEx = async (
   visualStyleOptions?: VisualStyleOptions,
   opaqueAspect?: OpaqueAspects,
   deleteOriginal?: boolean,
+  setCurrentNetworkId?: (id: string) => void,
 ): Promise<string> => {
   if (viewModel === undefined) {
     throw new Error('Could not find the current network view model.')
@@ -144,7 +145,8 @@ export const saveCopyToNDEx = async (
     throw new Error('The network is rejected by NDEx')
   }
   addNetworkToWorkspace(uuid as IdType) // add the new network to the workspace
-  if (deleteOriginal === true) {
+  if(setCurrentNetworkId) setCurrentNetworkId(uuid as string)
+  if (deleteOriginal === true) {  
     deleteNetworkFromWorkspace(network.id) // delete the original network from the workspace
   }
   return uuid


### PR DESCRIPTION
### Changes Made

#### 1. Menu Item Rename
- If a menu item name ends with `...`, it means it will open a dialog.
- Get rid of some words like `current` or `network` to be more concise
<img width="350" alt="image" src="https://github.com/user-attachments/assets/5d77bba2-5a44-4016-8a1b-9efd418809cd" />


#### 2.Disable certain menu items when the workspace is empty
- 'Open workspace' is also disabled when the user is anonymous
<img width="600" alt="image" src="https://github.com/user-attachments/assets/879c16c5-080a-4601-b596-a9f23c11be85" />

#### 3. Change the behavior of `Save Network to NDEx` (previously called `Save Current Network to NDEx (overwrite)`)
- Enable it to save the `local` networks (previously it could not do this)
- It will create a copy for the local network, save it to NDEx and then delete the origin one
    - The behavior is similar to `Save Copy to NDEx` (previously called `Save Current Network to NDEx as...`). The only difference is that the latter would not delete the original one
    - When there are local networks in the workspace, `Saving workspace` operation  (no matter creating a new workspace entry or updating an existing one) will adopt the `save copy and delete original one` strategy

#### 4. Make tooltips on the right so that it would not block the button below it 
|After change| Before change|
|-----|-----|
|<img height="70" alt="image" src="https://github.com/user-attachments/assets/643d4fa7-e7c8-4ce9-ae68-2667aea03394" />|<img height="70" alt="image" src="https://github.com/user-attachments/assets/faaf08b5-baac-445d-8895-83dce80d76b9" />|