### PR TITLE
Add Context to check Cytoscape Desktop's availability

### DIFF
--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -4,6 +4,7 @@ import './split-pane.css'
 import './data-grid.css'
 import appConfig from './assets/config.json'
 import { AppConfigContext } from './AppConfigContext'
+import { FeatureAvailabilityProvider } from './components/FeatureAvailability'
 import { App } from './App'
 // @ts-expect-error-next-line
 import { NDEx } from '@js4cytoscape/ndex-client'
@@ -145,9 +146,11 @@ keycloak
           <AppConfigContext.Provider value={appConfig}>
             <React.StrictMode>
               <KeycloakContext.Provider value={keycloak}>
-                <ErrorBoundary>
-                  <App />
-                </ErrorBoundary>
+                <FeatureAvailabilityProvider>
+                  <ErrorBoundary>
+                    <App />
+                  </ErrorBoundary>
+                </FeatureAvailabilityProvider>
               </KeycloakContext.Provider>
             </React.StrictMode>
           </AppConfigContext.Provider>,

--- a/src/components/FeatureAvailability/FeatureAvailabilityContext.ts
+++ b/src/components/FeatureAvailability/FeatureAvailabilityContext.ts
@@ -1,0 +1,31 @@
+import { createContext } from 'react'
+
+export type FeatureAvailabilityState = {
+  isCyDeskAvailable: boolean
+  isSafari: boolean
+}
+
+export const FeatureAvailabilityActionType = {
+  SET_CYDESK_AVAILABLE: 'SET_CYDESK_AVAILABLE',
+  SET_CYDESK_UNAVAILABLE: 'SET_CYDESK_UNAVAILABLE',
+  SET_IS_SAFARI: 'SET_IS_SAFARI',
+  SET_NOT_SAFARI: 'SET_IS_NOT_SAFARI',
+} as const
+
+export type FeatureAvailabilityActionType =
+  (typeof FeatureAvailabilityActionType)[keyof typeof FeatureAvailabilityActionType]
+
+export type FeatureAvailabilityAction = {
+  type: FeatureAvailabilityActionType
+  payload?: any
+}
+
+export const initialState: FeatureAvailabilityState = {
+  isCyDeskAvailable: false,
+  isSafari: false,
+}
+
+export const FeatureAvailabilityContext = createContext<{
+  state: FeatureAvailabilityState
+  tooltip: string
+}>({ state: initialState, tooltip: '' })

--- a/src/components/FeatureAvailability/FeatureAvailabilityProvider.tsx
+++ b/src/components/FeatureAvailability/FeatureAvailabilityProvider.tsx
@@ -1,0 +1,101 @@
+import React, {
+  useContext,
+  useEffect,
+  useReducer,
+  ReactNode,
+  useMemo,
+} from 'react'
+import {
+  initialState,
+  FeatureAvailabilityState,
+  FeatureAvailabilityActionType,
+  FeatureAvailabilityAction,
+  FeatureAvailabilityContext,
+} from './FeatureAvailabilityContext'
+
+const END_POINT = 'http://127.0.0.1:1234/v1/version'
+const POLLING_INTERVAL = 5000
+const reducer = (
+  state: FeatureAvailabilityState,
+  action: FeatureAvailabilityAction,
+): FeatureAvailabilityState => {
+  switch (action.type) {
+    case FeatureAvailabilityActionType.SET_CYDESK_AVAILABLE:
+      return { ...state, isCyDeskAvailable: true }
+    case FeatureAvailabilityActionType.SET_CYDESK_UNAVAILABLE:
+      return { ...state, isCyDeskAvailable: false }
+    case FeatureAvailabilityActionType.SET_IS_SAFARI:
+      return { ...state, isSafari: true }
+    case FeatureAvailabilityActionType.SET_NOT_SAFARI:
+      return { ...state, isSafari: false }
+    default:
+      return state
+  }
+}
+
+export const FeatureAvailabilityProvider: React.FC<{
+  children: ReactNode
+}> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const pollAvailability = async (abortController: AbortController) => {
+    try {
+      const response = await fetch(END_POINT, {
+        signal: abortController.signal,
+      })
+      if (response.ok) {
+        dispatch({
+          type: FeatureAvailabilityActionType.SET_CYDESK_AVAILABLE,
+        })
+      } else {
+        dispatch({ type: FeatureAvailabilityActionType.SET_CYDESK_UNAVAILABLE })
+      }
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        dispatch({ type: FeatureAvailabilityActionType.SET_CYDESK_UNAVAILABLE })
+      }
+    }
+  }
+
+  const tooltip = useMemo(() => {
+    if (state.isSafari) {
+      return 'This feature is not available in Safari.'
+    }
+    if (!state.isCyDeskAvailable) {
+      return 'To use this feature, you need Cytoscape running 3.8.0 or higher on your machine (default port 1234).'
+    }
+    return 'Open a copy of the current network in Cytoscape Desktop.'
+  }, [state.isSafari, state.isCyDeskAvailable])
+
+  useEffect(() => {
+    const ua = navigator.userAgent.toLowerCase()
+    const isSafari = ua.includes('safari') && !ua.includes('chrome')
+    dispatch({
+      type: isSafari
+        ? FeatureAvailabilityActionType.SET_IS_SAFARI
+        : FeatureAvailabilityActionType.SET_NOT_SAFARI,
+    })
+    if (isSafari) {
+      return
+    }
+    const abortController = new AbortController()
+
+    const intervalId = setInterval(() => {
+      pollAvailability(abortController)
+    }, POLLING_INTERVAL)
+
+    return () => {
+      clearInterval(intervalId)
+      abortController.abort()
+    }
+  }, [])
+
+  return (
+    <FeatureAvailabilityContext.Provider value={{ state, tooltip }}>
+      {children}
+    </FeatureAvailabilityContext.Provider>
+  )
+}
+
+export const useFeatureAvailability = () =>
+  useContext(FeatureAvailabilityContext)

--- a/src/components/FeatureAvailability/index.ts
+++ b/src/components/FeatureAvailability/index.ts
@@ -1,0 +1,1 @@
+export { useFeatureAvailability, FeatureAvailabilityProvider } from './FeatureAvailabilityProvider'

--- a/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
+++ b/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
@@ -10,15 +10,12 @@ import { useTableStore } from '../../store/TableStore'
 import { useViewModelStore } from '../../store/ViewModelStore'
 import { useVisualStyleStore } from '../../store/VisualStyleStore'
 import { useNetworkSummaryStore } from '../../store/NetworkSummaryStore'
-import { exportNetworkToCx2 } from '../../store/io/exportCX'
 import { Network } from '../../models/NetworkModel'
-import { useEffect, useMemo, useState } from 'react'
 import { useUiStateStore } from '../../store/UiStateStore'
 import { useOpaqueAspectStore } from '../../store/OpaqueAspectStore'
 import { IdType } from '../../models'
-import { useMessageStore } from '../../store/MessageStore'
-import { MessageSeverity } from '../../models/MessageModel'
 import { useFeatureAvailability } from '../FeatureAvailability'
+import { useOpenNetworkInCytoscape } from '../../store/hooks/useOpenInCytoscapeDesktop'
 
 interface OpenInCytoscapeButtonProps {
   targetNetworkId?: IdType
@@ -30,7 +27,7 @@ export const OpenInCytoscapeButton = ({
   networkLabel,
 }: OpenInCytoscapeButtonProps): JSX.Element => {
   const featureAvailabilityState = useFeatureAvailability()
-
+  const openNetworkInCytoscape = useOpenNetworkInCytoscape()
   const currentNetworkId: IdType = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
@@ -39,7 +36,6 @@ export const OpenInCytoscapeButton = ({
 
   const cyndex = new CyNDEx()
 
-  const addMessage = useMessageStore((state) => state.addMessage)
   const table = useTableStore((state) => state.tables[networkId])
   const summary = useNetworkSummaryStore((state) => state.summaries[networkId])
 
@@ -60,59 +56,18 @@ export const OpenInCytoscapeButton = ({
       ? allOpaqueAspects[targetNetworkId]
       : undefined
 
-  const openNetworkInCytoscape = async (): Promise<void> => {
-    if (viewModel === undefined) {
-      throw new Error('Could not find the current network view model.')
-    }
-
-    let targetSummary: any = summary
-    if (summary === undefined) {
-      targetSummary = {
-        name: networkLabel ?? 'Interaction Network',
-        properties: [],
-        externalId: '',
-        isReadOnly: false,
-        isShowcase: false,
-        owner: '',
-      }
-    }
-
-    const cx = exportNetworkToCx2(
+  const handleClick = async (): Promise<void> => {
+    await openNetworkInCytoscape(
       network,
       visualStyle,
-      targetSummary,
-      table.nodeTable,
-      table.edgeTable,
+      summary,
+      table,
       visualStyleOptions,
       viewModel,
-      targetSummary.name,
       opaqueAspects,
+      cyndex,
+      networkLabel,
     )
-    try {
-      addMessage({
-        message: 'Sending this network to Cytoscape Desktop...',
-        duration: 3000,
-        severity: MessageSeverity.INFO,
-      })
-      await cyndex.postCX2NetworkToCytoscape(cx)
-      addMessage({
-        message: 'Network successfully opened in Cytoscape Desktop.',
-        duration: 3000,
-        severity: MessageSeverity.SUCCESS,
-      })
-    } catch (e) {
-      console.warn('Could not open the network in Cytoscape Desktop!', e)
-      addMessage({
-        message:
-          'To use this feature, you need Cytoscape 3.6.0 or higher running on your machine (default port: 1234) and the CyNDEx-2 app installed',
-        duration: 3000,
-        severity: MessageSeverity.ERROR,
-      })
-    }
-  }
-
-  const handleClick = async (): Promise<void> => {
-    await openNetworkInCytoscape()
   }
 
   return (

--- a/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
+++ b/src/components/FloatingToolBar/OpenInCytoscapeButton.tsx
@@ -12,12 +12,13 @@ import { useVisualStyleStore } from '../../store/VisualStyleStore'
 import { useNetworkSummaryStore } from '../../store/NetworkSummaryStore'
 import { exportNetworkToCx2 } from '../../store/io/exportCX'
 import { Network } from '../../models/NetworkModel'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useUiStateStore } from '../../store/UiStateStore'
 import { useOpaqueAspectStore } from '../../store/OpaqueAspectStore'
 import { IdType } from '../../models'
 import { useMessageStore } from '../../store/MessageStore'
 import { MessageSeverity } from '../../models/MessageModel'
+import { useFeatureAvailability } from '../FeatureAvailability'
 
 interface OpenInCytoscapeButtonProps {
   targetNetworkId?: IdType
@@ -28,10 +29,7 @@ export const OpenInCytoscapeButton = ({
   targetNetworkId,
   networkLabel,
 }: OpenInCytoscapeButtonProps): JSX.Element => {
-  const isSafari = useMemo(() => {
-    const ua = navigator.userAgent.toLowerCase()
-    return ua.includes('safari') && !ua.includes('chrome')
-  }, [])
+  const featureAvailabilityState = useFeatureAvailability()
 
   const currentNetworkId: IdType = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
@@ -119,22 +117,16 @@ export const OpenInCytoscapeButton = ({
 
   return (
     <>
-      <Tooltip
-        title={
-          isSafari
-            ? 'This feature is not available on Safari'
-            : 'Open network in Cytoscape Desktop (useful for high performance computing)'
-        }
-        placement="top"
-        arrow
-      >
+      <Tooltip title={featureAvailabilityState.tooltip} placement="top" arrow>
         <span>
           <IconButton
             onClick={handleClick}
             aria-label="fit"
             size="small"
             disableFocusRipple={true}
-            disabled={isSafari}
+            disabled={
+              featureAvailabilityState.state.isCyDeskAvailable === false
+            }
           >
             <OpenInNew fontSize="inherit" />
           </IconButton>

--- a/src/components/ToolBar/DataMenu/OpenNetworkInCytoscapeMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/OpenNetworkInCytoscapeMenuItem.tsx
@@ -1,5 +1,5 @@
 import { MenuItem, Tooltip, Box } from '@mui/material'
-import { ReactElement, useMemo } from 'react'
+import { ReactElement, useEffect, useMemo, useState } from 'react'
 import { BaseMenuProps } from '../BaseMenuProps'
 
 // @ts-expect-error-next-line
@@ -18,11 +18,13 @@ import { useUiStateStore } from '../../../store/UiStateStore'
 import { useOpaqueAspectStore } from '../../../store/OpaqueAspectStore'
 import { useMessageStore } from '../../../store/MessageStore'
 import { MessageSeverity } from '../../../models/MessageModel'
+import { useFeatureAvailability } from '../../FeatureAvailability'
 
 export const OpenNetworkInCytoscapeMenuItem = ({
   handleClose,
 }: BaseMenuProps): ReactElement => {
   const cyndex = new CyNDEx()
+  const featureAvailabilityState = useFeatureAvailability()
   const currentNetworkId = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
@@ -96,12 +98,10 @@ export const OpenNetworkInCytoscapeMenuItem = ({
     await openNetworkInCytoscape()
   }
 
-  const isSafari = useMemo(() => {
-    const ua = navigator.userAgent.toLowerCase()
-    return ua.includes('safari') && !ua.includes('chrome')
-  }, [])
+  const disabled =
+    featureAvailabilityState.state.isCyDeskAvailable === false ||
+    currentNetworkId === ''
 
-  const disabled = isSafari || currentNetworkId === ''
   const menuItem = (
     <MenuItem onClick={handleOpenNetworkInCytoscape} disabled={disabled}>
       Open Network in Cytoscape Desktop
@@ -112,13 +112,7 @@ export const OpenNetworkInCytoscapeMenuItem = ({
     <Tooltip
       arrow
       placement="right"
-      title={
-        disabled
-          ? isSafari && currentNetworkId !== ''
-            ? 'This feature is not available on Safari'
-            : ''
-          : 'Download and open Cytoscape to open network'
-      }
+      title={currentNetworkId === '' ? '' : featureAvailabilityState.tooltip}
     >
       <Box>{menuItem}</Box>
     </Tooltip>

--- a/src/components/ToolBar/DataMenu/OpenNetworkInCytoscapeMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/OpenNetworkInCytoscapeMenuItem.tsx
@@ -1,5 +1,5 @@
 import { MenuItem, Tooltip, Box } from '@mui/material'
-import { ReactElement, useEffect, useMemo, useState } from 'react'
+import { ReactElement } from 'react'
 import { BaseMenuProps } from '../BaseMenuProps'
 
 // @ts-expect-error-next-line
@@ -11,24 +11,22 @@ import { useTableStore } from '../../../store/TableStore'
 import { useViewModelStore } from '../../../store/ViewModelStore'
 import { useVisualStyleStore } from '../../../store/VisualStyleStore'
 import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore'
-import { exportNetworkToCx2 } from '../../../store/io/exportCX'
 import { Network } from '../../../models/NetworkModel'
 import { NetworkView } from '../../../models/ViewModel'
 import { useUiStateStore } from '../../../store/UiStateStore'
 import { useOpaqueAspectStore } from '../../../store/OpaqueAspectStore'
-import { useMessageStore } from '../../../store/MessageStore'
-import { MessageSeverity } from '../../../models/MessageModel'
 import { useFeatureAvailability } from '../../FeatureAvailability'
+import { useOpenNetworkInCytoscape } from '../../../store/hooks/useOpenInCytoscapeDesktop'
 
 export const OpenNetworkInCytoscapeMenuItem = ({
   handleClose,
 }: BaseMenuProps): ReactElement => {
   const cyndex = new CyNDEx()
+  const openNetworkInCytoscape = useOpenNetworkInCytoscape()
   const featureAvailabilityState = useFeatureAvailability()
   const currentNetworkId = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
-  const addMessage = useMessageStore((state) => state.addMessage)
   const table = useTableStore((state) => state.tables[currentNetworkId])
   const summary = useNetworkSummaryStore(
     (state) => state.summaries[currentNetworkId],
@@ -49,53 +47,18 @@ export const OpenNetworkInCytoscapeMenuItem = ({
     (state) => state.opaqueAspects[currentNetworkId],
   )
 
-  const openNetworkInCytoscape = async (): Promise<void> => {
-    if (viewModel === undefined) {
-      addMessage({
-        message: 'Could not find the current network view model.',
-        duration: 4000,
-        severity: MessageSeverity.WARNING,
-      })
-      return
-    }
-    const cx = exportNetworkToCx2(
+  const handleOpenNetworkInCytoscape = async (): Promise<void> => {
+    await openNetworkInCytoscape(
       network,
       visualStyle,
       summary,
-      table.nodeTable,
-      table.edgeTable,
+      table,
       visualStyleOptions,
       viewModel,
-      `Copy of ${summary.name}`,
       opaqueAspects,
+      cyndex,
     )
-    try {
-      addMessage({
-        message: 'Sending this network to Cytoscape Desktop...',
-        duration: 3000,
-        severity: MessageSeverity.INFO,
-      })
-
-      await cyndex.postCX2NetworkToCytoscape(cx)
-      addMessage({
-        message: 'Network successfully opened in Cytoscape Desktop.',
-        duration: 4000,
-        severity: MessageSeverity.SUCCESS,
-      })
-    } catch (e) {
-      addMessage({
-        message:
-          'To use this feature, you need Cytoscape 3.6.0 or higher running on your machine (default port: 1234) and the CyNDEx-2 app installed.',
-        duration: 6000,
-        severity: MessageSeverity.ERROR,
-      })
-      console.error('Could not open the network in Cytoscape Desktop!', e)
-    }
     handleClose()
-  }
-
-  const handleOpenNetworkInCytoscape = async (): Promise<void> => {
-    await openNetworkInCytoscape()
   }
 
   const disabled =

--- a/src/store/hooks/useOpenInCytoscapeDesktop.ts
+++ b/src/store/hooks/useOpenInCytoscapeDesktop.ts
@@ -1,0 +1,89 @@
+import { useMessageStore } from '../MessageStore'
+// @ts-expect-error-next-line
+import { CyNDEx } from '@js4cytoscape/ndex-client'
+import { exportNetworkToCx2 } from '../io/exportCX'
+import { MessageSeverity } from '../../models/MessageModel'
+import { Network } from '../../models/NetworkModel'
+import { NetworkView } from '../../models/ViewModel'
+import {
+  NdexNetworkSummary,
+  OpaqueAspects,
+  TableRecord,
+  VisualStyle,
+} from '../../models'
+import { VisualStyleOptions } from '../../models/VisualStyleModel/VisualStyleOptions'
+
+export const useOpenNetworkInCytoscape = () => {
+  const addMessage = useMessageStore((state) => state.addMessage)
+
+  const openNetworkInCytoscape = async (
+    network: Network,
+    visualStyle: VisualStyle,
+    summary: NdexNetworkSummary | undefined,
+    table: TableRecord,
+    visualStyleOptions: VisualStyleOptions,
+    viewModel: NetworkView | undefined,
+    opaqueAspects: OpaqueAspects|undefined,
+    cyndex: CyNDEx,
+    networkLabel?: string,
+  ): Promise<void> => {
+    if (viewModel === undefined) {
+      addMessage({
+        message: 'Could not find the current network view model.',
+        duration: 4000,
+        severity: MessageSeverity.WARNING,
+      })
+      return
+    }
+
+    let exportSummary: any = summary
+    if (summary === undefined) {
+        exportSummary = {
+        name: networkLabel ?? 'Interaction Network',
+        properties: [],
+        externalId: '',
+        isReadOnly: false,
+        isShowcase: false,
+        owner: '',
+      }
+    }
+
+    const cx = exportNetworkToCx2(
+      network,
+      visualStyle,
+      exportSummary,
+      table.nodeTable,
+      table.edgeTable,
+      visualStyleOptions,
+      viewModel,
+      `Copy of ${exportSummary.name}`,
+      opaqueAspects,
+    )
+
+    try {
+      addMessage({
+        message: 'Sending this network to Cytoscape Desktop...',
+        duration: 3000,
+        severity: MessageSeverity.INFO,
+      })
+
+      await cyndex.postCX2NetworkToCytoscape(cx)
+
+      addMessage({
+        message: 'Network successfully opened in Cytoscape Desktop.',
+        duration: 3000,
+        severity: MessageSeverity.SUCCESS,
+      })
+    } catch (error) {
+      addMessage({
+        message:
+          'To use this feature, you need Cytoscape 3.6.0 or higher running on your machine (default port: 1234) and the CyNDEx-2 app installed.',
+        duration: 5000,
+        severity: MessageSeverity.ERROR,
+      })
+      console.error('Could not open the network in Cytoscape Desktop!', error)
+    }
+  }
+
+  return openNetworkInCytoscape
+}


### PR DESCRIPTION
Ticket: [CW-490](https://cytoscape.atlassian.net/browse/CW-490)

### To Test
1. Open Cytoscape-Web and observe the behavior of the two "Open in Cytoscape Desktop" buttons as Cytoscape-Desktop is started or stopped.
2. Ensure that the buttons are enabled when Cytoscape-Desktop is running and disabled when it is not.
3. Click the enabled button to test whether it can open the copy of the network in the Cytoscape Desktop successfully.

One button is in `Data -> Open Network in Cytoscape` menu, the other is in the floating toolbar of the renderer.

[CW-490]: https://cytoscape.atlassian.net/browse/CW-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ