### PR TITLE
Render annotations for cy.js networks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",
         "@glideapps/glide-data-grid": "^5.2.1",
+        "@js4cytoscape/cx2js": "^0.6.11",
+        "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.3",
         "@js4cytoscape/ndex-client": "^0.4.3-alpha.12",
         "@mantine/core": "^7.6.2",
         "@mantine/dropzone": "^7.6.2",
@@ -42,6 +44,7 @@
         "allotment": "1.18.1",
         "chroma-js": "^2.4.2",
         "cytoscape": "^3.28.1",
+        "cytoscape-canvas": "^3.0.1",
         "cytoscape-pdf-export": "^0.0.2",
         "cytoscape-svg": "^0.4.0",
         "d3-array": "^3.2.4",
@@ -3282,6 +3285,31 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js4cytoscape/cx2js": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/@js4cytoscape/cx2js/-/cx2js-0.6.11.tgz",
+      "integrity": "sha512-yVwKjBr3IRf0M1X8qO3ZWTulUuFZj2BNH+ixOzIbsoB+P5dnrMB6RQNG8GYnf9Dh1J3F7LtW6UPyS4xAJlDQZw==",
+      "dependencies": {
+        "cytoscape-canvas": "3.0.1",
+        "fs": "^0.0.1-security",
+        "lodash": "^4.17.10"
+      },
+      "engines": {
+        "node": ">=6.3.0"
+      }
+    },
+    "node_modules/@js4cytoscape/cyannotation-cx2js": {
+      "version": "0.8.7-alpha.3",
+      "resolved": "https://registry.npmjs.org/@js4cytoscape/cyannotation-cx2js/-/cyannotation-cx2js-0.8.7-alpha.3.tgz",
+      "integrity": "sha512-PG4cKpQrBhJUL5Q4EjT+XHl2KhIVajuOcQahiEvymx+L9USk28JNILSolgD69plK8EIomN3d/N9UZOPW2voFQA==",
+      "dependencies": {
+        "cytoscape-canvas": "3.0.1",
+        "lodash": "^4.17.10"
+      },
+      "engines": {
+        "node": ">=6.3.0"
       }
     },
     "node_modules/@js4cytoscape/ndex-client": {
@@ -8231,6 +8259,11 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/cytoscape-canvas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-canvas/-/cytoscape-canvas-3.0.1.tgz",
+      "integrity": "sha512-R1nCLnJHGTR5fWEpNQQBPyoigdnfhnk1lOHegzmzz1Kg6yxzVf0hfdRAMa0wPAhtC4kkgyoViiIfZ/zyCqMhEQ=="
+    },
     "node_modules/cytoscape-pdf-export": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/cytoscape-pdf-export/-/cytoscape-pdf-export-0.0.2.tgz",
@@ -10482,6 +10515,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0-beta.1",
   "private": true,
   "license": "MIT",
-  
   "scripts": {
     "clean": "rm -rf dist",
     "test": "npm run test:playwright && npm run test:unit",
@@ -15,7 +14,6 @@
     "lint": "eslint --ext .js,.ts,.jsx,.tsx src",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'"
   },
-  
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/plugin-transform-modules-commonjs": "^7.24.8",
@@ -80,6 +78,8 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@glideapps/glide-data-grid": "^5.2.1",
+    "@js4cytoscape/cx2js": "^0.6.11",
+    "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.3",
     "@js4cytoscape/ndex-client": "^0.4.3-alpha.12",
     "@mantine/core": "^7.6.2",
     "@mantine/dropzone": "^7.6.2",
@@ -108,6 +108,7 @@
     "allotment": "1.18.1",
     "chroma-js": "^2.4.2",
     "cytoscape": "^3.28.1",
+    "cytoscape-canvas": "^3.0.1",
     "cytoscape-pdf-export": "^0.0.2",
     "cytoscape-svg": "^0.4.0",
     "d3-array": "^3.2.4",

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -7,6 +7,10 @@ import Cytoscape, {
   NodeSingular,
   SingularElementArgument,
 } from 'cytoscape'
+// @ts-expect-error-next-line
+import { CxToCyCanvas } from '@js4cytoscape/cyannotation-cx2js'
+// @ts-expect-error-next-line
+import { CyNetworkUtils, CxToJs } from '@js4cytoscape/cx2js'
 
 import { registerCyExtensions } from './register-cy-extensions'
 
@@ -30,9 +34,10 @@ import {
   Orientation,
   PaperSize,
 } from '../../ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm'
+import { useNetworkSummaryStore } from '../../../store/NetworkSummaryStore'
+import { CX_ANNOTATIONS_KEY } from './annotations/CyAnnotation'
 
 registerCyExtensions()
-
 interface NetworkRendererProps {
   network?: Network
 
@@ -65,6 +70,16 @@ const CyjsRenderer = ({
     IdType | undefined
   >(undefined)
 
+  // const [annotationRenderer, setAnnotationRenderer] = useState<any>(() => {
+  //   const cxNetworkUtils = new CyNetworkUtils()
+  //   const cyService = new CxToJs(cxNetworkUtils)
+  //   return new CxToCyCanvas(cyService)
+  // })
+
+  // Canvas layer state that we need to keep track of so that we can clear the previous network layers if any
+  // before rendering the next network.
+  const [annotationLayers, setAnnotationLayers] = useState<any[]>([])
+
   // Store sub-selection state. If show-hide mode is selected, then
   // the selected node will be highlighted and the others will be shown, too.
   const [subSelectedEdges, setSubSelectedEdges] = useState<IdType[]>([])
@@ -95,6 +110,7 @@ const CyjsRenderer = ({
     (state) => state.ui.visualStyleOptions[id]?.visualEditorProperties,
   )
   const tables = useTableStore((state) => state.tables)
+  const summaries = useNetworkSummaryStore((state) => state.summaries)
   const getViewModel: (id: IdType) => NetworkView | undefined =
     useViewModelStore((state) => state.getViewModel)
 
@@ -130,6 +146,7 @@ const CyjsRenderer = ({
   }, [vs, isRunning])
 
   const table = tables[id]
+  const summary = summaries[id]
 
   const [cy, setCy] = useState<any>(null)
   const cyContainer = useRef(null)
@@ -312,6 +329,42 @@ const CyjsRenderer = ({
       target.removeClass('hover')
       setHoveredElement(undefined)
     })
+
+    const annotations = (summary?.properties ?? []).filter(
+      (p) => p.predicateString === CX_ANNOTATIONS_KEY,
+    )
+
+    const niceCXForCyAnnotationRendering = {
+      networkAttributes: {
+        elements: annotations.map((a) => {
+          return {
+            n: CX_ANNOTATIONS_KEY,
+            v: a.value,
+          }
+        }),
+      },
+    }
+
+    annotationLayers.forEach((layer) => {
+      const ctx = layer?.getCanvas()?.getContext('2d')
+      if (ctx !== undefined) {
+        layer.clear(ctx)
+      }
+    })
+
+    const cxNetworkUtils = new CyNetworkUtils()
+    const cyService = new CxToJs(cxNetworkUtils)
+    const annotationRenderer = new CxToCyCanvas(cyService)
+
+    if (annotations.length > 0) {
+      const result = annotationRenderer.drawAnnotationsFromNiceCX(
+        cy,
+        niceCXForCyAnnotationRendering,
+      )
+      setAnnotationLayers([result.topLayer, result.bottomLayer])
+    } else {
+      setAnnotationLayers([])
+    }
 
     cy.endBatch()
 

--- a/src/components/NetworkPanel/CyjsRenderer/register-cy-extensions.ts
+++ b/src/components/NetworkPanel/CyjsRenderer/register-cy-extensions.ts
@@ -3,7 +3,11 @@ import cytoscape from 'cytoscape'
 import pdf from 'cytoscape-pdf-export'
 // @ts-expect-error-next-line
 import svg from 'cytoscape-svg'
+// @ts-expect-error-next-line
+import cyCanvas from 'cytoscape-canvas'
+
 export const registerCyExtensions = (): void => {
   cytoscape.use(pdf)
   cytoscape.use(svg)
+  cytoscape.use(cyCanvas)
 }


### PR DESCRIPTION
- Read only annotation display for cytoscape.js networks
- Use the same package version as the ndex angular app for displaying annotations
- Remove previous layers on each render