### PR TITLE
Fix continuous mapping form ui issues

### DIFF
--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -1021,7 +1021,14 @@ export function ContinuousColorMappingForm(props: {
                   alignItems: 'center',
                 }}
               >
-                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                <Box
+                  sx={{
+                    maxWidth: 80,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   {m.attribute}
                 </Box>
                 <ExpandableNumberInput
@@ -1038,7 +1045,14 @@ export function ContinuousColorMappingForm(props: {
                   justifyContent: 'space-between',
                 }}
               >
-                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                <Box
+                  sx={{
+                    maxWidth: 80,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   {props.visualProperty.displayName}
                 </Box>
                 <VisualPropertyValueForm

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -395,7 +395,9 @@ export function ContinuousColorMappingForm(props: {
       m.ltMinVpValue,
       m.gtMaxVpValue,
     )
-    setAddHandleFormValue(minState.value as number)
+    setAddHandleFormValue(
+      ((minState.value as number) + (maxState.value as number)) / 2,
+    )
   }, [minState])
 
   // anytime someone changes the max value, make sure all handle values are less than the max
@@ -419,7 +421,9 @@ export function ContinuousColorMappingForm(props: {
       m.ltMinVpValue,
       m.gtMaxVpValue,
     )
-    setAddHandleFormValue(minState.value as number)
+    setAddHandleFormValue(
+      ((minState.value as number) + (maxState.value as number)) / 2,
+    )
   }, [maxState])
 
   return (
@@ -1017,7 +1021,9 @@ export function ContinuousColorMappingForm(props: {
                   alignItems: 'center',
                 }}
               >
-                {m.attribute}
+                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                  {m.attribute}
+                </Box>
                 <ExpandableNumberInput
                   value={addHandleFormValue}
                   onConfirm={(newValue) => setAddHandleFormValue(newValue)}
@@ -1032,7 +1038,9 @@ export function ContinuousColorMappingForm(props: {
                   justifyContent: 'space-between',
                 }}
               >
-                {props.visualProperty.displayName}
+                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                  {props.visualProperty.displayName}
+                </Box>
                 <VisualPropertyValueForm
                   currentValue={addHandleFormVpValue}
                   visualProperty={props.visualProperty}

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -1115,9 +1115,19 @@ export function ContinuousColorMappingForm(props: {
             horizontal: 'center',
           }}
         >
-          <Box sx={{ p: 1 }}>
+          <Box sx={{ p: 1, width: 200 }}>
             <Box>
-              <Typography variant="body1">{m.attribute}</Typography>
+              <Typography
+                variant="body1"
+                sx={{
+                  maxWidth: 180,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {m.attribute}
+              </Typography>
               <Box
                 sx={{
                   display: 'flex',

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -806,7 +806,17 @@ export function ContinuousNumberMappingForm(props: {
         >
           <Box sx={{ p: 1, width: 200 }}>
             <Box>
-              <Typography variant="body1">{m.attribute}</Typography>
+              <Typography
+                variant="body1"
+                sx={{
+                  maxWidth: 180,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {m.attribute}
+              </Typography>
               <Box sx={{ p: 1 }}>
                 <Box
                   sx={{

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -286,7 +286,9 @@ export function ContinuousNumberMappingForm(props: {
       m.gtMaxVpValue,
     )
 
-    setAddHandleFormValue(minState.value as number)
+    setAddHandleFormValue(
+      ((minState.value as number) + (maxState.value as number)) / 2,
+    )
   }, [minState])
 
   // anytime someone changes the max value, make sure all handle values are less than the max
@@ -310,8 +312,9 @@ export function ContinuousNumberMappingForm(props: {
       m.ltMinVpValue,
       m.gtMaxVpValue,
     )
-
-    setAddHandleFormValue(minState.value as number)
+    setAddHandleFormValue(
+      ((minState.value as number) + (maxState.value as number)) / 2,
+    )
   }, [maxState])
 
   return (
@@ -372,7 +375,8 @@ export function ContinuousNumberMappingForm(props: {
 
                 return (
                   <Draggable
-                    disabled={isEndHandle}
+                    // disabled={isEndHandle}
+                    axis={isEndHandle ? 'y' : 'both'}
                     key={h.id}
                     bounds={{
                       left: LINE_CHART_MARGIN_LEFT,
@@ -399,7 +403,11 @@ export function ContinuousNumberMappingForm(props: {
                           .toFixed(4),
                       )
 
-                      setHandle(h.id, newValue, newVpValue)
+                      if (isEndHandle) {
+                        setHandle(h.id, h.value as number, newVpValue)
+                      } else {
+                        setHandle(h.id, newValue, newVpValue)
+                      }
                     }}
                     position={{
                       x: pixelPositionX,
@@ -448,11 +456,9 @@ export function ContinuousNumberMappingForm(props: {
                             width: 2,
                             top: HANDLE_VERTICAL_OFFSET,
                             height: pixelPositionY,
-                            backgroundColor: isEndHandle
-                              ? '#D9D9D9'
-                              : '#03082d',
+                            backgroundColor: '#03082d',
                             '&:hover': {
-                              cursor: 'move',
+                              cursor: isEndHandle ? 'ns-resize' : 'move',
                             },
                           }}
                         ></Box>
@@ -555,13 +561,14 @@ export function ContinuousNumberMappingForm(props: {
                         </Box>
                       </Paper>
                       <IconButton
-                        disabled={isEndHandle}
                         className="handle"
                         size="large"
                         sx={{
                           position: 'relative',
                           top: -114,
-                          '&:hover': { cursor: 'move' },
+                          '&:hover': {
+                            cursor: isEndHandle ? 'ns-resize' : 'move',
+                          },
                         }}
                       >
                         <ArrowDropDownIcon
@@ -569,7 +576,7 @@ export function ContinuousNumberMappingForm(props: {
                             fontSize: '60px',
                             opacity: 1,
                             zIndex: 3,
-                            color: isEndHandle ? '#D9D9D9' : '#03082d',
+                            color: '#03082d',
                           }}
                         />
                       </IconButton>
@@ -702,7 +709,9 @@ export function ContinuousNumberMappingForm(props: {
                   alignItems: 'center',
                 }}
               >
-                {m.attribute}
+                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                  {m.attribute}
+                </Box>
                 <ExpandableNumberInput
                   min={minState.value as number}
                   max={maxState.value as number}
@@ -720,7 +729,9 @@ export function ContinuousNumberMappingForm(props: {
                   alignItems: 'center',
                 }}
               >
-                {props.visualProperty.displayName}
+                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                  {props.visualProperty.displayName}
+                </Box>
                 <ExpandableNumberInput
                   value={addHandleFormVpValue}
                   onConfirm={(newVal) => {

--- a/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/components/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -709,7 +709,14 @@ export function ContinuousNumberMappingForm(props: {
                   alignItems: 'center',
                 }}
               >
-                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                <Box
+                  sx={{
+                    maxWidth: 80,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   {m.attribute}
                 </Box>
                 <ExpandableNumberInput
@@ -729,7 +736,14 @@ export function ContinuousNumberMappingForm(props: {
                   alignItems: 'center',
                 }}
               >
-                <Box sx={{ maxWidth: 80, overflow: 'hidden' }}>
+                <Box
+                  sx={{
+                    maxWidth: 80,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   {props.visualProperty.displayName}
                 </Box>
                 <ExpandableNumberInput


### PR DESCRIPTION
- Set default value of the new handle form to be the mean of the max and min values
- Users can drag the end handles along the y axis
- Fix issue where long column names would overflow the new handle form