### PR TITLE
Allow null for inputNetwork or inputColumns in serviceInputDefinition

### DIFF
--- a/src/components/FloatingToolBar/ShareNetworkButtton.tsx
+++ b/src/components/FloatingToolBar/ShareNetworkButtton.tsx
@@ -53,19 +53,13 @@ export const ShareNetworkButton = ({
     state.getViewModel(currentNetworkId),
   )
 
-  const networkInfo = useNetworkSummaryStore(
+  const networkSummary = useNetworkSummaryStore(
     (state) => state.summaries[currentNetworkId],
   )
-  // If networkInfo is undefined or null, this becomes `false`
-  const isNdex = networkInfo?.isNdex;
 
-  const isNotNdex = isNdex === false;
+  const isLocal = networkSummary?.isNdex !== true
 
   const addMessage = useMessageStore((state) => state.addMessage)
-
-  const { selectedNodes, selectedEdges } = networkViewModel ?? {}
-  const selectedNodeCount: number = selectedNodes?.length ?? 0
-  const selectedEdgeCount: number = selectedEdges?.length ?? 0
 
   const getQueryString = (): string => {
     const panelParams = new URLSearchParams(panels)
@@ -158,7 +152,7 @@ export const ShareNetworkButton = ({
     <>
       <Tooltip
         title={
-          isNotNdex
+          isLocal
             ? 'Save this network to NDEx first to generate a shareable URL.'
             : 'Share this network (copy URL to clipboard)'
         }
@@ -167,11 +161,11 @@ export const ShareNetworkButton = ({
       >
         <span>
           <IconButton
-            onClick={isNotNdex ? undefined : handleClick}
+            onClick={isLocal ? undefined : handleClick}
             aria-label="share"
             size="small"
             disableFocusRipple
-            disabled={isNotNdex}
+            disabled={isLocal}
           >
             <Share fontSize="inherit" />
           </IconButton>

--- a/src/features/ServiceApps/index.ts
+++ b/src/features/ServiceApps/index.ts
@@ -40,8 +40,8 @@ interface RunTaskProps {
   serviceUrl: string
   algorithmName: string
   customParameters: { [key: string]: string }
-  network: Network
-  table: TableRecord
+  network?: Network
+  table?: TableRecord
   visualStyle?: VisualStyle
   summary?: NdexNetworkSummary
   visualStyleOptions?: VisualStyleOptions
@@ -222,7 +222,7 @@ export const useRunTask = (): ((
       if (serviceInputDefinition !== undefined) {
         const { type, scope, inputNetwork, inputColumns } =
           serviceInputDefinition
-        if (inputNetwork !== null) {
+        if (inputNetwork !== null && network !== undefined) {
           data = createNetworkDataObj(
             scope,
             inputNetwork,
@@ -234,7 +234,7 @@ export const useRunTask = (): ((
             viewModel,
             opaqueAspect,
           )
-        } else if (inputColumns !== null) {
+        } else if (inputColumns !== null && table !== undefined) {
           data = createTableDataObj(
             type === SelectedDataType.Node ? table.nodeTable : table.edgeTable,
             scope,

--- a/src/store/hooks/useServiceTaskRunner.ts
+++ b/src/store/hooks/useServiceTaskRunner.ts
@@ -119,8 +119,12 @@ export const useServiceTaskRunner = (): ((
         throw new Error(`Service not found for URL: ${url}`)
       }
 
-      if (networkRef.current === undefined) {
+      if (serviceApp.serviceInputDefinition?.inputNetwork && networkRef.current === undefined) {
         throw new Error('Network not found')
+      }
+
+      if (serviceApp.serviceInputDefinition?.inputColumns && tableRef.current === undefined) {
+        throw new Error('Table not found')
       }
 
       const customParameters =


### PR DESCRIPTION
TIcket: [CW-491](https://cytoscape.atlassian.net/browse/CW-491)

### Changes Made:
- Disable the **submit** button in the app dialog ONLY WHEN the network/table data is required in the service-app's `serviceInputDefinition`
- Customize the tooltip for two cases 
    - There is no active network
    - The input column does not exist in the table 
- Some code clean in `src/components/FloatingToolBar/ShareNetworkButtton.tsx`

### To Test
- Add service apps in the `App -> App Manager`
- Delete all the networks in the current workspace
- Check
    -  The Service-app [Open URL - null service input definition](https://cd.ndexbio.org/cy/cytocontainer/v1/openurlexamplenoinput) can be run (the submit button would be enabled)
    - All other service-app cannot be run, namely the 'submit' button is disabled with different tooltips
        - Apps under "Run Functional Enrichment" would have the tooltip   "Unable to run service. There isn't an active network".
        - Other apps would have the tooltip:  "Unable to run service. The network doesn't have input columns that match the required data types from the service."
<img width="400" alt="image" src="https://github.com/user-attachments/assets/aecb3e69-73d5-49e1-bbb6-44c82635e0b0" />



[CW-491]: https://cytoscape.atlassian.net/browse/CW-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ