### PR TITLE
Reset isModified as false after initial layout apply

### DIFF
--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -363,6 +363,7 @@ const WorkSpaceEditor = (): JSX.Element => {
               updateNodePositions(networkId, positionMap)
               updateSummary(networkId, nextSummary)
               setIsRunning(false)
+              setNetworkModified(networkId, false)
             }
 
             engine.apply(


### PR DESCRIPTION
Ticket: [CW-483](https://cytoscape.atlassian.net/browse/CW-483)

#### Changes Made
Added a line to reset the network's **isModified** flag as `false` if the network does not have a layout and would be applied the default layout when loading

#### To Test 
- Try to load this network (UUID: 06f859c1-8051-11ef-b4e1-005056ae6f73) 
- It will not have the 'red' mark once loaded

[CW-483]: https://cytoscape.atlassian.net/browse/CW-483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ