### PR TITLE
Minor improvements on 'Saving Workspace'

### DIFF
--- a/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -111,7 +111,7 @@ export const CopyNetworkToNDExMenuItem = (
       if (e.message.includes(TimeOutErrorIndicator)) {
         addMessage({
           message: TimeOutErrorMessage,
-          duration: 6000,
+          duration: 4000,
           severity: MessageSeverity.ERROR,
         })
       } else {
@@ -119,7 +119,7 @@ export const CopyNetworkToNDExMenuItem = (
           message: `Error: Could not save a copy of the current network to NDEx. ${
             e.message as string
           }`,
-          duration: 5000,
+          duration: 4000,
           severity: MessageSeverity.ERROR,
         })
       }

--- a/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -139,7 +139,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
     } else if (!isModified) {
       setTooltipText('This network has not been modified since the last save')
     } else {
-      setTooltipText('')
+      setTooltipText('Overwrite network to NDEx')
     }
   }, [
     isModified,
@@ -211,7 +211,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
       if (e.message.includes(TimeOutErrorIndicator)) {
         addMessage({
           message: TimeOutErrorMessage,
-          duration: 6000,
+          duration: 4000,
           severity: MessageSeverity.ERROR,
         })
       } else {
@@ -219,7 +219,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
           message: `Error: Could not save a copy of the current network to NDEx. ${
             e.message as string
           }`,
-          duration: 5000,
+          duration: 4000,
           severity: MessageSeverity.ERROR,
         })
       }
@@ -265,7 +265,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
       if (e.message.includes(TimeOutErrorIndicator)) {
         addMessage({
           message: TimeOutErrorMessage,
-          duration: 6000,
+          duration: 4000,
           severity: MessageSeverity.ERROR,
         })
       } else {
@@ -273,7 +273,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuProps): ReactElement => {
           message: `Error: Could not overwrite the current network to NDEx. ${
             e.message as string
           }`,
-          duration: 3000,
+          duration: 4000,
           severity: MessageSeverity.ERROR,
         })
       }

--- a/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/components/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -21,7 +21,6 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
   const getToken = useCredentialStore((state) => state.getToken)
   const authenticated: boolean = client?.authenticated ?? false
   const addMessage = useMessageStore((state) => state.addMessage)
-  const [openConfirmDialog, setOpenConfirmDialog] = useState<boolean>(false)
   const [openNamingDialog, setOpenNamingDialog] = useState<boolean>(false)
 
   const {
@@ -70,19 +69,17 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
       )
     } catch (e) {
       addMessage({
-        message: `Failed to update workspace to NDEx.`,
-        duration: 5000,
+        message: `Failed to update the workspace to NDEx.`,
+        duration: 4000,
         severity: MessageSeverity.ERROR,
       })
     }
-
-    setOpenConfirmDialog(false)
     props.handleClose()
   }
 
   const handleSaveWorkspaceToNDEx = async (): Promise<void> => {
     if (isRemoteWorkspace) {
-      setOpenConfirmDialog(true)
+      await saveWorkspaceToNDEx()
     } else {
       setOpenNamingDialog(true)
     }
@@ -104,16 +101,17 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
     <>
       {enabled ? (
         <>
-          {menuItem}
-          <ConfirmationDialog
-            title="Save Workspace to NDEx"
-            message="Do you want to save/overwrite the current workspace to NDEx?"
-            onConfirm={saveWorkspaceToNDEx}
-            open={openConfirmDialog}
-            setOpen={setOpenConfirmDialog}
-            buttonTitle="Save"
-            isAlert={true}
-          />
+          <Tooltip
+            arrow
+            placement="right"
+            title={
+              isRemoteWorkspace
+                ? 'Overwrite workspace to NDEx'
+                : 'Save workspace to NDEx'
+            }
+          >
+            <Box>{menuItem}</Box>
+          </Tooltip>
           <WorkspaceNamingDialog
             openDialog={openNamingDialog}
             onClose={onCloseWorkspaceNamingDialog}

--- a/src/components/ToolBar/DataMenu/WorkspaceNamingDialog.tsx
+++ b/src/components/ToolBar/DataMenu/WorkspaceNamingDialog.tsx
@@ -15,7 +15,6 @@ import { fetchMyWorkspaces, useSaveWorkspace } from '../../../utils/ndex-utils'
 import { useMessageStore } from '../../../store/MessageStore'
 import { MessageSeverity } from '../../../models/MessageModel'
 import { useWorkspaceData } from '../../../store/hooks/useWorkspaceData'
-import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 import { ConfirmationDialog } from '../../Util/ConfirmationDialog'
 
 interface WorkspaceNamingDialogProps {
@@ -47,14 +46,13 @@ export const WorkspaceNamingDialog = ({
     currentWorkspaceName,
     networkModifiedStatus,
   } = useWorkspaceData()
-  const [workspaceName, setWorkspaceName] = useState(currentWorkspaceName)
+  const [workspaceName, setWorkspaceName] = useState('')
   const [showWarning, setShowWarning] = useState(false)
   const [warningMessage, setWarningMessage] = useState('')
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [workspaceIdToBeOverwritten, setWorkspaceIdToBeOverwritten] = useState<
     string | undefined
   >(undefined)
-  const setIsRemote = useWorkspaceStore((state) => state.setIsRemote)
   const saveWorkspace = useSaveWorkspace()
   const ndexClient = new NDEx(ndexBaseUrl)
 
@@ -88,10 +86,9 @@ export const WorkspaceNamingDialog = ({
         currentNetworkId,
         workspaceIdToBeOverwritten,
       )
-      setIsRemote(true)
     } catch (e) {
       addMessage({
-        duration: 5000,
+        duration: 4000,
         message: 'Failed to overwrite the workspace in NDEx',
         severity: MessageSeverity.ERROR,
       })
@@ -138,13 +135,12 @@ export const WorkspaceNamingDialog = ({
           apps,
           serviceApps,
         )
-        setIsRemote(true)
       }
     } catch (e) {
       console.error(e)
       addMessage({
-        duration: 5000,
-        message: 'Failed to save workspace to NDEx',
+        duration: 4000,
+        message: 'Failed to save the workspace to NDEx',
         severity: MessageSeverity.ERROR,
       })
     }
@@ -177,6 +173,7 @@ export const WorkspaceNamingDialog = ({
             fullWidth
             variant="standard"
             value={workspaceName}
+            placeholder={currentWorkspaceName}
             onChange={handleNameChange}
             onKeyDown={(e) => {
               e.stopPropagation()
@@ -194,6 +191,7 @@ export const WorkspaceNamingDialog = ({
             Cancel
           </Button>
           <Button
+            disabled={workspaceName.trim().length === 0}
             onClick={onSave}
             sx={{
               color: '#FFFFFF',
@@ -212,8 +210,7 @@ export const WorkspaceNamingDialog = ({
       </Dialog>
       <ConfirmationDialog
         title="Confirm Workspace Overwrite"
-        message="A workspace with this name already exists. Do you want to overwrite
-            it?"
+        message="A workspace with the same name already exists in NDEx. Do you want to overwrite it?"
         onConfirm={handleConfirmSave}
         open={showConfirmDialog}
         setOpen={setShowConfirmDialog}

--- a/src/utils/ndex-utils.ts
+++ b/src/utils/ndex-utils.ts
@@ -223,6 +223,7 @@ export const useSaveWorkspace = () => {
   const saveCopyToNDEx = useSaveCopyToNDEx()
   const setId = useWorkspaceStore((state) => state.setId)
   const renameWorkspace = useWorkspaceStore((state) => state.setName)
+  const setIsRemote = useWorkspaceStore((state) => state.setIsRemote)
 
   const saveWorkspace = async (
     accessToken: string,
@@ -324,15 +325,15 @@ export const useSaveWorkspace = () => {
         if (e.message.includes(TimeOutErrorIndicator)) {
           addMessage({
             message: TimeOutErrorMessage,
-            duration: 6000,
+            duration: 3000,
             severity: MessageSeverity.ERROR,
           })
         } else {
           addMessage({
-            message: `Error: ${summary.isNdex ? 'Unable to save the network to NDEx.' : 'Could not save a copy of the local network to NDEx.'} ${
+            message: `Error: Unable to save ${summary.isNdex ? 'the network' : 'a copy of the local network'}(${summary.name}) to NDEx: ${
               e.message as string
             }`,
-            duration: 5000,
+            duration: 3000,
             severity: MessageSeverity.ERROR,
           })
         }
@@ -376,9 +377,10 @@ export const useSaveWorkspace = () => {
       const { uuid } = response
       setId(uuid)
     }
+    setIsRemote(true)
     renameWorkspace(workspaceName)
     addMessage({
-      message: `Saved workspace to NDEx successfully.`,
+      message: 'Saved workspace to NDEx successfully.',
       duration: 3000,
       severity: MessageSeverity.SUCCESS,
     })


### PR DESCRIPTION
### Made some minor changes on 'Saving Workspace'
- Added tooltips for 'Save Network' and 'Save Workspace' since they would overwrite data

|Menu Item | Scenario |Tooltip|
|-----|-----|-----|
|Save Network | Save a local network to NDEx|<img width="400" alt="image" src="https://github.com/user-attachments/assets/ccf3a795-cc39-4be3-8c23-850f6c57299d" />|
|Save Network | Save a NDEx network|<img width="400" alt="image" src="https://github.com/user-attachments/assets/70b824af-06e4-492b-8714-36480b31a8ac" />|
|Save Workspace |Create a new workspace in NDEx|<img width="400" alt="image" src="https://github.com/user-attachments/assets/c2b05635-7ed1-4507-91d5-39747d377bcd" />|
|Save Workspace |Overwrite the remote version in NDEx|<img width="400" alt="image" src="https://github.com/user-attachments/assets/be2ca86f-45f5-493d-9ef5-5e7cc47914af" />| 

- Made the suggested workspace name as placeholder in the naming dialog and disable the `save` button if the text field is empty
<img width="302" alt="image" src="https://github.com/user-attachments/assets/84376672-07dd-423a-97b1-0bfcd35e649c" />

- Removed the confirmation dialog when overwriting/updating a remote workspace (keeping aligned with the behavior of saving networks)