### PR TITLE
Clear messages if the url is redirected to another workspace

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -61,6 +61,7 @@ const AppShell = (): ReactElement => {
   const [search, setSearch] = useSearchParams()
 
   const addMessage = useMessageStore((state) => state.addMessage)
+  const resetMessage = useMessageStore((state) => state.resetMessages)
 
   const initializedRef = useRef(false)
 
@@ -232,6 +233,9 @@ const AppShell = (): ReactElement => {
   }, [])
 
   const redirect = async (): Promise<void> => {
+    // clear all messages
+    resetMessage()
+
     if (!initializedRef.current || id === '') return
 
     // const parsed = parsePathName(location.pathname)

--- a/src/models/StoreModel/MessageStoreModel.ts
+++ b/src/models/StoreModel/MessageStoreModel.ts
@@ -6,6 +6,7 @@ export interface MessageState {
 
 export interface MessageAction {
   addMessage: (message: Message) => void
+  resetMessages: () => void 
 }
 
 export type MessageStore = MessageState & MessageAction

--- a/src/store/MessageStore.ts
+++ b/src/store/MessageStore.ts
@@ -11,5 +11,10 @@ export const useMessageStore = create(
         state.messages.push(message)
       })
     },
+    resetMessages: () => {
+      set((state) => {
+        state.messages = []
+      })
+    },
   })),
 )


### PR DESCRIPTION
Ticket: [possibly wrong message when opening workspace from NDEx](https://cytoscape.atlassian.net/browse/CW-519)

### Root of the bug
When loading another workspace, the message snack-bar component would be rerendered. And in that component, there is a **state**, called [currentMessageIndex](https://github.com/cytoscape/cytoscape-web/blob/development/src/components/Messages/SnackbarMessageList.tsx#L10), would be reset to 0. It controls the index of the message that would be shown in the snack-bar. Therefore, if the message list is not cleaned when redirecting the url, it would iterate through the message list again after redirect.

### How to reproduce the bug (in dev branch)

#### *It is easier to reproduce this bug on the local machine

1. Click 'save workspace' or 'open network in Cytoscape' that would trigger the message
<img width="600" alt="image" src="https://github.com/user-attachments/assets/821ab5aa-5223-426d-98e5-fb7641b43f59" />

2. Open a workspace in your account by clicking `Data -> Open Workspace from NDEx`
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ed27763f-174c-4db7-8a8a-a6943eea36ed" />

3. The message would show again
<img width="600" alt="image" src="https://github.com/user-attachments/assets/cb306910-16f9-4519-9932-0c28c3969a2d" />

### To Test
Just rerun the above procedure in this branch, the message(in step3) would not show.