### PR TITLE
Partial fix for CW-513

### DIFF
--- a/src/store/VisualStyleStore.ts
+++ b/src/store/VisualStyleStore.ts
@@ -186,7 +186,7 @@ export const useVisualStyleStore = create(
         attributeValues,
       ) {
         set((state) => {
-          const DEFAULT_COLOR_SCHEME = ['#b2182b', 'white', '#2166ac']
+          const DEFAULT_COLOR_SCHEME = ['#2166ac', 'white', '#b2182b']
           const DEFAULT_NUMBER_RANGE =
             !vpName.includes('Opacity') && !vpName.includes('opacity')
               ? [1, 100]


### PR DESCRIPTION
- Update the default color scheme colors to be the same ones as Cytoscape Desktop
- Set the min and max values of the continous color creation function to be the largest absolute value if the data is two tailed
- Unable to fix the selected palette as the palette UI code needs to be reworked