### PR TITLE
Fix bug of adding an extra network when loading workspace

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -268,7 +268,7 @@ const AppShell = (): ReactElement => {
         navigate(
           `/${id}/networks/${currentNetworkId}${location.search.toString()}`,
         )
-      } else {
+      } else if (networkIds.includes(networkId)) {
         // the user is trying to load a network that is already in the workspace
         // check that if they have an outdated version of the network by comparing modification times
         // of the local copy and the ndex summary


### PR DESCRIPTION
Ticket: [CW-516](https://cytoscape.atlassian.net/browse/CW-516)

This bug can not be reproduced steadily. In my experience, it is easier to reproduce on a local machine (with longer internet latency).

The root of the bug lies in:
When loading a new workspace, due to the change of `workspaceId`, the `redirect()` function in `AppShell.ts` would be triggered. And it will parse the `networkId` in the URL (src/components/AppShell.tsx line 242), and as long as the `currentNetworkId` is valid, it will check whether the parsed network is up-to-date and load it to the workspace.

According to the comment from line 272 to 274 in src/components/AppShell.tsx

>         // the user is trying to load a network that is already in the workspace
>         // check that if they have an outdated version of the network by comparing modification times
>         // of the local copy and the ndex summary

This network should be loaded if it is already in the workspace. But the condition "it is in the workspace" has not been checked, so I added this condition checker: 
```
} else if (networkIds.includes(networkId)) {

```

I am not 100% sure whether this will harm the original usage of this function. Please help me check this.

[CW-516]: https://cytoscape.atlassian.net/browse/CW-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ