### PR TITLE
Clear urlNetIdRef after use

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -58,6 +58,7 @@ const AppShell = (): ReactElement => {
 
   // This is necessary to prevent creating a new workspace on every render
   const [showDialog, setShowDialog] = useState<boolean>(false)
+  const [targetNetworkId, setTargetNetworkId] = useState<string>('')
   const [search, setSearch] = useSearchParams()
 
   const addMessage = useMessageStore((state) => state.addMessage)
@@ -250,6 +251,7 @@ const AppShell = (): ReactElement => {
       // ID from the URL parameter
       if (parsedNetworkId !== '' && parsedNetworkId !== undefined) {
         addNetworkIds(parsedNetworkId)
+        await waitSeconds(1)
         setCurrentNetworkId(parsedNetworkId)
         navigate(
           `/${id}/networks/${parsedNetworkId}${location.search.toString()}`,
@@ -300,16 +302,17 @@ const AppShell = (): ReactElement => {
             if (localNetworkModified && authenticated) {
               // local network and ndex network have been modified and the user is authenticated
               // ask the user what they want to do
+              setTargetNetworkId(networkId)
               setShowDialog(true)
             } else {
               // the local network has not been modified but it has been modified on NDEx
               // update the network silently
               deleteNetwork(networkId)
-              await waitSeconds(2)
+              await waitSeconds(1)
               addNetworkIds(networkId)
-              await waitSeconds(2)
+              await waitSeconds(1)
               setCurrentNetworkId(networkId)
-              await waitSeconds(2)
+              await waitSeconds(1)
               deleteNetworkModifiedStatus(networkId)
 
               navigate(
@@ -318,6 +321,7 @@ const AppShell = (): ReactElement => {
             }
           } else {
             addNetworkIds(networkId)
+            await waitSeconds(1)
             setCurrentNetworkId(networkId)
             navigate(
               `/${id}/networks/${networkId}${location.search.toString()}`,
@@ -409,6 +413,7 @@ const AppShell = (): ReactElement => {
       </Box>
       <UpdateNetworkDialog
         open={showDialog}
+        networkId={targetNetworkId}
         onClose={() => setShowDialog(false)}
       />
       <WarningDialog

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -240,6 +240,10 @@ const AppShell = (): ReactElement => {
 
     // const parsed = parsePathName(location.pathname)
     const parsedNetworkId = urlNetIdRef.current
+    // Clear it only after the network ID has been used for redirection
+    setTimeout(() => {
+      urlNetIdRef.current = ''
+    }, 0)
 
     // At this point, workspace ID is always available
     if (currentNetworkId === '' || currentNetworkId === undefined) {

--- a/src/components/UpdateNetworkDialog.tsx
+++ b/src/components/UpdateNetworkDialog.tsx
@@ -17,8 +17,10 @@ import { waitSeconds } from '../utils/wait-seconds'
 
 export const UpdateNetworkDialog = (props: {
   open: boolean
+  networkId: string
   onClose: () => void
 }): ReactElement => {
+  const { networkId } = props
   const [loading, setLoading] = useState<boolean>(false)
   const navigate = useNavigate()
   const workspace = useWorkspaceStore((state) => state.workspace)
@@ -32,11 +34,9 @@ export const UpdateNetworkDialog = (props: {
 
   const authenticated = client?.authenticated ?? false
 
-  const { id, currentNetworkId } = workspace
+  const { id } = workspace
 
-  const summary = useNetworkSummaryStore(
-    (state) => state.summaries[currentNetworkId],
-  )
+  const summary = useNetworkSummaryStore((state) => state.summaries[networkId])
 
   const deleteNetworkModifiedStatus = useWorkspaceStore(
     (state) => state.deleteNetworkModifiedStatus,
@@ -59,7 +59,7 @@ export const UpdateNetworkDialog = (props: {
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        {loading && <CircularProgress />}
+        {loading && <CircularProgress size={30} />}
         <Button
           variant="outlined"
           disabled={loading}
@@ -70,61 +70,33 @@ export const UpdateNetworkDialog = (props: {
         >
           Cancel
         </Button>
-        {!authenticated ? (
-          <Button
-            sx={{
-              color: '#FFFFFF',
-              backgroundColor: '#337ab7',
-              '&:hover': {
-                backgroundColor: '#285a9b',
-              },
-            }}
-            onClick={() => {
-              client
-                ?.login()
-                .then((result) => {
-                  console.log('* Login success', result)
-                })
-                .catch((error: any) => {
-                  console.warn('Failed to login', error)
-                })
-            }}
-          >
-            Sign in to create a copy to NDEx
-          </Button>
-        ) : (
-          <>
-            <Button
-              sx={{
-                color: '#FFFFFF',
-                backgroundColor: '#337ab7',
-                '&:hover': {
-                  backgroundColor: '#285a9b',
-                },
-              }}
-              disabled={!authenticated || loading}
-              onClick={async () => {
-                const parsed = parsePathName(location.pathname)
-                const { networkId } = parsed
-                setLoading(true)
-                deleteNetwork(networkId)
-                await waitSeconds(2)
-                addNetworkIds(networkId)
-                await waitSeconds(2)
-                setCurrentNetworkId(networkId)
-                await waitSeconds(2)
-                deleteNetworkModifiedStatus(networkId)
-                navigate(
-                  `/${id}/networks/${networkId}${location.search.toString()}`,
-                )
-                setLoading(false)
-                props.onClose()
-              }}
-            >
-              Update
-            </Button>
-          </>
-        )}
+        <Button
+          sx={{
+            color: '#FFFFFF',
+            backgroundColor: '#337ab7',
+            '&:hover': {
+              backgroundColor: '#285a9b',
+            },
+          }}
+          disabled={!authenticated || loading}
+          onClick={async () => {
+            setLoading(true)
+            deleteNetwork(networkId)
+            await waitSeconds(1)
+            addNetworkIds(networkId)
+            await waitSeconds(1)
+            setCurrentNetworkId(networkId)
+            await waitSeconds(1)
+            deleteNetworkModifiedStatus(networkId)
+            navigate(
+              `/${id}/networks/${networkId}${location.search.toString()}`,
+            )
+            setLoading(false)
+            props.onClose()
+          }}
+        >
+          Update
+        </Button>
       </DialogActions>
     </Dialog>
   )


### PR DESCRIPTION
This is a fix for this [ticket](https://cytoscape.atlassian.net/browse/CW-516)

### Changes Made

#### 1. Clear urlNetIdRef after use
Set the `urlNetIdRef` value to an empty string after use in the `redirect` function.
This could resolve the bug and also would not break the original "share network logic"

#### 2. Debug 'Load Network'
- Add 'Waitsecond' before setCurrentNetworkId if the networkId is just added into the workspace
- Clear the UpdateNetwork dialog
    - Delete the unnecessary code since the dialog is shown only when the user is authenticated
    - Pass the correct target networkId to the dialog  instead of reading the currentNetworkId (the target networkId is not necessarily the current one)

### Related Pull Request:
[Fix bug of adding an extra network when loading workspace](https://github.com/cytoscape/cytoscape-web/pull/418)
[CW-516 Fixed timing issue after loading workspace](https://github.com/cytoscape/cytoscape-web/pull/420)