### PR TITLE
Fix issue where annotations may not be rendered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cytoscape-web",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cytoscape-web",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@antv/g6": "^4.8.22",
@@ -15,7 +15,7 @@
         "@emotion/styled": "^11.10.4",
         "@glideapps/glide-data-grid": "^5.2.1",
         "@js4cytoscape/cx2js": "^0.6.11",
-        "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.3",
+        "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.6",
         "@js4cytoscape/ndex-client": "^0.4.3-alpha.12",
         "@mantine/core": "^7.6.2",
         "@mantine/dropzone": "^7.6.2",
@@ -3301,9 +3301,10 @@
       }
     },
     "node_modules/@js4cytoscape/cyannotation-cx2js": {
-      "version": "0.8.7-alpha.3",
-      "resolved": "https://registry.npmjs.org/@js4cytoscape/cyannotation-cx2js/-/cyannotation-cx2js-0.8.7-alpha.3.tgz",
-      "integrity": "sha512-PG4cKpQrBhJUL5Q4EjT+XHl2KhIVajuOcQahiEvymx+L9USk28JNILSolgD69plK8EIomN3d/N9UZOPW2voFQA==",
+      "version": "0.8.7-alpha.6",
+      "resolved": "https://registry.npmjs.org/@js4cytoscape/cyannotation-cx2js/-/cyannotation-cx2js-0.8.7-alpha.6.tgz",
+      "integrity": "sha512-bW6UbypkMJ7IxOw8QyBM6BZy2WhahasCK417NKwbspsBbbELq187ucuOKlBbPTcItQ8gGRouWIDt85p4SemZwQ==",
+      "license": "MIT",
       "dependencies": {
         "cytoscape-canvas": "3.0.1",
         "lodash": "^4.17.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@emotion/styled": "^11.10.4",
         "@glideapps/glide-data-grid": "^5.2.1",
         "@js4cytoscape/cx2js": "^0.6.11",
-        "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.6",
+        "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.3",
         "@js4cytoscape/ndex-client": "^0.4.3-alpha.12",
         "@mantine/core": "^7.6.2",
         "@mantine/dropzone": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@emotion/styled": "^11.10.4",
     "@glideapps/glide-data-grid": "^5.2.1",
     "@js4cytoscape/cx2js": "^0.6.11",
-    "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.6",
+    "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.3",
     "@js4cytoscape/ndex-client": "^0.4.3-alpha.12",
     "@mantine/core": "^7.6.2",
     "@mantine/dropzone": "^7.6.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@emotion/styled": "^11.10.4",
     "@glideapps/glide-data-grid": "^5.2.1",
     "@js4cytoscape/cx2js": "^0.6.11",
-    "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.3",
+    "@js4cytoscape/cyannotation-cx2js": "^0.8.7-alpha.6",
     "@js4cytoscape/ndex-client": "^0.4.3-alpha.12",
     "@mantine/core": "^7.6.2",
     "@mantine/dropzone": "^7.6.2",

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -340,7 +340,7 @@ const CyjsRenderer = ({
         elements: annotations.map((a) => {
           return {
             n: CX_ANNOTATIONS_KEY,
-            v: a.value,
+            v: !Array.isArray(a.value) ? [a.value] : a.value,
           }
         }),
       },

--- a/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/components/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -362,6 +362,8 @@ const CyjsRenderer = ({
         cy,
         niceCXForCyAnnotationRendering,
       )
+      annotationRenderer.drawBackground(cy, bgColor)
+
       setAnnotationLayers([result.topLayer, result.bottomLayer])
     } else {
       setAnnotationLayers([])
@@ -754,7 +756,9 @@ const CyjsRenderer = ({
         sx={{
           width: '100%',
           height: '100%',
-          backgroundColor: bgColor,
+          backgroundColor: 'rgba(0,0,0,0)',
+          zIndex: 0
+
         }}
         id="cy-container"
         ref={cyContainer}


### PR DESCRIPTION
- Depending on how the network summary is retrieved from NDEx, it may give a network attribute value as a single string even when it specifies the data type as an array


Fixes CW-508

### Testing
Load network 495f1d07-eb3b-11eb-b666-0ac135e8bacf from dev1 into cytoscape web.  The annotation should be displayed.

