### PR TITLE
Tooltip for duplicated App Menu Items

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -25,7 +25,7 @@ import { useViewModelStore } from '../../store/ViewModelStore'
 import { IdType } from '../../models/IdType'
 import { useVisualStyleStore } from '../../store/VisualStyleStore'
 
-import { isValidUrl } from '../../utils/is-url'
+import { isValidUrl } from '../../utils/url-util'
 import {
   EditTableColumnForm,
   CreateTableColumnForm,

--- a/src/models/AppModel/ServiceMetadata.ts
+++ b/src/models/AppModel/ServiceMetadata.ts
@@ -16,6 +16,7 @@ export interface ServiceMetadata {
   serviceInputDefinition?: ServiceInputDefinition
   cyWebAction: ServiceAppAction[]
   cyWebMenuItem: CyWebMenuItem
-
+  author: string
+  citation:string
   parameters: ServiceAppParameter[]
 }

--- a/src/utils/is-url.ts
+++ b/src/utils/is-url.ts
@@ -1,6 +1,0 @@
-export function isValidUrl(input: string): boolean {
-  const urlPattern =
-    /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[a-zA-Z0-9-._~:\/?#[\]@!$&'()*+,;=]*)?$/
-
-  return urlPattern.test(input)
-}

--- a/src/utils/url-util.ts
+++ b/src/utils/url-util.ts
@@ -1,0 +1,16 @@
+export function isValidUrl(input: string): boolean {
+  const urlPattern =
+    /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[a-zA-Z0-9-._~:\/?#[\]@!$&'()*+,;=]*)?$/
+
+  return urlPattern.test(input)
+}
+
+export const getDomain = (url: string): string => {
+  try {
+    const parsedUrl = new URL(url);
+    return `${parsedUrl.protocol}//${parsedUrl.host}/`; 
+  } catch (error) {
+    console.error("Invalid URL:", error);
+    return "";
+  }
+};


### PR DESCRIPTION
Ticket: [CW-473](https://cytoscape.atlassian.net/browse/CW-473)

### Changes Made
- Check whether there are name duplications between the existing and the newly added paths.
- If it is the end of the path (namely the last item), then it will add tooltips for them (as long as they have template and they are not intermediate menu items)
- If they are both intermediate menu items, then merge these path by letting the newly added paths follow the existing one

### UI
<img width="906" alt="image" src="https://github.com/user-attachments/assets/69f766f9-5c8d-429b-803e-d2cab9f343ff" />


[CW-473]: https://cytoscape.atlassian.net/browse/CW-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ