### PR TITLE
Fix issue where users could input floats into integer columns

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -455,31 +455,40 @@ export default function TableBrowser(props: {
         return
 
       if (isListType(column.type)) {
-        data = deserializeValueList(column.type, data as string)
-      }
-
-      if (
-        column.type !== ValueTypeName.Integer &&
-        column.type !== ValueTypeName.Long
-      ) {
-        setCellValue(
-          props.currentNetworkId,
-          currentTable === nodeTable ? 'node' : 'edge',
-          `${cxId}`,
-          columnKey,
-          data as ValueType,
-        )
-      } else {
-        if (Number.isInteger(data)) {
+        if (serializedStringIsValid(column.type, data as string)) {
+          data = deserializeValueList(column.type, data as string)
           setCellValue(
             props.currentNetworkId,
             currentTable === nodeTable ? 'node' : 'edge',
             `${cxId}`,
             columnKey,
-            parseFloat(data as string),
+            data as ValueType,
+          )
+        }
+      } else {
+        if (
+          column.type !== ValueTypeName.Integer &&
+          column.type !== ValueTypeName.Long
+        ) {
+          setCellValue(
+            props.currentNetworkId,
+            currentTable === nodeTable ? 'node' : 'edge',
+            `${cxId}`,
+            columnKey,
+            data as ValueType,
           )
         } else {
-          // the user is trying to assign a double value to a integer column.  Ignore this value.
+          if (Number.isInteger(data)) {
+            setCellValue(
+              props.currentNetworkId,
+              currentTable === nodeTable ? 'node' : 'edge',
+              `${cxId}`,
+              columnKey,
+              parseFloat(data as string),
+            )
+          } else {
+            // the user is trying to assign a double value to a integer column.  Ignore this value.
+          }
         }
       }
     },

--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -458,7 +458,10 @@ export default function TableBrowser(props: {
         data = deserializeValueList(column.type, data as string)
       }
 
-      if (column.type !== ValueTypeName.Integer) {
+      if (
+        column.type !== ValueTypeName.Integer &&
+        column.type !== ValueTypeName.Long
+      ) {
         setCellValue(
           props.currentNetworkId,
           currentTable === nodeTable ? 'node' : 'edge',
@@ -475,7 +478,6 @@ export default function TableBrowser(props: {
             columnKey,
             parseFloat(data as string),
           )
-
         } else {
           // the user is trying to assign a double value to a integer column.  Ignore this value.
         }
@@ -779,8 +781,8 @@ export default function TableBrowser(props: {
 
   const selectedCell =
     selection.rows.length > 0 &&
-      selectedCellColumn !== null &&
-      selectedCellColumn >= 0
+    selectedCellColumn !== null &&
+    selectedCellColumn >= 0
       ? [selectedCellColumn, selection.rows.first()!]
       : null
 
@@ -832,8 +834,9 @@ export default function TableBrowser(props: {
                 )
               }}
             >
-              {`Apply value to selected ${currentTable === nodeTable ? 'nodes' : 'edges'
-                }`}
+              {`Apply value to selected ${
+                currentTable === nodeTable ? 'nodes' : 'edges'
+              }`}
             </Button>
             <Button
               onClick={() => {

--- a/src/components/TableBrowser/TableColumnForm.tsx
+++ b/src/components/TableBrowser/TableColumnForm.tsx
@@ -274,7 +274,12 @@ export function CreateTableColumnForm(
         },
       }}
       disabled={columnName === ''}
-      onClick={() => props.onSubmit(columnName, valueTypeName, defaultValue)}
+      onClick={() => {
+        props.onSubmit(columnName, valueTypeName, defaultValue)
+        setColumnName('')
+        setDefaultValue('')
+        setValueTypeName(ValueTypeName.String)
+      }}
     >
       Confirm
     </Button>
@@ -326,7 +331,15 @@ export function CreateTableColumnForm(
       </DialogContent>
 
       <DialogActions>
-        <Button color="primary" onClick={props.onClose}>
+        <Button
+          color="primary"
+          onClick={() => {
+            setColumnName('')
+            setDefaultValue('')
+            setValueTypeName(ValueTypeName.String)
+            props.onClose()
+          }}
+        >
           Cancel
         </Button>
         {submitButton}

--- a/src/models/TableModel/impl/ValueTypeImpl.ts
+++ b/src/models/TableModel/impl/ValueTypeImpl.ts
@@ -27,9 +27,9 @@ export const serializedStringIsValid = (
     } else if (valueTypeName === ValueTypeName.Double) {
       return !isNaN(+serializedString)
     } else if (valueTypeName === ValueTypeName.Long) {
-      return !isNaN(+serializedString)
+      return !isNaN(+serializedString) && Number.isInteger(+serializedString)
     } else if (valueTypeName === ValueTypeName.Integer) {
-      return !isNaN(+serializedString)
+      return !isNaN(+serializedString) && Number.isInteger(+serializedString)
     } else if (valueTypeName === ValueTypeName.String) {
       return true
     }


### PR DESCRIPTION
- Perform a check when the user inputs values into integer columns in the table browser
- Reject the value if it is a float.

Testing:
- Open a network
- Input a decimal value in a integer column
- It should not update the value