### PR TITLE
Import network description/properties from URL-fetched CX2

### DIFF
--- a/src/models/CxModel/fetch-url-cx-util.ts
+++ b/src/models/CxModel/fetch-url-cx-util.ts
@@ -1,6 +1,9 @@
 import { createDataFromCx } from '../../utils/cx-utils'
 import { NdexNetworkSummary } from '../../models/NetworkSummaryModel'
 import { Cx2 } from './Cx2'
+import { getAttributeDeclarations, getNetworkAttributes } from '../../models/CxModel/cx2-util'
+import { NdexNetworkProperty } from '../../models/NetworkSummaryModel'
+import { ValueType, ValueTypeName } from '../../models/TableModel'
 import { v4 as uuidv4 } from 'uuid'
 import { Visibility } from '../NetworkSummaryModel/Visibility'
 import { NetworkWithView } from '../NetworkWithViewModel'
@@ -30,10 +33,29 @@ export const fetchUrlCx = async (
     const uuid = uuidv4()
     const network = await createDataFromCx(uuid, data)
 
+    const networkAttributeDeclarations = getAttributeDeclarations(data)?.attributeDeclarations?.[0]?.networkAttributes ?? {}
+    const networkAttributes = getNetworkAttributes(data)?.[0] ?? {}
+    
+    const urlObj = new URL(url)
+    const name = (network.networkAttributes?.attributes?.name as string) || `${urlObj.host} (${new Date().toLocaleString()})`
+    
+    const description = networkAttributes.description ?? ''
+    
+    const properties: NdexNetworkProperty[] = Object.entries(
+      networkAttributes,
+    ).map(([key, value]) => {
+      return {
+        predicateString: key,
+        value: value as ValueType,
+        dataType: networkAttributeDeclarations[key]?.d ?? ValueTypeName.String,
+        subNetworkId: null,
+      }
+    })
+
     const summary = {
       isNdex: false,
       ownerUUID: uuid,
-      name: (network.networkAttributes?.attributes?.name as string) || 'test',
+      name,
       isReadOnly: false,
       subnetworkIds: [],
       isValid: false,
@@ -56,14 +78,14 @@ export const fetchUrlCx = async (
       hasSample: false,
       cxFileSize: 0,
       cx2FileSize: 0,
-      properties: [],
+      properties,
       owner: '',
       version: '',
       completed: false,
       visibility: Visibility.PUBLIC,
       nodeCount: network.network.nodes.length,
       edgeCount: network.network.edges.length,
-      description: 'test',
+      description,
       creationTime: new Date(Date.now()),
       externalId: uuid,
       isDeleted: false,


### PR DESCRIPTION
Ticket: [CW-529](https://cytoscape.atlassian.net/browse/CW-529)

**Changes:**
- Fixes importing the network `description` and other network properties from a URL-fetched CX2 data.
- I'm also suggesting a better default `name`--Instead of "test", one that contains the URL host and import date/time (e.g. `iregulon.baderlab.net (3/4/2025, 4:15:08 PM)`).
____

<img width="1068" alt="CW-529" src="https://github.com/user-attachments/assets/83db7271-1362-405d-9105-5f9b3e605bee" />


[CW-529]: https://cytoscape.atlassian.net/browse/CW-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ