### PR TITLE
New URL parameter for the selected network view

### DIFF
--- a/src/components/NetworkPanel/NetworkTabs.tsx
+++ b/src/components/NetworkPanel/NetworkTabs.tsx
@@ -5,6 +5,7 @@ import { Renderer } from '../../models/RendererModel/Renderer'
 import { NetworkTab } from './NetworkTab'
 import { Network } from '../../models/NetworkModel'
 import { useUiStateStore } from '../../store/UiStateStore'
+import { useSearchParams } from 'react-router-dom'
 
 interface NetworkTabsProps {
   network: Network
@@ -14,6 +15,14 @@ interface NetworkTabsProps {
   bgColor?: string
   handleClick?: () => void
 }
+
+/**
+ * URL search parameter key for the active network view
+ * This is used to store the active tab index in the URL
+ * so that it can be restored when the user navigates back to this page
+ * or refreshes the page.
+ */
+const ACTIVE_NETWORK_VIEW = 'activenetworkview'
 
 export const NetworkTabs = ({
   network,
@@ -26,6 +35,7 @@ export const NetworkTabs = ({
     (state) => state.ui.networkViewUi.activeTabIndex,
   )
   const setSelected = useUiStateStore((state) => state.setNetworkViewTabIndex)
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const customNetworkTabName = useUiStateStore(
     (state) => state.ui.customNetworkTabName,
@@ -52,7 +62,24 @@ export const NetworkTabs = ({
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setSelected(newValue)
+
+    // Update URL search parameter with the selected tab ID
+    const newSearchParams = new URLSearchParams(searchParams)
+    newSearchParams.set(ACTIVE_NETWORK_VIEW, newValue.toString())
+    setSearchParams(newSearchParams, { replace: true })
   }
+
+  // Read tab ID from URL on initial render and set it as the selected view
+  useEffect(() => {
+    const tabParam = searchParams.get(ACTIVE_NETWORK_VIEW)
+    if (tabParam !== null) {
+      const tabIndex = parseInt(tabParam, 10)
+      const rendererList = Object.values(renderers)
+      if (!isNaN(tabIndex) && tabIndex >= 0 && tabIndex < rendererList.length) {
+        setSelected(tabIndex)
+      }
+    }
+  }, [])
 
   const rendererList = Object.values(renderers)
   return (


### PR DESCRIPTION
This pull request enhances the `NetworkTabs` component in `src/components/NetworkPanel/NetworkTabs.tsx` by adding functionality to persist the active network view tab state in the URL. This ensures that the selected tab remains consistent when the user navigates back to the page or refreshes it. The key changes include importing necessary hooks, defining a constant for the URL parameter, updating the URL when the tab changes, and reading the tab state from the URL on initial render.

Global state for selected network view is already there, and local DB is not updated.

Enhancements to `NetworkTabs` component:

* [`src/components/NetworkPanel/NetworkTabs.tsx`](diffhunk://#diff-287ffcdfc714d30b9405a72af81bffabd496124a3ed34a77d7223a1ea2712689R8): Imported `useSearchParams` from `react-router-dom` to manage URL search parameters.
* [`src/components/NetworkPanel/NetworkTabs.tsx`](diffhunk://#diff-287ffcdfc714d30b9405a72af81bffabd496124a3ed34a77d7223a1ea2712689R19-R26): Defined `ACTIVE_NETWORK_VIEW` constant to store the active tab index in the URL.
* [`src/components/NetworkPanel/NetworkTabs.tsx`](diffhunk://#diff-287ffcdfc714d30b9405a72af81bffabd496124a3ed34a77d7223a1ea2712689R38): Added `useSearchParams` hook to manage search parameters and update the URL when the tab changes.
* [`src/components/NetworkPanel/NetworkTabs.tsx`](diffhunk://#diff-287ffcdfc714d30b9405a72af81bffabd496124a3ed34a77d7223a1ea2712689R65-R82): Implemented `useEffect` to read the tab ID from the URL on initial render and set it as the selected view.