### PR TITLE
Hotfix for issue where the table browser would block the UI

### DIFF
--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -230,6 +230,7 @@ export default function TableBrowser(props: {
   const setNetworkModified: (id: IdType, isModified: boolean) => void =
     useWorkspaceStore((state) => state.setNetworkModified)
 
+  // TODO reenable this when we figure out why this sometimes blocks the UI when switching to/from a hcx network
   // set the network to 'modified' when the table data is modified
   // useTableStore.subscribe(
   //   (state) => state.tables[networkId],

--- a/src/components/TableBrowser/TableBrowser.tsx
+++ b/src/components/TableBrowser/TableBrowser.tsx
@@ -231,30 +231,31 @@ export default function TableBrowser(props: {
     useWorkspaceStore((state) => state.setNetworkModified)
 
   // set the network to 'modified' when the table data is modified
-  useTableStore.subscribe(
-    (state) => state.tables[networkId],
-    (next: TableRecord, prev: TableRecord) => {
-      if (prev === undefined || next === undefined) {
-        return
-      }
+  // useTableStore.subscribe(
+  //   (state) => state.tables[networkId],
+  //   (next: TableRecord, prev: TableRecord) => {
+  //     if (prev === undefined || next === undefined) {
+  //       return
+  //     }
 
-      // Check if any table data has changed (excluding the selected rows/columns)
-      const tableDataChanged =
-        !_.isEqual(prev.nodeTable, next.nodeTable) ||
-        !_.isEqual(prev.edgeTable, next.edgeTable)
+  //     console.log('Table data changed', prev, next)
+  //     // Check if any table data has changed (excluding the selected rows/columns)
+  //     const tableDataChanged =
+  //       !_.isEqual(prev.nodeTable, next.nodeTable) ||
+  //       !_.isEqual(prev.edgeTable, next.edgeTable)
 
-      const { networkModified } = workspace
+  //     const { networkModified } = workspace
 
-      const currentNetworkIsNotModified =
-        networkModified[networkId] === undefined ||
-        networkModified[networkId] === false
+  //     const currentNetworkIsNotModified =
+  //       networkModified[networkId] === undefined ||
+  //       networkModified[networkId] === false
 
-      // If table data changed and the network is not already marked as modified, set it to modified
-      if (tableDataChanged && currentNetworkIsNotModified) {
-        setNetworkModified(networkId, true)
-      }
-    },
-  )
+  //     // If table data changed and the network is not already marked as modified, set it to modified
+  //     if (tableDataChanged && currentNetworkIsNotModified) {
+  //       setNetworkModified(networkId, true)
+  //     }
+  //   },
+  // )
 
   const nodeTable = tables[networkId]?.nodeTable
   const edgeTable = tables[networkId]?.edgeTable
@@ -464,6 +465,7 @@ export default function TableBrowser(props: {
             columnKey,
             data as ValueType,
           )
+          setNetworkModified(networkId, true)
         }
       } else {
         if (
@@ -477,6 +479,7 @@ export default function TableBrowser(props: {
             columnKey,
             data as ValueType,
           )
+          setNetworkModified(networkId, true)
         } else {
           if (Number.isInteger(data)) {
             setCellValue(
@@ -486,6 +489,7 @@ export default function TableBrowser(props: {
               columnKey,
               parseFloat(data as string),
             )
+            setNetworkModified(networkId, true)
           } else {
             // the user is trying to assign a double value to a integer column.  Ignore this value.
           }
@@ -661,6 +665,8 @@ export default function TableBrowser(props: {
                     currentTable === nodeTable ? 'node' : 'edge',
                     columnKey,
                   )
+                  setNetworkModified(networkId, true)
+
                   setSelection({
                     ...selection,
                     columns: CompactSelection.fromSingleSelection(
@@ -737,6 +743,7 @@ export default function TableBrowser(props: {
                 selectedColumn.id,
                 newColumnName,
               )
+              setNetworkModified(networkId, true)
 
               if (mappingUpdateType === 'rename') {
                 visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
@@ -772,6 +779,8 @@ export default function TableBrowser(props: {
               currentTable === nodeTable ? 'node' : 'edge',
               selectedColumn.id,
             )
+            setNetworkModified(networkId, true)
+
             if (mappingUpdateType === 'delete') {
               visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
                 setMapping(props.currentNetworkId, vp.name, undefined)
@@ -822,6 +831,7 @@ export default function TableBrowser(props: {
                   cellValue,
                   undefined,
                 )
+                setNetworkModified(networkId, true)
               }}
             >
               Apply value to column
@@ -841,6 +851,7 @@ export default function TableBrowser(props: {
                   cellValue,
                   rows.map((r) => r.id),
                 )
+                setNetworkModified(networkId, true)
               }}
             >
               {`Apply value to selected ${
@@ -972,6 +983,8 @@ export default function TableBrowser(props: {
                 dataType,
                 valueType,
               )
+              setNetworkModified(networkId, true)
+
               setCreateColumnFormError(undefined)
               setSelection({
                 ...selection,

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
@@ -64,7 +64,9 @@ export function TableColumnAppendForm(props: BaseMenuProps) {
   const activeTableIndex = useUiStateStore(
     (state) => state.ui.tableUi.activeTabIndex,
   )
-
+  const setNetworkModified = useWorkspaceStore(
+    (state) => state.setNetworkModified,
+  )
   const table = useTableStore((state) => state.tables[currentNetworkId])
   const setTable = useTableStore((state) => state.setTable)
   const nodeTable = table?.nodeTable
@@ -151,6 +153,7 @@ export function TableColumnAppendForm(props: BaseMenuProps) {
       )
       setTable(currentNetworkId, tableToAppend, nextTable)
     }
+    setNetworkModified(currentNetworkId, true)
     setLoading(false)
     reset()
     props.handleClose()


### PR DESCRIPTION
- Manually call 'setNetworkModified' in the various table browser functions instead of listening to all changes in the table.

Should fix CW-542