### PR TITLE
Hiview selection and sharing bugs

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -168,6 +168,15 @@ const AppShell = (): ReactElement => {
             Your workspace has now been initialized with the last cache.`,
           )
         }
+        // Replace current network ID with the one in the URL.
+        // This is necessary to prevent switching to the current network ID in the cache
+        if (
+          networkId !== undefined &&
+          networkId !== '' &&
+          networkId !== workspace.currentNetworkId
+        ) {
+          workspace.currentNetworkId = networkId
+        }
         setWorkspace(workspace)
       })
     }

--- a/src/components/FloatingToolBar/ShareNetworkButtton.tsx
+++ b/src/components/FloatingToolBar/ShareNetworkButtton.tsx
@@ -45,9 +45,6 @@ export const ShareNetworkButton = ({
   // Encode UI states as URL search params
   const [search, setSearch] = useSearchParams()
 
-  // selectedNodes from the URL
-  const selectedNodesUrlRef = useRef<string | null>(null)
-
   const ui: Ui = useUiStateStore((state) => state.ui)
   const { panels } = ui
 
@@ -116,23 +113,6 @@ export const ShareNetworkButton = ({
       setSearch(params)
     }, 200)
   }
-
-  useEffect(() => {
-    const selectedInURL = search.get(SelectionStates.SelectedNodes)
-    if (selectedInURL !== null && selectedNodesUrlRef.current === null) {
-      selectedNodesUrlRef.current = selectedInURL
-    }
-    if (
-      selectedInURL !== null &&
-      selectedNodesUrlRef.current !== null &&
-      selectedInURL !== selectedNodesUrlRef.current
-    ) {
-      // Set the selected nodes in the URL
-      const params = new URLSearchParams(search)
-      params.set(SelectionStates.SelectedNodes, selectedInURL)
-      setSelection(new URLSearchParams(search))
-    }
-  }, [])
 
   useEffect(() => {
     setSelection(new URLSearchParams(search))

--- a/src/components/FloatingToolBar/ShareNetworkButtton.tsx
+++ b/src/components/FloatingToolBar/ShareNetworkButtton.tsx
@@ -1,7 +1,7 @@
 import { IconButton, Tooltip } from '@mui/material'
 import { Share } from '@mui/icons-material'
 import { useWorkspaceStore } from '../../store/WorkspaceStore'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Ui } from '../../models/UiModel'
 import { NetworkView } from '../../models/ViewModel'
@@ -44,6 +44,9 @@ export const ShareNetworkButton = ({
 
   // Encode UI states as URL search params
   const [search, setSearch] = useSearchParams()
+
+  // selectedNodes from the URL
+  const selectedNodesUrlRef = useRef<string | null>(null)
 
   const ui: Ui = useUiStateStore((state) => state.ui)
   const { panels } = ui
@@ -113,6 +116,23 @@ export const ShareNetworkButton = ({
       setSearch(params)
     }, 200)
   }
+
+  useEffect(() => {
+    const selectedInURL = search.get(SelectionStates.SelectedNodes)
+    if (selectedInURL !== null && selectedNodesUrlRef.current === null) {
+      selectedNodesUrlRef.current = selectedInURL
+    }
+    if (
+      selectedInURL !== null &&
+      selectedNodesUrlRef.current !== null &&
+      selectedInURL !== selectedNodesUrlRef.current
+    ) {
+      // Set the selected nodes in the URL
+      const params = new URLSearchParams(search)
+      params.set(SelectionStates.SelectedNodes, selectedInURL)
+      setSelection(new URLSearchParams(search))
+    }
+  }, [])
 
   useEffect(() => {
     setSelection(new URLSearchParams(search))

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
@@ -638,8 +638,8 @@ export const CirclePackingPanel = ({
 
     // Expand circles to the level of the selected node and zoom in to that circle
     if (selectedNodes.length > 0) {
-      // updateForZoom(9)
-      // lastZoomLevelRef.current = 9
+      updateForZoom(4)
+      lastZoomLevelRef.current = 4
     }
   }, [selectedNodes, selectedLeaf])
 

--- a/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
+++ b/src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx
@@ -33,6 +33,7 @@ import { useFilterStore } from '../../../../store/FilterStore'
 import { useRendererFunctionStore } from '../../../../store/RendererFunctionStore'
 import { useCredentialStore } from '../../../../store/CredentialStore'
 import { AppConfigContext } from '../../../../AppConfigContext'
+import { set } from 'lodash'
 
 interface CirclePackingPanelProps {
   rendererId: string
@@ -76,6 +77,8 @@ export const CirclePackingPanel = ({
   const searchState: SearchState = useFilterStore((state) => state.search.state)
 
   const [lastNetworkId, setLastNetworkId] = useState<IdType>('')
+
+  const [networkSwitched, setNetworkSwitched] = useState<boolean>(false)
 
   // Expand all circles if the search result is shown
   const [expandAll, setExpandAll] = useState<boolean>(false)
@@ -149,23 +152,15 @@ export const CirclePackingPanel = ({
 
     if (selectedNodes.length > 0) {
       const targetNode: IdType = selectedNodes[0]
-      const rootNode =
-        circlePackingView.hierarchy as d3Hierarchy.HierarchyCircularNode<D3TreeNode>
-      const circleNode = findHierarchyNode(targetNode, rootNode)
-      if (circleNode === undefined) {
-        console.warn(
-          'Node selected in primary view is not found in Circle Packing view',
-        )
-        return
-      }
-
-      const depth: number = circleNode.depth
-      selectedDepthRef.current = depth
-      updateForZoom(depth)
-      lastZoomLevelRef.current = depth
+      expandSelectedCircle(targetNode)
     }
 
     // Move to center
+    fitRoot()
+    setNetworkSwitched(true)
+  }, [visible])
+
+  const fitRoot = (): void => {
     const fitFunction = getRendererFunction(rendererId, 'fit')
     if (fitFunction === undefined) {
       console.log('Registering fit function for CP renderer')
@@ -174,7 +169,25 @@ export const CirclePackingPanel = ({
     if (initialSize !== undefined && initialSize.w > 0 && initialSize.h > 0) {
       fitCircle()
     }
-  }, [visible])
+  }
+
+  const expandSelectedCircle = (selectedNodeId: IdType) => {
+    const rootNode =
+      circlePackingView.hierarchy as d3Hierarchy.HierarchyCircularNode<D3TreeNode>
+    const circleNode = findHierarchyNode(selectedNodeId, rootNode)
+    if (circleNode === undefined) {
+      console.warn(
+        'Node selected in primary view is not found in Circle Packing view',
+      )
+      return
+    }
+
+    const depth: number = circleNode.depth
+
+    selectedDepthRef.current = depth
+    updateForZoom(depth)
+    lastZoomLevelRef.current = depth
+  }
 
   /**
    * Fit the circle to the view port
@@ -637,9 +650,11 @@ export const CirclePackingPanel = ({
     displaySelectedNodes(selectedNodeSet, selectedLeaf)
 
     // Expand circles to the level of the selected node and zoom in to that circle
-    if (selectedNodes.length > 0) {
-      updateForZoom(4)
-      lastZoomLevelRef.current = 4
+    if (selectedNodes.length > 0 && networkSwitched) {
+      // updateForZoom(4)
+      // lastZoomLevelRef.current = 4
+      setNetworkSwitched(false)
+      expandSelectedCircle(selectedNodes[0])
     }
   }, [selectedNodes, selectedLeaf])
 


### PR DESCRIPTION
This pull request introduces updates to improve network handling and visualization behavior in the Circle Packing view. The changes primarily focus on ensuring proper network switching and sharing via URL, enhancing the Circle Packing Panel's functionality, and adding utility imports.


### Network Handling Improvements:
* [`src/components/AppShell.tsx`](diffhunk://#diff-2171383e90569dd4d13c47d428ef2ec7e91bceda8a6124ff4ac96ab9d72d4786R171-R179): Added logic to update the `currentNetworkId` in the workspace when the network ID in the URL differs from the cached one. This ensures consistency between the URL and the application state.

This ensures the current network ID in the URL is always used when it is copy & pasted.

### Circle Packing Panel Enhancements:
* `src/features/HierarchyViewer/components/CustomLayout/CirclePackingPanel.tsx`:
  - Introduced a `networkSwitched` state to track when the network has changed and adjust the zoom level accordingly. [[1]](diffhunk://#diff-c0c5ccf9782b6304a7dd8854b2b8cd61ee4764660d5ecef1bb1fa3ecc8d6e7a6R81-R82) [[2]](diffhunk://#diff-c0c5ccf9782b6304a7dd8854b2b8cd61ee4764660d5ecef1bb1fa3ecc8d6e7a6L640-R657)
  - Refactored and extracted the logic for centering the view (`fitRoot`) and expanding selected circles (`expandSelectedCircle`) to improve modularity and maintainability. [[1]](diffhunk://#diff-c0c5ccf9782b6304a7dd8854b2b8cd61ee4764660d5ecef1bb1fa3ecc8d6e7a6R155-R177) [[2]](diffhunk://#diff-c0c5ccf9782b6304a7dd8854b2b8cd61ee4764660d5ecef1bb1fa3ecc8d6e7a6R186-L178)

