### PR TITLE
Fixed missing selection issue when copy & paste URL

### DIFF
--- a/src/components/FloatingToolBar/ShareNetworkButtton.tsx
+++ b/src/components/FloatingToolBar/ShareNetworkButtton.tsx
@@ -86,9 +86,7 @@ export const ShareNetworkButton = ({
     if (selectedNodeCount === 0 && selectedEdgeCount === 0) {
       params.delete(SelectionStates.SelectedNodes)
       params.delete(SelectionStates.SelectedEdges)
-      setTimeout(() => {
-        setSearch(params)
-      }, 200)
+      setSearch(params)
       return
     }
 
@@ -109,9 +107,13 @@ export const ShareNetworkButton = ({
     } else {
       params.delete(SelectionStates.SelectedEdges)
     }
-    setTimeout(() => {
-      setSearch(params)
-    }, 200)
+    // setTimeout(() => {
+    //   console.log(
+    //     `###Now setting Selected nodes In URL:`,
+    //     params.get(SelectionStates.SelectedNodes),
+    //   )
+    setSearch(params)
+    // }, 200)
   }
 
   useEffect(() => {

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -526,7 +526,13 @@ const WorkSpaceEditor = (): JSX.Element => {
     } else {
       loadCurrentNetworkById(currentNetworkId)
         .then(() => {
+          restoreSelectionStates()
+
           restoreTableBrowserTabState()
+          setTimeout(() => {
+            restoreActiveNetworkView()
+          }, 1000)
+
           navigate(
             `/${workspace.id}/networks/${currentNetworkId}${location.search.toString()}`,
           )


### PR DESCRIPTION
This pull request includes changes to improve the behavior of selection state restoration and URL parameter updates in the network-sharing and workspace editor components. The most important changes involve removing unnecessary `setTimeout` calls and adding functionality to restore the active network view after a delay.

This fix will avoid missing selection problem after copy & paste.

### Improvements to selection state handling:

* [`src/components/FloatingToolBar/ShareNetworkButtton.tsx`](diffhunk://#diff-d804b4c2f3987fc8d4d3d917df9ee6d15c60109534c67538ea452cc64587af56L89-L91): Removed the `setTimeout` wrapper around the `setSearch` function to simplify the code and ensure immediate updates to URL parameters when no nodes or edges are selected.

* [`src/components/FloatingToolBar/ShareNetworkButtton.tsx`](diffhunk://#diff-d804b4c2f3987fc8d4d3d917df9ee6d15c60109534c67538ea452cc64587af56L112-R116): Commented out a `setTimeout` block that logged debug information and delayed the `setSearch` function call, likely as part of a cleanup effort.

### Enhancements to workspace editor behavior:

* [`src/components/Workspace/WorkspaceEditor.tsx`](diffhunk://#diff-dbc87ef8753984874b0e2ee607155749ba50b0b378ec8c83a804a8fa6fc85e27R529-R535): Added a call to `restoreSelectionStates` to ensure that selection states are properly restored when a network is loaded.

* [`src/components/Workspace/WorkspaceEditor.tsx`](diffhunk://#diff-dbc87ef8753984874b0e2ee607155749ba50b0b378ec8c83a804a8fa6fc85e27R529-R535): Introduced a delayed call to `restoreActiveNetworkView` using `setTimeout` to ensure the active network view is restored after other asynchronous operations complete.