### PR TITLE
CW-551 Fix for undo function issues for the subnetworks

### DIFF
--- a/src/components/ToolBar/EditMenu/DeleteSelectedNodesMenuItem.tsx
+++ b/src/components/ToolBar/EditMenu/DeleteSelectedNodesMenuItem.tsx
@@ -16,6 +16,8 @@ import {
   ValueType,
 } from '../../../models'
 import { useTableStore } from '../../../store/TableStore'
+import { useUiStateStore } from '../../../store/UiStateStore'
+import { target } from '../../../../webpack.config'
 
 export const DeleteSelectedNodesMenuItem = (
   props: BaseMenuProps,
@@ -29,6 +31,15 @@ export const DeleteSelectedNodesMenuItem = (
     (state) => state.workspace.currentNetworkId,
   )
 
+  // Grab active network view id
+  const activeNetworkId: IdType = useUiStateStore(
+    (state) => state.ui.activeNetworkView,
+  )
+  const targetNetworkId: IdType =
+    activeNetworkId === undefined || activeNetworkId === ''
+      ? currentNetworkId
+      : activeNetworkId
+
   const viewModel: NetworkView | undefined = useViewModelStore((state) =>
     state.getViewModel(currentNetworkId),
   )
@@ -39,12 +50,14 @@ export const DeleteSelectedNodesMenuItem = (
     viewModel !== undefined ? viewModel.selectedNodes : []
 
   useEffect(() => {
-    if (selectedNodes.length > 0) {
+    // Disable the menu item if there are no selected nodes
+    // or if the sub network view is selected
+    if (selectedNodes.length > 0 && targetNetworkId === currentNetworkId) {
       setDisabled(false)
     } else {
       setDisabled(true)
     }
-  }, [selectedNodes])
+  }, [selectedNodes, targetNetworkId])
 
   const handleDeleteNodes = (): void => {
     props.handleClose()

--- a/src/components/ToolBar/EditMenu/UndoMenuItem.tsx
+++ b/src/components/ToolBar/EditMenu/UndoMenuItem.tsx
@@ -1,5 +1,5 @@
 import { MenuItem } from '@mui/material'
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement } from 'react'
 import { BaseMenuProps } from '../BaseMenuProps'
 import { useUndoStack } from '../../../task/UndoStack'
 import { useUndoStore } from '../../../store/UndoStore'
@@ -26,7 +26,6 @@ export const UndoMenuItem = (props: BaseMenuProps): ReactElement => {
   ) ?? { undoStack: [], redoStack: [] }
 
   const handleUndo = (): void => {
-    // TODO: ask user to confirm deletion
     undoLastEdit()
     props.handleClose()
   }


### PR DESCRIPTION
This pull request introduces updates to undo functionality for subnetworks. The changes focus on ensuring the correct network context is used when performing actions, and removing unused code.

### Enhancements to network view handling:

* Updated `DeleteSelectedNodesMenuItem` to account for the active network view. Added logic to disable the menu item when the active network view differs from the main network or when no nodes are selected. (`src/components/ToolBar/EditMenu/DeleteSelectedNodesMenuItem.tsx`, [[1]](diffhunk://#diff-9d556ccabfe524ff6f3de49cada2ae6cdaaa7f06ae305efe4cb6a6a90181ac4cR34-R42) [[2]](diffhunk://#diff-9d556ccabfe524ff6f3de49cada2ae6cdaaa7f06ae305efe4cb6a6a90181ac4cL42-R60)
* Refactored `useUndoStack` to dynamically determine the target network ID at the moment of execution, addressing potential "stale closure" issues. This ensures undo/redo operations are applied to the correct network view. (`src/task/UndoStack.tsx`, [[1]](diffhunk://#diff-d6a842e40a6e73b83d354d71db5c7facd549e1ec46ee2a780f55ba2e2a6d6249L65-R65) [[2]](diffhunk://#diff-d6a842e40a6e73b83d354d71db5c7facd549e1ec46ee2a780f55ba2e2a6d6249L76-R76) [[3]](diffhunk://#diff-d6a842e40a6e73b83d354d71db5c7facd549e1ec46ee2a780f55ba2e2a6d6249L92-R118)

### Code cleanup and simplification:

* Removed an unused import (`deleteEdges`) from `UndoStack.tsx` to clean up the codebase. (`src/task/UndoStack.tsx`, [src/task/UndoStack.tsxL23](diffhunk://#diff-d6a842e40a6e73b83d354d71db5c7facd549e1ec46ee2a780f55ba2e2a6d6249L23))
* Simplified `UndoMenuItem` by removing an outdated TODO comment and unused `useState` and `useEffect` imports. (`src/components/ToolBar/EditMenu/UndoMenuItem.tsx`, [[1]](diffhunk://#diff-37ab5e5be0b35eaf09111c0a3956451ce780a7fd4542436dd37c9db6fba8c9a4L2-R2) [[2]](diffhunk://#diff-37ab5e5be0b35eaf09111c0a3956451ce780a7fd4542436dd37c9db6fba8c9a4L29)