### PR TITLE
custom graphics bugs

### DIFF
--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -230,6 +230,34 @@ export default function VizmapperView(props: {
         />,
       )
     }
+  } else {
+    // There are no existing custom graphics vps set, so let the user
+    // edit the first image chart property
+    const imageChart1Vp = customGraphicVps.find(
+      (vp) => vp.name === 'nodeImageChart1',
+    )
+    const imageChartSize1Vp = customGraphicVps.find(
+      (vp) => vp.name === 'nodeImageChartSize1',
+    )
+
+    if (imageChart1Vp) {
+      nodeVps.push(
+        <VisualPropertyView
+          key={imageChart1Vp.name}
+          currentNetworkId={props.networkId}
+          visualProperty={imageChart1Vp}
+        />,
+      )
+    }
+    if (imageChartSize1Vp) {
+      nodeVps.push(
+        <VisualPropertyView
+          key={imageChartSize1Vp.name}
+          currentNetworkId={props.networkId}
+          visualProperty={imageChartSize1Vp}
+        />,
+      )
+    }
   }
 
   const edgeVps = VisualStyleFn.edgeVisualProperties(visualStyle).map((vp) => {

--- a/src/components/Vizmapper/index.tsx
+++ b/src/components/Vizmapper/index.tsx
@@ -69,6 +69,8 @@ function VisualPropertyView(props: {
   if (arrowColorDisabled)
     tooltip = `Edge color to arrows is enabled. Use the \'${edgeLineColorName}\' property to adjust the arrow color, or uncheck \“Edge color to arrows\” in \'${edgeLineColorName}\' to enable editing of the arrow color.`
 
+  const hasWarning = vpName.includes('nodeImageChart')
+
   return (
     <Box
       sx={{
@@ -164,6 +166,23 @@ function VisualPropertyView(props: {
           </IconButton>
         </Tooltip>
       )}
+
+      {hasWarning && (
+        <Tooltip
+          placement="top"
+          title={
+            'Due to rendering limitations, custom graphics size cannot be edited and will scale to the size of nodes by default.  Original size values are preserved.'
+          }
+          arrow={true}
+          sx={{
+            mr: 1,
+          }}
+        >
+          <IconButton sx={{ padding: 0.5 }}>
+            <InfoIcon sx={{ color: 'rgb(0,0,0,0.4)' }} />
+          </IconButton>
+        </Tooltip>
+      )}
     </Box>
   )
 }
@@ -209,10 +228,10 @@ export default function VizmapperView(props: {
     getFirstValidCustomGraphicVp(customGraphicVps)
 
   if (firstValidCustomGraphicVP !== undefined) {
-    const customGraphicsSizeVP = getSizePropertyForCustomGraphic(
-      firstValidCustomGraphicVP,
-      customGraphicVps,
-    )
+    // const customGraphicsSizeVP = getSizePropertyForCustomGraphic(
+    //   firstValidCustomGraphicVP,
+    //   customGraphicVps,
+    // )
 
     nodeVps.push(
       <VisualPropertyView
@@ -221,24 +240,27 @@ export default function VizmapperView(props: {
         visualProperty={firstValidCustomGraphicVP}
       />,
     )
-    if (customGraphicsSizeVP) {
-      nodeVps.push(
-        <VisualPropertyView
-          key={customGraphicsSizeVP.name}
-          currentNetworkId={props.networkId}
-          visualProperty={customGraphicsSizeVP}
-        />,
-      )
-    }
+
+    // Dont expose custom graphics size properties for now
+    // there are rendering limitations in cy.js
+    // if (customGraphicsSizeVP) {
+    //   nodeVps.push(
+    //     <VisualPropertyView
+    //       key={customGraphicsSizeVP.name}
+    //       currentNetworkId={props.networkId}
+    //       visualProperty={customGraphicsSizeVP}
+    //     />,
+    //   )
+    // }
   } else {
     // There are no existing custom graphics vps set, so let the user
     // edit the first image chart property
     const imageChart1Vp = customGraphicVps.find(
       (vp) => vp.name === 'nodeImageChart1',
     )
-    const imageChartSize1Vp = customGraphicVps.find(
-      (vp) => vp.name === 'nodeImageChartSize1',
-    )
+    // const imageChartSize1Vp = customGraphicVps.find(
+    //   (vp) => vp.name === 'nodeImageChartSize1',
+    // )
 
     if (imageChart1Vp) {
       nodeVps.push(
@@ -249,15 +271,15 @@ export default function VizmapperView(props: {
         />,
       )
     }
-    if (imageChartSize1Vp) {
-      nodeVps.push(
-        <VisualPropertyView
-          key={imageChartSize1Vp.name}
-          currentNetworkId={props.networkId}
-          visualProperty={imageChartSize1Vp}
-        />,
-      )
-    }
+    // if (imageChartSize1Vp) {
+    //   nodeVps.push(
+    //     <VisualPropertyView
+    //       key={imageChartSize1Vp.name}
+    //       currentNetworkId={props.networkId}
+    //       visualProperty={imageChartSize1Vp}
+    //     />,
+    //   )
+    // }
   }
 
   const edgeVps = VisualStyleFn.edgeVisualProperties(visualStyle).map((vp) => {

--- a/src/models/VisualStyleModel/impl/compute-view-util.ts
+++ b/src/models/VisualStyleModel/impl/compute-view-util.ts
@@ -17,6 +17,7 @@ import {
   EdgeFillType,
   EdgeArrowShapeType,
   CustomGraphicsType,
+  NodeVisualPropertyName,
 } from '..'
 
 import * as VisualStyleFnImpl from './VisualStyleFnImpl'
@@ -332,9 +333,16 @@ const computeView = (
 
   if (firstValidCustomGraphicVp !== undefined) {
     const { name, mapping, bypassMap } = firstValidCustomGraphicVp
-    const customGraphicsSizeVP = getSizePropertyForCustomGraphic(
-      firstValidCustomGraphicVp,
-      customGraphicNodeVps,
+    // const customGraphicsSizeVP = getSizePropertyForCustomGraphic(
+    //   firstValidCustomGraphicVp,
+    //   customGraphicNodeVps,
+    // )
+
+    const heightvp = nonCustomGraphicNodeVps.find(
+      (vp) => vp.name === NodeVisualPropertyName.NodeHeight,
+    )
+    const widthvp = nonCustomGraphicNodeVps.find(
+      (vp) => vp.name === NodeVisualPropertyName.NodeHeight,
     )
 
     const bypass = bypassMap.get(id)
@@ -345,7 +353,8 @@ const computeView = (
         id,
         bypass as CustomGraphicsType,
         row,
-        customGraphicsSizeVP,
+        widthvp as VisualProperty<VisualPropertyValueType>,
+        heightvp as VisualProperty<VisualPropertyValueType>,
         mappers,
       )
     } else if (mapping !== undefined) {
@@ -363,7 +372,8 @@ const computeView = (
             id,
             computedValue as CustomGraphicsType,
             row,
-            customGraphicsSizeVP,
+            widthvp as VisualProperty<VisualPropertyValueType>,
+            heightvp as VisualProperty<VisualPropertyValueType>,
             mappers,
           )
         }
@@ -376,7 +386,8 @@ const computeView = (
         id,
         defaultValue as CustomGraphicsType,
         row,
-        customGraphicsSizeVP,
+        widthvp as VisualProperty<VisualPropertyValueType>,
+        heightvp as VisualProperty<VisualPropertyValueType>,
         mappers,
       )
     }

--- a/src/models/VisualStyleModel/impl/compute-view-util.ts
+++ b/src/models/VisualStyleModel/impl/compute-view-util.ts
@@ -342,7 +342,7 @@ const computeView = (
       (vp) => vp.name === NodeVisualPropertyName.NodeHeight,
     )
     const widthvp = nonCustomGraphicNodeVps.find(
-      (vp) => vp.name === NodeVisualPropertyName.NodeHeight,
+      (vp) => vp.name === NodeVisualPropertyName.NodeWidth,
     )
 
     const bypass = bypassMap.get(id)


### PR DESCRIPTION
- Fix issue where the user would not be able to add a custom graphic to nodes if there are no existing custom graphic properties set
- Disable custom graphics sizes for pie charts and render the pie size to be the min of height and width per node
- Dont expose custom graphics size visual properties in the vizmapper
- Add a tooltip communicating to the user the limitations of rendering custom graphics at specific sizes
- All changes described avoid the case of rendering a custom graphic that is larger than the node dimensions leading to rendering issues
