### PR TITLE
Reorganized right-panel to correctly expand contents for wide displays

### DIFF
--- a/src/components/Workspace/SidePanel/SidePanel.tsx
+++ b/src/components/Workspace/SidePanel/SidePanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Tab, Tabs } from '@mui/material'
+import { Box, Tab, Tabs } from '@mui/material'
 import { SyntheticEvent, useState } from 'react'
 import { getTabContents } from './TabContents'
 
@@ -17,8 +17,7 @@ export const SidePanel = (): JSX.Element => {
   const tabContents = getTabContents(value)
 
   return (
-    <Container
-      disableGutters={true}
+    <Box
       sx={{
         width: '100%',
         height: '100%',
@@ -71,6 +70,6 @@ export const SidePanel = (): JSX.Element => {
       >
         {tabContents}
       </Box>
-    </Container>
+    </Box>
   )
 }

--- a/src/components/Workspace/SidePanel/TabPanel.tsx
+++ b/src/components/Workspace/SidePanel/TabPanel.tsx
@@ -20,9 +20,15 @@ export const TabPanel = (props: TabPanelProps): JSX.Element => {
       id={`sidepanel-${index}`}
       aria-labelledby={`sidepanel-${index}`}
       {...other}
-      sx={{ width: '100%', height: '100%' }}
+      sx={{
+        width: '100%',
+        height: '100%',
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
     >
-      {children}
+      <Box sx={{ width: '100%', height: '100%', flexGrow: 1 }}>{children}</Box>
     </Box>
   )
 }

--- a/src/components/Workspace/WorkspaceEditor.tsx
+++ b/src/components/Workspace/WorkspaceEditor.tsx
@@ -674,16 +674,28 @@ const WorkSpaceEditor = (): JSX.Element => {
           </Allotment.Pane>
         </Allotment>
 
-        {panels.right === PanelState.OPEN ? (
-          <Box sx={{ width: '100%', height: '100%' }}>
-            <OpenRightPanelButton
-              toOpen={false}
-              title="Close panel"
-              show={panels.right === PanelState.OPEN}
-            />
-            <SidePanel />
-          </Box>
-        ) : null}
+        {panels.right === PanelState.OPEN && (
+          <Allotment.Pane>
+            <Box
+              sx={{
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                minWidth: 0, // For shrink to hide
+              }}
+            >
+              <OpenRightPanelButton
+                toOpen={false}
+                title="Close panel"
+                show={panels.right === PanelState.OPEN}
+              />
+              <Box sx={{ flexGrow: 1, width: '100%' }}>
+                <SidePanel />
+              </Box>
+            </Box>
+          </Allotment.Pane>
+        )}
       </Allotment>
       <SnackbarMessageList />
       <OpenRightPanelButton

--- a/src/features/HierarchyViewer/components/MainPanel.tsx
+++ b/src/features/HierarchyViewer/components/MainPanel.tsx
@@ -217,6 +217,8 @@ export const MainPanel = (): JSX.Element => {
           width: '100%',
           height: '100%',
           boxSizing: 'border-box',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
         <Allotment vertical minSize={100}>


### PR DESCRIPTION
The current version has an empty area when opening sub-networks in the right-panel (see the picture below) on a wide display.

This pull request fix the issue and refactors the layout and styling of components in the workspace, focusing on replacing `Container` with `Box` for layout consistency, improving flexbox usage, and enhancing responsiveness. The changes primarily affect the `SidePanel`, `TabPanel`, `WorkspaceEditor`, and `MainPanel` components.

### Layout and Container Refactor:
* Replaced `Container` with `Box` in `SidePanel` for layout consistency and removed the `disableGutters` property. (`src/components/Workspace/SidePanel/SidePanel.tsx`, [[1]](diffhunk://#diff-212cf432544bfdd5efe336045d480102f03e26a28dc98b6434db91fa4bf63c29L1-R1) [[2]](diffhunk://#diff-212cf432544bfdd5efe336045d480102f03e26a28dc98b6434db91fa4bf63c29L20-R20) [[3]](diffhunk://#diff-212cf432544bfdd5efe336045d480102f03e26a28dc98b6434db91fa4bf63c29L74-R73)

### Flexbox Enhancements:
* Updated `TabPanel` to include flexbox properties (`display: 'flex'`, `flexDirection: 'column'`) and wrapped `children` inside a `Box` with `flexGrow: 1` for better layout control. (`src/components/Workspace/SidePanel/TabPanel.tsx`, [src/components/Workspace/SidePanel/TabPanel.tsxL23-R31](diffhunk://#diff-49e074e72211b645f79d57a9b27e9e57b8d8e0a21a6ba26278d0b2a120ac03d5L23-R31))
* Refactored `WorkspaceEditor` to add flexbox properties (`display: 'flex'`, `flexDirection: 'column'`) to the right panel, ensuring proper resizing and responsiveness. (`src/components/Workspace/WorkspaceEditor.tsx`, [src/components/Workspace/WorkspaceEditor.tsxL677-R698](diffhunk://#diff-dbc87ef8753984874b0e2ee607155749ba50b0b378ec8c83a804a8fa6fc85e27L677-R698))
* Applied flexbox styling (`display: 'flex'`, `flexDirection: 'column'`) to `MainPanel` to improve vertical layout structure. (`src/features/HierarchyViewer/components/MainPanel.tsx`, [src/features/HierarchyViewer/components/MainPanel.tsxR220-R221](diffhunk://#diff-61332a9065088cff9e57f69517cadb05e110dc6df68468d62e07c063d18c40fbR220-R221))
 
![Screenshot 2025-05-22 164340](https://github.com/user-attachments/assets/121c664d-8e4b-47c9-9387-78b7087561d6)
