### PR TITLE
Adjust the style of network property editor to always show the confirm/cancel button (CW-583)

### DIFF
--- a/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
@@ -96,7 +96,7 @@ export const NetworkPropertyEditor = (
       >
         <Box sx={{ p: 2, height: 'calc(100% - 60px)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           <Chip
-            sx={{ p: 1, mb: 2, width: 100 }}
+            sx={{ p: 1, mb: 2, width: 90 }}
             size="small"
             label={
               <Typography variant="caption">

--- a/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
@@ -94,7 +94,15 @@ export const NetworkPropertyEditor = (
           flexDirection: 'column',
         }}
       >
-        <Box sx={{ p: 2, height: 'calc(100% - 60px)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <Box
+          sx={{
+            p: 2,
+            height: 'calc(100% - 60px)',
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <Chip
             sx={{ p: 1, mb: 2, width: 90 }}
             size="small"
@@ -143,8 +151,22 @@ export const NetworkPropertyEditor = (
                 }
               `}
             </style>
-            <Box sx={{ height: 290, border: '1px solid #e0e0e0', borderRadius: 1, overflow: 'hidden' }}>
-              <RichTextEditor editor={editor} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <Box
+              sx={{
+                height: 290,
+                border: '1px solid #e0e0e0',
+                borderRadius: 1,
+                overflow: 'hidden',
+              }}
+            >
+              <RichTextEditor
+                editor={editor}
+                style={{
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
                 <RichTextEditor.Toolbar>
                   <RichTextEditor.ControlsGroup>
                     <RichTextEditor.Bold />
@@ -185,7 +207,9 @@ export const NetworkPropertyEditor = (
                   </RichTextEditor.ControlsGroup>
                 </RichTextEditor.Toolbar>
 
-                <RichTextEditor.Content style={{ flex: 1, overflowY: 'auto' }} />
+                <RichTextEditor.Content
+                  style={{ flex: 1, overflowY: 'auto' }}
+                />
               </RichTextEditor>
             </Box>
           </MantineProvider>
@@ -201,14 +225,16 @@ export const NetworkPropertyEditor = (
             }}
           />
         </Box>
-        <Box sx={{ 
-          px: 2, 
-          py: 1, 
-          borderTop: '1px solid #e0e0e0',
-          display: 'flex', 
-          justifyContent: 'space-between',
-          backgroundColor: '#fafafa'
-        }}>
+        <Box
+          sx={{
+            px: 2,
+            py: 1,
+            borderTop: '1px solid #e0e0e0',
+            display: 'flex',
+            justifyContent: 'space-between',
+            backgroundColor: '#fafafa',
+          }}
+        >
           <Button
             color="primary"
             onClick={(e) => {

--- a/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
@@ -88,109 +88,127 @@ export const NetworkPropertyEditor = (
     >
       <Paper
         sx={{
-          p: 2,
-          width: 800,
-          height: 800,
-          overflowY: 'scroll',
+          width: 850,
+          height: 810,
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
-        <Chip
-          sx={{ p: 1, mb: 2 }}
-          size="small"
-          label={
-            <Typography variant="caption">
-              {localSummaryState.visibility}
-            </Typography>
-          }
-        />
-        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <TextField
+        <Box sx={{ p: 2, height: 'calc(100% - 60px)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          <Chip
+            sx={{ p: 1, mb: 2 }}
             size="small"
-            label="Name"
-            sx={{ width: '60%', mr: 1, fontSize: 12 }}
-            value={localSummaryState.name}
-            onChange={(e) => {
+            label={
+              <Typography variant="caption">
+                {localSummaryState.visibility}
+              </Typography>
+            }
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <TextField
+              size="small"
+              label="Name"
+              sx={{ width: '60%', mr: 1, fontSize: 12 }}
+              value={localSummaryState.name}
+              onChange={(e) => {
+                setLocalSummaryState({
+                  ...localSummaryState,
+                  name: e.target.value,
+                })
+              }}
+            ></TextField>
+            <TextField
+              size="small"
+              label="Version"
+              sx={{ width: '20%', fontSize: 12 }}
+              value={localSummaryState.version ?? ''}
+              onChange={(e) => {
+                setLocalSummaryState({
+                  ...localSummaryState,
+                  version: e.target.value,
+                })
+              }}
+            />
+          </Box>
+
+          <Typography sx={{ ml: 1.5, pt: 1 }} gutterBottom>
+            Description
+          </Typography>
+          <MantineProvider>
+            <style>
+              {`
+                .mantine-RichTextEditor-toolbar {
+                  padding-top: 0 !important;
+                  padding-bottom: 0 !important;
+                }
+              `}
+            </style>
+            <Box sx={{ height: 290, border: '1px solid #e0e0e0', borderRadius: 1, overflow: 'hidden' }}>
+              <RichTextEditor editor={editor} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                <RichTextEditor.Toolbar>
+                  <RichTextEditor.ControlsGroup>
+                    <RichTextEditor.Bold />
+                    <RichTextEditor.Italic />
+                    <RichTextEditor.Underline />
+                    <RichTextEditor.Strikethrough />
+                    <RichTextEditor.ClearFormatting />
+                    <RichTextEditor.Highlight />
+                    <RichTextEditor.Code />
+                  </RichTextEditor.ControlsGroup>
+
+                  <RichTextEditor.ControlsGroup>
+                    <RichTextEditor.H1 />
+                    <RichTextEditor.H2 />
+                    <RichTextEditor.H3 />
+                    <RichTextEditor.H4 />
+                  </RichTextEditor.ControlsGroup>
+
+                  <RichTextEditor.ControlsGroup>
+                    <RichTextEditor.Blockquote />
+                    <RichTextEditor.Hr />
+                    <RichTextEditor.BulletList />
+                    <RichTextEditor.OrderedList />
+                    <RichTextEditor.Subscript />
+                    <RichTextEditor.Superscript />
+                  </RichTextEditor.ControlsGroup>
+
+                  <RichTextEditor.ControlsGroup>
+                    <RichTextEditor.Link />
+                    <RichTextEditor.Unlink />
+                  </RichTextEditor.ControlsGroup>
+
+                  <RichTextEditor.ControlsGroup>
+                    <RichTextEditor.AlignLeft />
+                    <RichTextEditor.AlignCenter />
+                    <RichTextEditor.AlignJustify />
+                    <RichTextEditor.AlignRight />
+                  </RichTextEditor.ControlsGroup>
+                </RichTextEditor.Toolbar>
+
+                <RichTextEditor.Content style={{ flex: 1, overflowY: 'auto' }} />
+              </RichTextEditor>
+            </Box>
+          </MantineProvider>
+
+          <Divider sx={{ mt: 2, mb: 1 }} />
+          <NdexNetworkPropertyTable
+            networkProperties={localSummaryState.properties}
+            setNetworkProperties={(nextProperties) => {
               setLocalSummaryState({
                 ...localSummaryState,
-                name: e.target.value,
-              })
-            }}
-          ></TextField>
-          <TextField
-            size="small"
-            label="Version"
-            sx={{ width: '20%', fontSize: 12 }}
-            value={localSummaryState.version ?? ''}
-            onChange={(e) => {
-              setLocalSummaryState({
-                ...localSummaryState,
-                version: e.target.value,
+                properties: nextProperties,
               })
             }}
           />
         </Box>
-
-        <Typography sx={{ ml: 1.5, pt: 1 }} gutterBottom>
-          Description
-        </Typography>
-        <MantineProvider>
-          <RichTextEditor editor={editor}>
-            <RichTextEditor.Toolbar sticky stickyOffset={60}>
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Bold />
-                <RichTextEditor.Italic />
-                <RichTextEditor.Underline />
-                <RichTextEditor.Strikethrough />
-                <RichTextEditor.ClearFormatting />
-                <RichTextEditor.Highlight />
-                <RichTextEditor.Code />
-              </RichTextEditor.ControlsGroup>
-
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.H1 />
-                <RichTextEditor.H2 />
-                <RichTextEditor.H3 />
-                <RichTextEditor.H4 />
-              </RichTextEditor.ControlsGroup>
-
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Blockquote />
-                <RichTextEditor.Hr />
-                <RichTextEditor.BulletList />
-                <RichTextEditor.OrderedList />
-                <RichTextEditor.Subscript />
-                <RichTextEditor.Superscript />
-              </RichTextEditor.ControlsGroup>
-
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Link />
-                <RichTextEditor.Unlink />
-              </RichTextEditor.ControlsGroup>
-
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.AlignLeft />
-                <RichTextEditor.AlignCenter />
-                <RichTextEditor.AlignJustify />
-                <RichTextEditor.AlignRight />
-              </RichTextEditor.ControlsGroup>
-            </RichTextEditor.Toolbar>
-
-            <RichTextEditor.Content />
-          </RichTextEditor>
-        </MantineProvider>
-
-        <Divider sx={{ mt: 2, mb: 1 }} />
-        <NdexNetworkPropertyTable
-          networkProperties={localSummaryState.properties}
-          setNetworkProperties={(nextProperties) => {
-            setLocalSummaryState({
-              ...localSummaryState,
-              properties: nextProperties,
-            })
-          }}
-        />
-        <Divider sx={{ mt: 2, mb: 1 }} />
-        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Box sx={{ 
+          px: 2, 
+          py: 1, 
+          borderTop: '1px solid #e0e0e0',
+          display: 'flex', 
+          justifyContent: 'space-between',
+          backgroundColor: '#fafafa'
+        }}>
           <Button
             color="primary"
             onClick={(e) => {

--- a/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyEditor.tsx
@@ -96,7 +96,7 @@ export const NetworkPropertyEditor = (
       >
         <Box sx={{ p: 2, height: 'calc(100% - 60px)', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           <Chip
-            sx={{ p: 1, mb: 2 }}
+            sx={{ p: 1, mb: 2, width: 100 }}
             size="small"
             label={
               <Typography variant="caption">

--- a/src/components/SummaryPanel/NdexNetworkPropertyTable.tsx
+++ b/src/components/SummaryPanel/NdexNetworkPropertyTable.tsx
@@ -233,7 +233,7 @@ const NdexNetworkPropertyTable = (props: {
         </Table>
       </TableContainer>
       <Button
-        sx={{ mt: 1 }}
+        sx={{ mt: 1, width: 'fit-content' }}
         variant="contained"
         onClick={() => addNetworkProperty()}
       >


### PR DESCRIPTION
Fixed the issue reported in CW-583. The confirm/cancel button was not visible to users when the description field is long. The new layout limits the height of the description field. 