### PR TITLE
feat: add Claude Code workflow commands

### DIFF
--- a/.claude/SETUP.md
+++ b/.claude/SETUP.md
@@ -1,0 +1,93 @@
+# Claude Code Workflow Setup
+
+This repo includes custom Claude Code commands for an AI-assisted development workflow. Follow these steps to set up your environment.
+
+## Prerequisites
+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed
+- Access to the `cytoscape` Jira Cloud instance
+- Write access to the `cytoscape/cytoscape-web` GitHub repo
+
+## 1. GitHub MCP Server
+
+Generate a fine-grained personal access token:
+
+1. GitHub > Settings > Developer Settings > Personal Access Tokens > Fine-grained tokens
+2. Set resource owner to your org (e.g., `cytoscape`)
+3. Select the `cw5` repository (or all repos)
+4. Under **Repository permissions**, set:
+   - Contents: Read and write
+   - Pull requests: Read and write
+   - Issues: Read and write
+   - Metadata: Read-only (auto-selected)
+5. Generate and copy the token
+
+Create a `.env` file in the project root (already in `.gitignore`):
+
+```
+GITHUB_PAT=your_token_here
+```
+
+Add the GitHub MCP server (run in your terminal, not in Claude Code):
+
+```bash
+claude mcp add-json github '{"type":"http","url":"https://api.githubcopilot.com/mcp","headers":{"Authorization":"Bearer '"$(grep GITHUB_PAT .env | cut -d '=' -f2)"'"}}' -s project
+```
+
+## 2. Atlassian/Jira MCP Server
+
+```bash
+claude mcp add atlassian -s project --transport sse https://mcp.atlassian.com/v1/sse
+```
+
+On first use, a browser window will open for OAuth authentication with your Atlassian account.
+
+## 3. Notification Sound (optional, macOS only)
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay /System/Library/Sounds/Glass.aiff"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## 4. Restart Claude Code
+
+Exit and relaunch Claude Code so the MCP servers connect.
+
+## Available Commands
+
+| Command | Description |
+|---|---|
+| `/start-ticket` | Fetch next highest priority Jira ticket and start working on it |
+| `/start-ticket CW-1234` | Work on a specific ticket |
+| `/skip-ticket` | Skip current ticket, fetch next from queue |
+| `/commit-push-pr` | Lint, review, commit, push, and create PR to `development` |
+| `/fix-pr-comments` | Read and fix GitHub PR review comments |
+| `/fix-pr-comments 42` | Fix comments on a specific PR |
+
+## Workflow
+
+```
+/start-ticket          -> picks up highest priority ticket, transitions to In Progress
+  ...discuss & implement...
+  ...manual UI testing...
+/commit-push-pr        -> lint, commit, push, create PR
+  ...AI reviewer + human review on GitHub...
+/fix-pr-comments       -> address review comments, push fixes
+  ...approve & merge PR...
+  ...Jira auto-transitions ticket to Done...
+```

--- a/.claude/SETUP.md
+++ b/.claude/SETUP.md
@@ -64,7 +64,69 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-## 4. Restart Claude Code
+## 4. Permissions (recommended allowlist)
+
+The repo ships with a shared deny list (`.claude/settings.json`) that blocks dangerous operations for everyone — force push, pushes to main/development, hard resets, branch deletion, and destructive GitHub MCP actions.
+
+For convenience, copy the recommended allowlist into your local settings. Create `.claude/settings.local.json` (already gitignored) and add:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git branch*)",
+      "Bash(git fetch*)",
+      "Bash(git checkout development*)",
+      "Bash(git checkout -b CW-*)",
+      "Bash(git checkout CW-*)",
+      "Bash(git add *)",
+      "Bash(git rm --cached*)",
+      "Bash(git commit *)",
+      "Bash(git push origin CW-*)",
+      "Bash(git push -u origin CW-*)",
+
+      "Bash(npm run lint*)",
+      "Bash(npm run test:unit*)",
+      "Bash(npm run build*)",
+      "Bash(npm install*)",
+
+      "Bash(afplay *)",
+      "Bash(ls *)",
+      "Bash(mkdir *)",
+      "Bash(which *)",
+
+      "mcp__atlassian__*",
+      "mcp__github__create_pull_request",
+      "mcp__github__list_pull_requests",
+      "mcp__github__pull_request_read",
+      "mcp__github__get_file_contents",
+      "mcp__github__list_commits",
+      "mcp__github__search_code"
+    ]
+  }
+}
+```
+
+This auto-approves safe operations (file edits, git on CW-* branches, lint/test/build, Jira read/write, GitHub PR tools). Everything else prompts for permission.
+
+### Safety layers
+
+| Layer | Scope | What it does |
+|---|---|---|
+| **Deny list** (`.claude/settings.json`) | Shared, committed | Blocks destructive operations for all team members |
+| **Allow list** (`.claude/settings.local.json`) | Personal, local | Auto-approves safe operations (opt-in) |
+| **Safety hook** (`.claude/hooks/pre-bash.sh`) | Shared, committed | Defense-in-depth — catches blocked patterns in bash commands |
+
+## 5. Restart Claude Code
 
 Exit and relaunch Claude Code so the MCP servers connect.
 

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,0 +1,13 @@
+Review all staged and unstaged changes. Then:
+
+1. Run `npm run lint` to check for lint errors. If there are errors, fix them.
+2. Review the diff for correctness, potential bugs, and code quality. Flag any concerns before proceeding.
+3. Stage all relevant changed files (do NOT stage .env or credential files).
+4. Create a conventional commit with a clear message summarizing the changes.
+5. Push the branch to origin.
+6. Create a pull request targeting the `development` branch using `gh pr create`. Include:
+   - A concise title (under 70 characters)
+   - A summary of changes
+   - A test plan checklist
+
+If any step fails, stop and report the issue rather than continuing.

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -5,9 +5,8 @@ Review all staged and unstaged changes. Then:
 3. Stage all relevant changed files (do NOT stage .env or credential files).
 4. Create a conventional commit with a clear message summarizing the changes.
 5. Push the branch to origin.
-6. Create a pull request targeting the `development` branch using `gh pr create`. Include:
+6. Create a pull request targeting the `development` branch on `cytoscape/cytoscape-web` using the GitHub MCP `create_pull_request` tool. Include:
    - A concise title (under 70 characters)
-   - A summary of changes
-   - A test plan checklist
+   - A body with: summary of changes, test plan checklist, and a "Closes CW-XXX" line if the branch name contains a ticket ID
 
 If any step fails, stop and report the issue rather than continuing.

--- a/.claude/commands/fix-pr-comments.md
+++ b/.claude/commands/fix-pr-comments.md
@@ -5,7 +5,7 @@ Fix review comments on a GitHub pull request.
 
 Workflow:
 
-1. Fetch the PR details and all review comments using the GitHub MCP server or `gh` CLI.
+1. Fetch the PR details and all review comments using the GitHub MCP server.
 2. Display a summary of actionable review comments (ignore resolved ones).
 3. For each actionable comment:
    - Show the comment and the relevant code

--- a/.claude/commands/fix-pr-comments.md
+++ b/.claude/commands/fix-pr-comments.md
@@ -1,0 +1,15 @@
+Fix review comments on a GitHub pull request.
+
+**If the user provides a PR number as $ARGUMENTS:** Use that PR.
+**If no argument:** Find open PRs authored by the current user on the `cytoscape/cytoscape-web` repo and let the user pick one.
+
+Workflow:
+
+1. Fetch the PR details and all review comments using the GitHub MCP server or `gh` CLI.
+2. Display a summary of actionable review comments (ignore resolved ones).
+3. For each actionable comment:
+   - Show the comment and the relevant code
+   - Implement the fix
+4. Run `npm run lint` to verify code quality after all fixes.
+5. Show a summary of all changes made.
+6. Ask the user if they want to push the fixes. If yes, commit with a message like `fix: address PR review comments` and push to the branch.

--- a/.claude/commands/skip-ticket.md
+++ b/.claude/commands/skip-ticket.md
@@ -1,0 +1,3 @@
+Skip the current ticket and fetch the next highest priority ticket from the CW project queue.
+
+Remember the current ticket as skipped for this session so it won't be suggested again. Then behave exactly like `/start-ticket` with no arguments — look up the current user's Jira account ID using `atlassianUserInfo` and the Jira Cloud ID via `getAccessibleAtlassianResources`, then fetch the next highest priority "To Do" ticket assigned to the current user or unassigned, excluding any previously skipped tickets.

--- a/.claude/commands/start-ticket.md
+++ b/.claude/commands/start-ticket.md
@@ -1,0 +1,17 @@
+Work on a Jira ticket from the CW project. This command supports three modes:
+
+**Mode 1 - Specific ticket:** If the user provides a ticket ID (e.g., `CW-1234`) as $ARGUMENTS, fetch that ticket.
+
+**Mode 2 - Next from queue:** If no argument is provided, search for the next highest priority ticket. First, look up the current user's Jira account ID using `atlassianUserInfo` and the Jira Cloud ID via `getAccessibleAtlassianResources`. Then query with JQL: `project = CW AND status = "To Do" AND (assignee = "{currentUserAccountId}" OR assignee is EMPTY) AND priority is not EMPTY ORDER BY priority DESC, created DESC` (priority DESC = Highest first, created DESC = most recent first). Tickets with no priority set are excluded. Skip any tickets the user has already skipped in this session.
+
+**Mode 3 - Skip:** If the user says "skip" as the argument, remember the current ticket as skipped for this session and fetch the next one using the same query.
+
+Once a ticket is selected:
+
+1. Display the ticket summary, description, priority, and status.
+2. Transition the ticket to "In Progress" (transition ID: 21) using the Atlassian MCP.
+3. If the ticket is unassigned, assign it to the current user using their account ID.
+4. Discuss the approach with the user — ask clarifying questions about the implementation before writing code.
+5. Once the user approves the approach, create a new branch off `development` named `CW-{ticketNumber}/{short-kebab-description}`.
+6. Implement the fix, running `npm run lint` to verify code quality.
+7. When the user is satisfied, inform them they can use `/commit-push-pr` to finalize.

--- a/.claude/hooks/pre-bash.sh
+++ b/.claude/hooks/pre-bash.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Safety hook: block dangerous operations as a fallback layer
+# The permissions deny list is the primary guard — this is defense in depth
+
+COMMAND="$1"
+
+BLOCKED_PATTERNS=(
+  "push --force"
+  "push origin main"
+  "push origin master"
+  "push origin development"
+  "reset --hard"
+  "branch -D"
+  "clean -f"
+  "rm -rf"
+  "drop database"
+  "truncate table"
+)
+
+for pattern in "${BLOCKED_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qF "$pattern"; then
+    echo "BLOCKED: Dangerous operation detected — '$pattern'"
+    echo "If you need to run this, do it manually outside Claude Code."
+    exit 1
+  fi
+done

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(git push --force*)",
+      "Bash(git push origin main*)",
+      "Bash(git push origin master*)",
+      "Bash(git push origin development*)",
+      "Bash(git reset --hard*)",
+      "Bash(git branch -D*)",
+      "Bash(git clean*)",
+      "Bash(rm -rf*)",
+      "mcp__github__delete_file",
+      "mcp__github__create_repository",
+      "mcp__github__merge_pull_request"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn.lock
 /playwright/.cache/
 /notes/
 /_NOTES/
+.env
+.mcp.json


### PR DESCRIPTION
## Summary
- Add custom slash commands (`.claude/commands/`) for AI-assisted development workflow: `/start-ticket`, `/skip-ticket`, `/commit-push-pr`, `/fix-pr-comments`
- Add team onboarding guide (`.claude/SETUP.md`) with MCP server setup instructions
- Untrack `.env` and add `.env`/`.mcp.json` to `.gitignore` to prevent committing secrets

## Test plan
- [ ] Run `/start-ticket` — verify it fetches the highest priority Jira ticket and transitions to In Progress
- [ ] Run `/skip-ticket` — verify it skips and fetches the next ticket
- [ ] Run `/commit-push-pr` — verify it lints, commits, pushes, and creates a PR
- [ ] Run `/fix-pr-comments` — verify it reads and addresses PR review comments
- [ ] Follow `.claude/SETUP.md` on a clean machine to verify onboarding steps
- [ ] Verify `.env` and `.mcp.json` are not tracked by git

Closes CW-666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds developer workflow docs/config and Claude Code command prompts without touching application runtime code; main impact is tooling behavior and gitignore hygiene.
> 
> **Overview**
> Adds a Claude Code onboarding guide (`.claude/SETUP.md`) plus custom slash-command playbooks for Jira ticket pickup/skip and GitHub PR creation/review-fix flows (`.claude/commands/*`).
> 
> Introduces shared safety controls for Claude Code with a committed denylist (`.claude/settings.json`) and a defense-in-depth bash hook (`.claude/hooks/pre-bash.sh`) to block destructive git/shell/database patterns. Updates `.gitignore` to ignore local secrets/config (`.env`, `.mcp.json`) and normalize `/_NOTES/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b77a8715ee113455e217bab93773e8b0f171711d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->