### PR TITLE
fix: address PR #505 review comments (items 13-17)

### DIFF
--- a/src/data/hooks/useDeleteCyNetwork.ts
+++ b/src/data/hooks/useDeleteCyNetwork.ts
@@ -114,13 +114,17 @@ export const useDeleteCyNetwork = (): UseDeleteCyNetworkReturn => {
 
     // Handle navigation if requested
     if (navigate) {
+      // Use fresh state after deletion to avoid stale workspace reference
+      const freshWorkspace = useWorkspaceStore.getState().workspace
       const nextNetworkId =
-        workspace.networkIds.filter((networkId) => networkId !== id)?.[0] ?? ''
+        freshWorkspace.networkIds.filter(
+          (networkId) => networkId !== id,
+        )?.[0] ?? ''
 
       if (nextNetworkId !== '') {
         setCurrentNetworkId(nextNetworkId)
         navigateToNetwork({
-          workspaceId: workspace.id,
+          workspaceId: freshWorkspace.id,
           networkId: nextNetworkId,
           searchParams: new URLSearchParams(location.search),
           replace: true,
@@ -128,7 +132,7 @@ export const useDeleteCyNetwork = (): UseDeleteCyNetworkReturn => {
       } else {
         setCurrentNetworkId('')
         navigateToNetwork({
-          workspaceId: workspace.id,
+          workspaceId: freshWorkspace.id,
           networkId: '',
           searchParams: new URLSearchParams(location.search),
           replace: true,

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -544,31 +544,9 @@ const MergeDialog: React.FC<MergeDialogProps> = ({
       )
 
       const newSummary = createNetworkSummary({
+        ...networkSummary,
         networkId: newNetworkId,
-        name: networkSummary.name,
-        description: networkSummary.description,
-        version: networkSummary.version,
-        properties: networkSummary.properties,
-        visibility: networkSummary.visibility,
-        ownerUUID: networkSummary.ownerUUID,
-        externalId: networkSummary.externalId,
         hasLayout: false, // Merged networks don't have layout initially
-        isNdex: networkSummary.isNdex,
-        isReadOnly: networkSummary.isReadOnly,
-        subnetworkIds: networkSummary.subnetworkIds,
-        isValid: networkSummary.isValid,
-        warnings: networkSummary.warnings,
-        isShowcase: networkSummary.isShowcase,
-        isCertified: networkSummary.isCertified,
-        indexLevel: networkSummary.indexLevel,
-        hasSample: networkSummary.hasSample,
-        cxFileSize: networkSummary.cxFileSize,
-        cx2FileSize: networkSummary.cx2FileSize,
-        owner: networkSummary.owner,
-        completed: networkSummary.completed,
-        isDeleted: networkSummary.isDeleted,
-        creationTime: networkSummary.creationTime,
-        modificationTime: networkSummary.modificationTime,
         nodeCount: newCyNetwork.network.nodes.length,
         edgeCount: newCyNetwork.network.edges.length,
       })

--- a/src/features/ServiceApps/resultHandler/updateNetwork.ts
+++ b/src/features/ServiceApps/resultHandler/updateNetwork.ts
@@ -118,6 +118,8 @@ export const useUpdateNetwork = (): (({
           hasLayout: anyNodeHasPosition,
           description: localDescription,
           modificationTime: new Date(Date.now()),
+          nodeCount: localNodeCount,
+          edgeCount: localEdgeCount,
         })
         setVisualStyleOptions(networkId, visualStyleOptions)
         setTables(networkId, nodeTable, edgeTable)

--- a/src/features/ToolBar/LayoutMenu/ValueEditor/ListEditor.tsx
+++ b/src/features/ToolBar/LayoutMenu/ValueEditor/ListEditor.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Chip,
   ListItem,
-  ListItemButton,
   ListItemText,
   TextField,
   Tooltip,

--- a/src/features/ToolBar/LayoutMenu/ValueEditor/NumberEditor.tsx
+++ b/src/features/ToolBar/LayoutMenu/ValueEditor/NumberEditor.tsx
@@ -9,10 +9,13 @@ import {
 } from '@mui/material'
 import { ChangeEvent } from 'react'
 
+import { ValueTypeName } from '../../../../models/TableModel'
+
 interface NumberEditorProps {
   optionName: string
   description: string
   value: number
+  valueType?: ValueTypeName
   setValue: (optionName: string, value: number) => void
   typeLabel?: string
   typeColor?: 'default' | 'primary' | 'secondary' | 'success' | 'warning' | 'error'
@@ -24,6 +27,7 @@ export const NumberEditor = ({
   optionName,
   description,
   value,
+  valueType,
   setValue,
   typeLabel,
   typeColor = 'success',
@@ -31,8 +35,14 @@ export const NumberEditor = ({
   error = false,
 }: NumberEditorProps): JSX.Element => {
   const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
-    const newValue: any = event.target.value
-    setValue(optionName, Number(newValue))
+    const parsed = event.target.valueAsNumber
+    if (Number.isNaN(parsed)) return
+    const coerced =
+      valueType === ValueTypeName.Integer ||
+      valueType === ValueTypeName.Long
+        ? Math.trunc(parsed)
+        : parsed
+    setValue(optionName, coerced)
   }
 
   if (tableLayout) {

--- a/src/features/ToolBar/LayoutMenu/ValueEditor/NumberEditor.tsx
+++ b/src/features/ToolBar/LayoutMenu/ValueEditor/NumberEditor.tsx
@@ -32,7 +32,7 @@ export const NumberEditor = ({
 }: NumberEditorProps): JSX.Element => {
   const handleChange = (event: ChangeEvent<HTMLInputElement>): void => {
     const newValue: any = event.target.value
-    setValue(optionName, Number.parseInt(newValue))
+    setValue(optionName, Number(newValue))
   }
 
   if (tableLayout) {

--- a/src/features/ToolBar/LayoutMenu/ValueEditor/ValueEditor.tsx
+++ b/src/features/ToolBar/LayoutMenu/ValueEditor/ValueEditor.tsx
@@ -91,6 +91,7 @@ export const ValueEditor = ({
         optionName={optionName}
         description={description}
         value={value as number}
+        valueType={valueType}
         setValue={setValue}
         typeLabel={showTypeChip ? getTypeLabel(valueType) : undefined}
         typeColor={getTypeColor(valueType)}


### PR DESCRIPTION
## Summary
- **Fix stale workspace state bug** in `useDeleteCyNetwork`: after deleting a network, the hook now reads fresh store state via `useWorkspaceStore.getState()` instead of using the stale render-time snapshot, which could select the deleted network as the "next" network
- **Fix Number.parseInt truncating decimals** in `NumberEditor`: layout parameters with Double/Float types (e.g. `3.14`) were being truncated to integers; now uses `Number()` to preserve decimal values
- **Fix missing nodeCount/edgeCount** in `updateNetwork`: service app result handler was computing but not passing node/edge counts to the summary update, leaving stale counts
- **Remove unused `ListItemButton` import** from `ListEditor`
- **Simplify `createNetworkSummary` call** in `MergeDialog`: replaced verbose field-by-field copy with spread operator, reducing maintenance burden when new fields are added

## Test plan
- [ ] Delete a network from a workspace with multiple networks — verify the correct next network is selected
- [ ] Use a layout algorithm with Double-type parameters — verify decimal values are preserved
- [ ] Run a service app that updates a network — verify node/edge counts are correct in the summary
- [ ] Open the layout value editor with list-type parameters — verify no console errors from unused imports
- [ ] Merge networks — verify the merged network summary is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)