### PR TITLE
CW-699: Interpolate color palettes when slices exceed base colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22961,24 +22961,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",

--- a/src/models/VisualStyleModel/impl/colorUtils.test.ts
+++ b/src/models/VisualStyleModel/impl/colorUtils.test.ts
@@ -132,24 +132,24 @@ describe('colorUtils', () => {
       expect(result[1]).toBe('#FFFF00')
     })
 
-    it('should cycle through base when count > base length', () => {
+    it('should interpolate through base when count > base length', () => {
       const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF']
       const result = pickEvenly(base, 7)
       expect(result).toHaveLength(7)
-      // Should cycle: [0, 1, 2, 0, 1, 2, 0]
-      expect(result[0]).toBe('#FF0000')
-      expect(result[1]).toBe('#00FF00')
-      expect(result[2]).toBe('#0000FF')
-      expect(result[3]).toBe('#FF0000')
-      expect(result[4]).toBe('#00FF00')
-      expect(result[5]).toBe('#0000FF')
-      expect(result[6]).toBe('#FF0000')
+      // Should interpolate smoothly from red to green to blue
+      expect(result[0]).toBe('#ff0000')
+      expect(result[1]).toBe('#df8a00') // interpolated orange-ish
+      expect(result[2]).toBe('#abc900') // interpolated yellow-green
+      expect(result[3]).toBe('#00ff00') // middle is green
+      expect(result[4]).toBe('#78b785') // interpolated green-blue
+      expect(result[5]).toBe('#766ec5') // interpolated blue
+      expect(result[6]).toBe('#0000ff') // end is blue
     })
 
     it('should handle single element base', () => {
       const base: ColorPalette = ['#FF0000']
       expect(pickEvenly(base, 1)).toEqual(['#FF0000'])
-      expect(pickEvenly(base, 3)).toEqual(['#FF0000', '#FF0000', '#FF0000'])
+      expect(pickEvenly(base, 3)).toEqual(['#ff0000', '#ff0000', '#ff0000']) // chroma js returns lowercase hex
     })
 
     it('should distribute evenly across the range', () => {
@@ -158,16 +158,15 @@ describe('colorUtils', () => {
       expect(result).toEqual(base)
     })
 
-    it('should handle large count values', () => {
+    it('should handle large count values by interpolating', () => {
       const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF']
       const result = pickEvenly(base, 100)
       expect(result).toHaveLength(100)
-      // Should cycle through base
-      expect(result[0]).toBe('#FF0000')
-      expect(result[1]).toBe('#00FF00')
-      expect(result[2]).toBe('#0000FF')
-      expect(result[3]).toBe('#FF0000')
-      expect(result[99]).toBe('#FF0000') // 99 % 3 = 0
+      // Should start with red and end with blue
+      expect(result[0]).toBe('#ff0000')
+      expect(result[49]).toMatch(/^#[0-9a-f]{6}$/i) // interpolated middle
+      expect(result[50]).toMatch(/^#[0-9a-f]{6}$/i) // interpolated middle
+      expect(result[99]).toBe('#0000ff')
     })
 
     it('should return correct indices for edge cases', () => {

--- a/src/models/VisualStyleModel/impl/colorUtils.test.ts
+++ b/src/models/VisualStyleModel/impl/colorUtils.test.ts
@@ -92,64 +92,69 @@ describe('colorUtils', () => {
     })
 
     it('should return middle element for count === 1', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff']
       const result = pickEvenly(base, 1)
       expect(result).toHaveLength(1)
       // For 5 elements, middle is index 2 (Math.floor((5-1)/2) = 2)
-      expect(result[0]).toBe('#0000FF')
+      expect(result[0]).toBe('#0000ff')
     })
 
     it('should return middle element for count === 1 with even-length base', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff', '#ffff00']
       const result = pickEvenly(base, 1)
       expect(result).toHaveLength(1)
       // For 4 elements, middle is index 1 (Math.floor((4-1)/2) = 1)
-      expect(result[0]).toBe('#00FF00')
+      expect(result[0]).toBe('#00ff00')
     })
 
     it('should return all elements when count equals base length', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff']
       const result = pickEvenly(base, 3)
       expect(result).toEqual(base)
     })
 
     it('should return evenly distributed elements when count < base length', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff']
       const result = pickEvenly(base, 3)
       expect(result).toHaveLength(3)
       // Should pick first, middle, and last
-      expect(result[0]).toBe('#FF0000')
-      expect(result[1]).toBe('#0000FF')
-      expect(result[2]).toBe('#FF00FF')
+      expect(result[0]).toBe('#ff0000')
+      expect(result[1]).toBe('#0000ff')
+      expect(result[2]).toBe('#ff00ff')
     })
 
     it('should return evenly distributed elements for count = 2', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF', '#FFFF00']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff', '#ffff00']
       const result = pickEvenly(base, 2)
       expect(result).toHaveLength(2)
       // Should pick first and last
-      expect(result[0]).toBe('#FF0000')
-      expect(result[1]).toBe('#FFFF00')
+      expect(result[0]).toBe('#ff0000')
+      expect(result[1]).toBe('#ffff00')
     })
 
     it('should interpolate through base when count > base length', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff']
       const result = pickEvenly(base, 7)
       expect(result).toHaveLength(7)
-      // Should interpolate smoothly from red to green to blue
+      // Start and end should match the base endpoints
       expect(result[0]).toBe('#ff0000')
-      expect(result[1]).toBe('#df8a00') // interpolated orange-ish
-      expect(result[2]).toBe('#abc900') // interpolated yellow-green
-      expect(result[3]).toBe('#00ff00') // middle is green
-      expect(result[4]).toBe('#78b785') // interpolated green-blue
-      expect(result[5]).toBe('#766ec5') // interpolated blue
-      expect(result[6]).toBe('#0000ff') // end is blue
+      expect(result[6]).toBe('#0000ff')
+      
+      // All values should be valid 6-digit hex colors
+      const hexRegex = /^#[0-9a-f]{6}$/i
+      result.forEach(color => {
+        expect(color).toMatch(hexRegex)
+      })
+      
+      // There should be intermediate colors, not just the endpoints
+      const uniqueColors = new Set(result)
+      expect(uniqueColors.size).toBeGreaterThan(2)
     })
 
     it('should handle single element base', () => {
-      const base: ColorPalette = ['#FF0000']
-      expect(pickEvenly(base, 1)).toEqual(['#FF0000'])
-      expect(pickEvenly(base, 3)).toEqual(['#ff0000', '#ff0000', '#ff0000']) // chroma js returns lowercase hex
+      const base: ColorPalette = ['#ff0000']
+      expect(pickEvenly(base, 1)).toEqual(['#ff0000'])
+      expect(pickEvenly(base, 3)).toEqual(['#ff0000', '#ff0000', '#ff0000'])
     })
 
     it('should distribute evenly across the range', () => {
@@ -159,7 +164,7 @@ describe('colorUtils', () => {
     })
 
     it('should handle large count values by interpolating', () => {
-      const base: ColorPalette = ['#FF0000', '#00FF00', '#0000FF']
+      const base: ColorPalette = ['#ff0000', '#00ff00', '#0000ff']
       const result = pickEvenly(base, 100)
       expect(result).toHaveLength(100)
       // Should start with red and end with blue

--- a/src/models/VisualStyleModel/impl/colorUtils.ts
+++ b/src/models/VisualStyleModel/impl/colorUtils.ts
@@ -491,18 +491,26 @@ export function generateRandomColor(): ColorType {
  */
 export function pickEvenly(base: ColorPalette, count: number): ColorPalette {
   if (!base.length || count <= 0) return []
-  const n = base.length
-  if (count === 1) return [base[Math.floor((n - 1) / 2)]]
+  
+  const normalizedBase = base.map((c) => c.toLowerCase() as ColorType)
+  const n = normalizedBase.length
+
+  if (count === 1) return [normalizedBase[Math.floor((n - 1) / 2)]]
+  
+  if (n === 1) {
+    return Array.from({ length: count }, () => normalizedBase[0])
+  }
+
   if (count <= n) {
     return Array.from({ length: count }, (_, i) => {
       const idx = Math.round((i * (n - 1)) / (count - 1))
-      return base[idx]
+      return normalizedBase[idx]
     })
   }
   
   // Use chroma.js to interpret base as a scale and sample it evenly
-  const scale = chroma.scale(base).mode('lab')
+  const scale = chroma.scale(normalizedBase).mode('lab')
   return Array.from({ length: count }, (_, i) => {
-    return scale(i / (count - 1)).hex() as ColorType
+    return scale(i / (count - 1)).hex().toLowerCase() as ColorType
   })
 }

--- a/src/models/VisualStyleModel/impl/colorUtils.ts
+++ b/src/models/VisualStyleModel/impl/colorUtils.ts
@@ -1,6 +1,7 @@
-import { ColorType } from '../VisualPropertyValue/ColorType'
-import { ColorPalette } from '../VisualPropertyValue/ColorPalette'
 import chroma from 'chroma-js'
+
+import { ColorPalette } from '../VisualPropertyValue/ColorPalette'
+import { ColorType } from '../VisualPropertyValue/ColorType'
 
 // Color palette arrays
 export const CompactCustomColors = [

--- a/src/models/VisualStyleModel/impl/colorUtils.ts
+++ b/src/models/VisualStyleModel/impl/colorUtils.ts
@@ -1,5 +1,6 @@
 import { ColorType } from '../VisualPropertyValue/ColorType'
 import { ColorPalette } from '../VisualPropertyValue/ColorPalette'
+import chroma from 'chroma-js'
 
 // Color palette arrays
 export const CompactCustomColors = [
@@ -498,5 +499,10 @@ export function pickEvenly(base: ColorPalette, count: number): ColorPalette {
       return base[idx]
     })
   }
-  return Array.from({ length: count }, (_, i) => base[i % n])
+  
+  // Use chroma.js to interpret base as a scale and sample it evenly
+  const scale = chroma.scale(base).mode('lab')
+  return Array.from({ length: count }, (_, i) => {
+    return scale(i / (count - 1)).hex() as ColorType
+  })
 }


### PR DESCRIPTION
Matches Cytoscape Desktop behavior by interpolating colors using `chroma-js` when a color palette is smaller than the requested count instead of looping. \n\n @copilot review