### PR TITLE
CW-677: Feedback for empty search matches

### DIFF
--- a/src/features/Messages/SnackbarMessageList.tsx
+++ b/src/features/Messages/SnackbarMessageList.tsx
@@ -66,7 +66,7 @@ export const SnackbarMessageList = (): React.ReactElement => {
   return (
     <Snackbar
       data-testid="snackbar-message-list"
-      sx={{ zIndex: 9999999 }}
+      sx={{ zIndex: 9999999, top: '64px !important' }}
       open={open}
       onClose={handleSnackbarClose}
       autoHideDuration={autoHideDuration}

--- a/src/features/ToolBar/Search/SearchBox.test.tsx
+++ b/src/features/ToolBar/Search/SearchBox.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { SearchBox } from './SearchBox'
+import { useMessageStore } from '../../../data/hooks/stores/MessageStore'
+import { useFilterStore } from '../../../data/hooks/stores/FilterStore'
+import { useUiStateStore } from '../../../data/hooks/stores/UiStateStore'
+import { useWorkspaceStore } from '../../../data/hooks/stores/WorkspaceStore'
+import { useTableStore } from '../../../data/hooks/stores/TableStore'
+import { useViewModelStore } from '../../../data/hooks/stores/ViewModelStore'
+import { MessageSeverity } from '../../../models/MessageModel'
+import { GraphObjectType } from '../../../models/NetworkModel'
+import { runSearch } from './searchUtil'
+
+// Mock the modules
+jest.mock('./searchUtil', () => ({
+  ...jest.requireActual('./searchUtil'),
+  runSearch: jest.fn(),
+  createFuseIndex: jest.fn(() => ({})),
+  filterColumns: jest.fn(() => new Set()),
+}))
+
+jest.mock('../../../data/hooks/stores/FilterStore')
+jest.mock('../../../data/hooks/stores/MessageStore')
+jest.mock('../../../data/hooks/stores/TableStore')
+jest.mock('../../../data/hooks/stores/UiStateStore')
+jest.mock('../../../data/hooks/stores/WorkspaceStore')
+jest.mock('../../../data/hooks/stores/ViewModelStore')
+
+describe('SearchBox', () => {
+    const addMessageMock = jest.fn()
+    const exclusiveSelectMock = jest.fn()
+    const setQueryMock = jest.fn()
+    const setSearchStateMock = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        // Setup store mocks
+        ;(useMessageStore as unknown as jest.Mock).mockImplementation((selector) => 
+            selector({ addMessage: addMessageMock })
+        )
+        ;(useFilterStore as unknown as jest.Mock).mockImplementation((selector) =>
+            selector({
+                search: {
+                    query: 'test-query',
+                    options: { exact: false, operator: 'OR' },
+                    index: { 'net1': { [GraphObjectType.NODE]: {}, [GraphObjectType.EDGE]: {} } },
+                    indexedColumns: { 'net1': {} }
+                },
+                setQuery: setQueryMock,
+                setSearchState: setSearchStateMock,
+                setIndexedColumns: jest.fn(),
+                setIndex: jest.fn(),
+            })
+        )
+        ;(useUiStateStore as unknown as jest.Mock).mockImplementation((selector) => 
+            selector({ ui: { activeNetworkView: 'net1' } })
+        )
+        ;(useWorkspaceStore as unknown as jest.Mock).mockImplementation((selector) =>
+            selector({
+                workspace: { currentNetworkId: 'net1' }
+            })
+        )
+        ;(useTableStore as unknown as jest.Mock).mockImplementation((selector) =>
+            selector({
+                tables: {
+                    'net1': { nodeTable: { columns: new Map(), rows: new Map() }, edgeTable: { columns: new Map(), rows: new Map() } }
+                }
+            })
+        )
+        ;(useViewModelStore as unknown as jest.Mock).mockImplementation((selector) =>
+            selector({ exclusiveSelect: exclusiveSelectMock })
+        )
+    })
+
+    it('shows "No matches found" when a search target is selected but no matches occur', async () => {
+        (runSearch as jest.Mock).mockReturnValue([]) // No matches
+
+        render(<SearchBox />)
+
+        const submitButton = screen.getByTestId('search-submit-button')
+        fireEvent.click(submitButton)
+
+        expect(addMessageMock).toHaveBeenCalledWith({
+            message: 'No matches for search term "test-query" found in the active network',
+            severity: MessageSeverity.INFO,
+        })
+    })
+
+    it('shows "No search target selected" when no target is selected and a search is performed', async () => {
+        (runSearch as jest.Mock).mockReturnValue([]) // No matches
+
+        render(<SearchBox />)
+
+        // Open settings to de-select Node checkbox (Node is selected by default)
+        const settingsButton = screen.getByTestId('search-settings-button')
+        fireEvent.click(settingsButton)
+
+        // Find the actual checkbox inputs by their label
+        const nodeCheckbox = screen.getByLabelText('Nodes') as HTMLInputElement
+        const edgeCheckbox = screen.getByLabelText('Edges') as HTMLInputElement
+
+        // De-select Node checkbox
+        fireEvent.click(nodeCheckbox)
+        
+        // Ensure both are unchecked (Edge is unchecked by default)
+        expect(nodeCheckbox.checked).toBe(false)
+        expect(edgeCheckbox.checked).toBe(false)
+
+        const submitButton = screen.getByTestId('search-submit-button')
+        fireEvent.click(submitButton)
+
+        expect(addMessageMock).toHaveBeenCalledWith({
+            message: 'No search target selected. Please select nodes and/or edges.',
+            severity: MessageSeverity.WARNING,
+        })
+
+        // Ensure "No matches found" was NOT called for this case
+        expect(addMessageMock).not.toHaveBeenCalledWith(expect.objectContaining({
+            severity: MessageSeverity.INFO
+        }))
+    })
+})

--- a/src/features/ToolBar/Search/SearchBox.tsx
+++ b/src/features/ToolBar/Search/SearchBox.tsx
@@ -109,74 +109,89 @@ export const SearchBox = (): JSX.Element => {
     }
 
     setSearchState(SearchState.IN_PROGRESS)
-    // Node and edge
-    const indices: Indices<Fuse<Record<string, ValueType>>> =
-      indexRecord[networkId]
+    try {
+      // Node and edge
+      const indices: Indices<Fuse<Record<string, ValueType>>> =
+        indexRecord[networkId]
 
-    if (indices === undefined) {
-      logUi.warn(`[${startSearch.name}]: No search indices found for network ${networkId}`)
-      addMessage({
-        message: 'Search index not ready. Please wait.',
-        severity: MessageSeverity.WARNING,
-      })
-      return
+      if (indices === undefined) {
+        logUi.warn(`[${startSearch.name}]: No search indices found for network ${networkId}`)
+        addMessage({
+          message: 'Search index not ready. Please wait.',
+          severity: MessageSeverity.WARNING,
+        })
+        return
+      }
+
+      const nodeIndex = indices[GraphObjectType.NODE]
+      const edgeIndex = indices[GraphObjectType.EDGE]
+
+      const isNodeTargetSelected = searchTargets[GraphObjectType.NODE]
+      const isEdgeTargetSelected = searchTargets[GraphObjectType.EDGE]
+
+      if (isNodeTargetSelected && nodeIndex === undefined) {
+        logUi.warn(`[${startSearch.name}]: Node index undefined for network ${networkId}`)
+        addMessage({
+          message: 'Node search index not ready. Please wait.',
+          severity: MessageSeverity.WARNING,
+        })
+        return
+      }
+
+      if (isEdgeTargetSelected && edgeIndex === undefined) {
+        logUi.warn(`[${startSearch.name}]: Edge index undefined for network ${networkId}`)
+        addMessage({
+          message: 'Edge search index not ready. Please wait.',
+          severity: MessageSeverity.WARNING,
+        })
+        return
+      }
+
+      // Clear selection
+      exclusiveSelect(networkId, [], [])
+
+      const operator: Operator = searchOptions.operator
+      const exact: boolean = searchOptions.exact
+
+      let nodesToBeSelected: IdType[] = []
+      let edgesToBeSelected: IdType[] = []
+
+      logUi.info(`[${startSearch.name}]: Executing search. Query: "${query}", Targets:`, searchTargets)
+
+      if (isNodeTargetSelected) {
+        nodesToBeSelected = runSearch(nodeIndex, query, operator, exact)
+      }
+      if (isEdgeTargetSelected) {
+        edgesToBeSelected = runSearch(edgeIndex, query, operator, exact)
+      }
+
+      logUi.info(`[${startSearch.name}]: Search complete. Nodes: ${nodesToBeSelected.length}, Edges: ${edgesToBeSelected.length}`)
+
+      exclusiveSelect(networkId, nodesToBeSelected, edgesToBeSelected)
+
+      const isAnyTargetSelected = isNodeTargetSelected || isEdgeTargetSelected
+
+      if (
+        isAnyTargetSelected &&
+        query !== '' &&
+        nodesToBeSelected.length === 0 &&
+        edgesToBeSelected.length === 0
+      ) {
+        logUi.info(`[${startSearch.name}]: No results found. Showing message.`)
+        addMessage({
+          message: `No matches for search term "${query}" found in the active network`,
+          severity: MessageSeverity.INFO,
+        })
+      } else if (!isAnyTargetSelected && query !== '') {
+        logUi.warn(`[${startSearch.name}]: No search target selected.`)
+        addMessage({
+          message: 'No search target selected. Please select nodes and/or edges.',
+          severity: MessageSeverity.WARNING,
+        })
+      }
+    } finally {
+      setSearchState(SearchState.DONE)
     }
-
-    const nodeIndex = indices[GraphObjectType.NODE]
-    const edgeIndex = indices[GraphObjectType.EDGE]
-
-    if (nodeIndex === undefined || edgeIndex === undefined) {
-      logUi.warn(`[${startSearch.name}]: Node or edge index undefined for network ${networkId}`)
-      addMessage({
-        message: 'Search index incomplete. Please wait.',
-        severity: MessageSeverity.WARNING,
-      })
-      return
-    }
-
-    // Clear selection
-    exclusiveSelect(networkId, [], [])
-
-    const operator: Operator = searchOptions.operator
-    let nodesToBeSelected: IdType[] = []
-    let edgesToBeSelected: IdType[] = []
-
-    logUi.info(`[${startSearch.name}]: Executing search. Query: "${query}", Targets:`, searchTargets)
-
-    if (searchTargets[GraphObjectType.NODE]) {
-      nodesToBeSelected = runSearch(nodeIndex, query, operator, exact)
-    }
-    if (searchTargets[GraphObjectType.EDGE]) {
-      edgesToBeSelected = runSearch(edgeIndex, query, operator, exact)
-    }
-
-    logUi.info(`[${startSearch.name}]: Search complete. Nodes: ${nodesToBeSelected.length}, Edges: ${edgesToBeSelected.length}`)
-
-    exclusiveSelect(networkId, nodesToBeSelected, edgesToBeSelected)
-
-    const isSearchTargetSelected =
-      searchTargets[GraphObjectType.NODE] || searchTargets[GraphObjectType.EDGE]
-
-    if (
-      isSearchTargetSelected &&
-      query !== '' &&
-      nodesToBeSelected.length === 0 &&
-      edgesToBeSelected.length === 0
-    ) {
-      logUi.info(`[${startSearch.name}]: No results found. Showing message.`)
-      addMessage({
-        message: `No matches for search term "${query}" found in the active network`,
-        severity: MessageSeverity.INFO,
-      })
-    } else if (!isSearchTargetSelected && query !== '') {
-      logUi.warn(`[${startSearch.name}]: No search target selected.`)
-      addMessage({
-        message: 'No search target selected. Please select nodes and/or edges.',
-        severity: MessageSeverity.WARNING,
-      })
-    }
-
-    setSearchState(SearchState.DONE)
   }
 
   const reIndex = (forceUpdate: boolean): void => {

--- a/src/features/ToolBar/Search/SearchBox.tsx
+++ b/src/features/ToolBar/Search/SearchBox.tsx
@@ -99,15 +99,38 @@ export const SearchBox = (): JSX.Element => {
   }
 
   const startSearch = (): void => {
+    if (networkId === undefined || networkId === '') {
+      logUi.warn(`[${startSearch.name}]: No network ID found`)
+      addMessage({
+        message: 'No network selected for search.',
+        severity: MessageSeverity.WARNING,
+      })
+      return
+    }
+
     setSearchState(SearchState.IN_PROGRESS)
     // Node and edge
     const indices: Indices<Fuse<Record<string, ValueType>>> =
       indexRecord[networkId]
 
+    if (indices === undefined) {
+      logUi.warn(`[${startSearch.name}]: No search indices found for network ${networkId}`)
+      addMessage({
+        message: 'Search index not ready. Please wait.',
+        severity: MessageSeverity.WARNING,
+      })
+      return
+    }
+
     const nodeIndex = indices[GraphObjectType.NODE]
     const edgeIndex = indices[GraphObjectType.EDGE]
 
     if (nodeIndex === undefined || edgeIndex === undefined) {
+      logUi.warn(`[${startSearch.name}]: Node or edge index undefined for network ${networkId}`)
+      addMessage({
+        message: 'Search index incomplete. Please wait.',
+        severity: MessageSeverity.WARNING,
+      })
       return
     }
 
@@ -118,6 +141,8 @@ export const SearchBox = (): JSX.Element => {
     let nodesToBeSelected: IdType[] = []
     let edgesToBeSelected: IdType[] = []
 
+    logUi.info(`[${startSearch.name}]: Executing search. Query: "${query}", Targets:`, searchTargets)
+
     if (searchTargets[GraphObjectType.NODE]) {
       nodesToBeSelected = runSearch(nodeIndex, query, operator, exact)
     }
@@ -125,16 +150,29 @@ export const SearchBox = (): JSX.Element => {
       edgesToBeSelected = runSearch(edgeIndex, query, operator, exact)
     }
 
+    logUi.info(`[${startSearch.name}]: Search complete. Nodes: ${nodesToBeSelected.length}, Edges: ${edgesToBeSelected.length}`)
+
     exclusiveSelect(networkId, nodesToBeSelected, edgesToBeSelected)
 
+    const isSearchTargetSelected =
+      searchTargets[GraphObjectType.NODE] || searchTargets[GraphObjectType.EDGE]
+
     if (
+      isSearchTargetSelected &&
       query !== '' &&
       nodesToBeSelected.length === 0 &&
       edgesToBeSelected.length === 0
     ) {
+      logUi.info(`[${startSearch.name}]: No results found. Showing message.`)
       addMessage({
-        message: `No matches found for "${query}"`,
+        message: `No matches for search term "${query}" found in the active network`,
         severity: MessageSeverity.INFO,
+      })
+    } else if (!isSearchTargetSelected && query !== '') {
+      logUi.warn(`[${startSearch.name}]: No search target selected.`)
+      addMessage({
+        message: 'No search target selected. Please select nodes and/or edges.',
+        severity: MessageSeverity.WARNING,
       })
     }
 

--- a/src/features/ToolBar/Search/SearchBox.tsx
+++ b/src/features/ToolBar/Search/SearchBox.tsx
@@ -2,12 +2,13 @@ import { Tooltip } from '@mui/material'
 import Fuse from 'fuse.js'
 import { useEffect, useRef, useState } from 'react'
 
-import { logUi } from '../../../debug'
 import { useFilterStore } from '../../../data/hooks/stores/FilterStore'
+import { useMessageStore } from '../../../data/hooks/stores/MessageStore'
 import { useTableStore } from '../../../data/hooks/stores/TableStore'
 import { useUiStateStore } from '../../../data/hooks/stores/UiStateStore'
 import { useViewModelStore } from '../../../data/hooks/stores/ViewModelStore'
 import { useWorkspaceStore } from '../../../data/hooks/stores/WorkspaceStore'
+import { logUi } from '../../../debug'
 import {
   IndexedColumns,
   Indices,
@@ -15,6 +16,7 @@ import {
 } from '../../../models/FilterModel/Search'
 import { SearchState } from '../../../models/FilterModel/SearchState'
 import { IdType } from '../../../models/IdType'
+import { MessageSeverity } from '../../../models/MessageModel'
 import { GraphObjectType } from '../../../models/NetworkModel'
 import { Table, ValueType, ValueTypeName } from '../../../models/TableModel'
 import { Search } from './Search'
@@ -87,6 +89,7 @@ export const SearchBox = (): JSX.Element => {
   const edgeTable: Table = tables?.edgeTable
 
   const exclusiveSelect = useViewModelStore((state) => state.exclusiveSelect)
+  const addMessage = useMessageStore((state) => state.addMessage)
 
   const clearSearch = (): void => {
     setQuery('')
@@ -123,6 +126,18 @@ export const SearchBox = (): JSX.Element => {
     }
 
     exclusiveSelect(networkId, nodesToBeSelected, edgesToBeSelected)
+
+    if (
+      query !== '' &&
+      nodesToBeSelected.length === 0 &&
+      edgesToBeSelected.length === 0
+    ) {
+      addMessage({
+        message: `No matches found for "${query}"`,
+        severity: MessageSeverity.INFO,
+      })
+    }
+
     setSearchState(SearchState.DONE)
   }
 


### PR DESCRIPTION
Fixed issue where no feedback was displayed when search yielded zero matches. Added a snackbar alert using `useMessageStore`.