### PR TITLE
CW-672: Skip tab reload if a service app task is running

### DIFF
--- a/src/features/SyncTabs.tsx
+++ b/src/features/SyncTabs.tsx
@@ -9,6 +9,8 @@ import {
   putTimestampToDb,
 } from '../data/db'
 import { logUi } from '../debug'
+import { ServiceStatus } from '../models/AppModel/ServiceStatus'
+import { useAppStore } from '../data/hooks/stores/AppStore'
 
 const markForPageReload = debounce(() => {
   void putTimestampToDb(Date.now())
@@ -25,6 +27,18 @@ export const SyncTabsAction = (): ReactElement => {
       if (document.hidden) {
         setLocalTimestamp(Date.now())
       } else {
+        const { currentTask } = useAppStore.getState()
+        const isTaskRunning =
+          currentTask?.status === ServiceStatus.Submitted ||
+          currentTask?.status === ServiceStatus.Processing
+
+        if (isTaskRunning) {
+          logUi.warn(
+            `[${SyncTabsAction.name}]: Page reload skipped because a service app task is running: ${currentTask.id}`,
+          )
+          return
+        }
+
         void getTimestampFromDb().then(async (timestamp) => {
           const workspace = await getWorkspaceFromDb(workspaceId)
 


### PR DESCRIPTION
## Summary
Prevents tab reloads from interrupting active service app tasks.

## Changes
- Updated SyncTabsAction to check currentTask status before reloading.
- Skips reload if task is in 'submitted' or 'processing' state.

## Testing
- Verified that reload logic now checks AppStore for active tasks.

## Jira
CW-672