### PR TITLE
CW-662: Add undo/redo support for continuous mappings

### DIFF
--- a/src/data/hooks/useUndoStack.tsx
+++ b/src/data/hooks/useUndoStack.tsx
@@ -377,6 +377,9 @@ export const useUndoStack = () => {
       [UndoCommandType.DELETE_DISCRETE_VALUE_MAP]: (params: any[]) => {
         setMapping(params[0], params[1], params[2])
       },
+      [UndoCommandType.SET_CONTINUOUS_MAPPING]: (params: any[]) => {
+        setMapping(params[0], params[1], params[2])
+      },
     }
 
     const lastEdit = undoStack[undoStack.length - 1]
@@ -644,6 +647,9 @@ export const useUndoStack = () => {
       },
       [UndoCommandType.DELETE_DISCRETE_VALUE]: (params: any[]) => {
         deleteDiscreteMappingValue(params[0], params[1], params[2])
+      },
+      [UndoCommandType.SET_CONTINUOUS_MAPPING]: (params: any[]) => {
+        setMapping(params[0], params[1], params[2])
       },
     }
     const lastEdit = redoStack[redoStack.length - 1]

--- a/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
+++ b/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousColorMappingForm.tsx
@@ -22,7 +22,9 @@ import Draggable from 'react-draggable'
 
 import { ColorPalettePicker } from './ColorPalettePicker'
 import { useVisualStyleStore } from '../../../../../data/hooks/stores/VisualStyleStore'
+import { useUndoStack } from '../../../../../data/hooks/useUndoStack'
 import { IdType } from '../../../../../models/IdType'
+import { UndoCommandType } from '../../../../../models/StoreModel/UndoStoreModel'
 import {
   VisualProperty,
   VisualPropertyValueType,
@@ -144,6 +146,7 @@ export function ContinuousColorMappingForm(props: {
   const setContinuousMappingValues = useVisualStyleStore(
     (state) => state.setContinuousMappingValues,
   )
+  const { postEdit } = useUndoStack()
 
   const valueDomain = [
     minState.value as number,
@@ -179,17 +182,37 @@ export function ContinuousColorMappingForm(props: {
           ltMinVpValue: VisualPropertyValueType,
           gtMaxVpValue: VisualPropertyValueType,
         ) => {
-          setContinuousMappingValues(
-            props.currentNetworkId,
-            props.visualProperty.name,
+          const nextMapping: ContinuousMappingFunction = {
+            ...m,
             min,
             max,
-            handles.map((h) => {
+            controlPoints: handles.map((h) => {
               return {
                 value: h.value,
                 vpValue: h.vpValue,
               }
             }),
+            ltMinVpValue,
+            gtMaxVpValue,
+          }
+
+          postEdit(
+            UndoCommandType.SET_CONTINUOUS_MAPPING,
+            `Update ${props.visualProperty.displayName} continuous mapping`,
+            [
+              props.currentNetworkId,
+              props.visualProperty.name,
+              props.visualProperty.mapping,
+            ],
+            [props.currentNetworkId, props.visualProperty.name, nextMapping],
+          )
+
+          setContinuousMappingValues(
+            props.currentNetworkId,
+            props.visualProperty.name,
+            min,
+            max,
+            nextMapping.controlPoints,
             ltMinVpValue,
             gtMaxVpValue,
           )

--- a/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -21,7 +21,9 @@ import * as React from 'react'
 import Draggable from 'react-draggable'
 
 import { useVisualStyleStore } from '../../../../../data/hooks/stores/VisualStyleStore'
+import { useUndoStack } from '../../../../../data/hooks/useUndoStack'
 import { IdType } from '../../../../../models/IdType'
+import { UndoCommandType } from '../../../../../models/StoreModel/UndoStoreModel'
 import {
   VisualProperty,
   VisualPropertyValueType,
@@ -81,6 +83,7 @@ export function ContinuousNumberMappingForm(props: {
   const setContinuousMappingValues = useVisualStyleStore(
     (state) => state.setContinuousMappingValues,
   )
+  const { postEdit } = useUndoStack()
 
   const LINE_CHART_WIDTH = 600
   const LINE_CHART_HEIGHT = 275
@@ -157,17 +160,37 @@ export function ContinuousNumberMappingForm(props: {
           ltMinVpValue: VisualPropertyValueType,
           gtMaxVpValue: VisualPropertyValueType,
         ) => {
-          setContinuousMappingValues(
-            props.currentNetworkId,
-            props.visualProperty.name,
+          const nextMapping: ContinuousMappingFunction = {
+            ...m,
             min,
             max,
-            handles.map((h) => {
+            controlPoints: handles.map((h) => {
               return {
                 value: h.value,
                 vpValue: h.vpValue,
               }
             }),
+            ltMinVpValue,
+            gtMaxVpValue,
+          }
+
+          postEdit(
+            UndoCommandType.SET_CONTINUOUS_MAPPING,
+            `Update ${props.visualProperty.displayName} continuous mapping`,
+            [
+              props.currentNetworkId,
+              props.visualProperty.name,
+              props.visualProperty.mapping,
+            ],
+            [props.currentNetworkId, props.visualProperty.name, nextMapping],
+          )
+
+          setContinuousMappingValues(
+            props.currentNetworkId,
+            props.visualProperty.name,
+            min,
+            max,
+            nextMapping.controlPoints,
             ltMinVpValue,
             gtMaxVpValue,
           )

--- a/src/models/StoreModel/UndoStoreModel.ts
+++ b/src/models/StoreModel/UndoStoreModel.ts
@@ -26,6 +26,7 @@ export const UndoCommandType = {
   DELETE_EDGES: 'DELETE_EDGES',
   CREATE_NODES: 'CREATE_NODES',
   CREATE_EDGES: 'CREATE_EDGES',
+  SET_CONTINUOUS_MAPPING: 'SET_CONTINUOUS_MAPPING',
 } as const
 
 export type UndoCommandType =


### PR DESCRIPTION
This PR fixes a bug where edits to continuous mappings in the Vizmapper were not registered in the application's undo/redo stack.

Changes:
- Added SET_CONTINUOUS_MAPPING to UndoCommandType in UndoStoreModel.ts
- Handled SET_CONTINUOUS_MAPPING in useUndoStack.tsx (calls setMapping for both undo and redo)
- Integrated postEdit from useUndoStack into ContinuousColorMappingForm.tsx and ContinuousNumberMappingForm.tsx inside the debounced update handlers.

This ensures that changes like color gradient adjustments and node size range updates can be reversed using the standard Undo/Redo commands.