### PR TITLE
Fix/cw 683 - New node is not always created within the viewport

### DIFF
--- a/src/features/ToolBar/EditMenu/CreateNodeMenuItem.tsx
+++ b/src/features/ToolBar/EditMenu/CreateNodeMenuItem.tsx
@@ -5,6 +5,7 @@ import { useNetworkSummaryStore } from '../../../data/hooks/stores/NetworkSummar
 import { useRendererStore } from '../../../data/hooks/stores/RendererStore'
 import { useUiStateStore } from '../../../data/hooks/stores/UiStateStore'
 import { useViewModelStore } from '../../../data/hooks/stores/ViewModelStore'
+import { useVisualStyleStore } from '../../../data/hooks/stores/VisualStyleStore'
 import { useWorkspaceStore } from '../../../data/hooks/stores/WorkspaceStore'
 import { useCreateNode } from '../../../data/hooks/useCreateNode'
 import { isHCX } from '../../../features/HierarchyViewer/utils/hierarchyUtil'
@@ -39,6 +40,7 @@ export const CreateNodeMenuItem = (props: BaseMenuProps): ReactElement => {
   )
 
   const getViewport = useRendererStore((state) => state.getViewport)
+  const visualStyles = useVisualStyleStore((state) => state.visualStyles)
 
   // Check if current view supports creation
   const canCreateInView = (): boolean => {
@@ -65,11 +67,24 @@ export const CreateNodeMenuItem = (props: BaseMenuProps): ReactElement => {
   const handleCreateNode = (): void => {
     // Get the viewport center (pan position)
     const viewport = getViewport('cyjs', currentNetworkId)
-    const centerX = viewport?.pan.x ?? 0
-    const centerY = viewport?.pan.y ?? 0
+    const panX = viewport?.pan.x ?? 0
+    const panY = viewport?.pan.y ?? 0
+    const zoom = viewport?.zoom ?? 1
+
+    // Random padding between 5 and 50, so multiple added nodes don't overlap exactly on top of each other
+    const pad = Math.floor(Math.random() * 45) + 5
+    // Get the default node width and height from the visual style
+    const defNodeWidth = visualStyles[currentNetworkId]?.nodeWidth?.defaultValue ?? 50
+    const defNodeHeight = visualStyles[currentNetworkId]?.nodeHeight?.defaultValue ?? 50
+    // Calculate an offset to ensure the new node is fully visible within the viewport,
+    // based on the default node size and the padding
+    const offset = Math.max(defNodeWidth as number, defNodeHeight as number) / 2 + pad
+    // Calculate the position to place the new node in the top-left corner, adjusted for pan, zoom and offset
+    const x = -panX / zoom + offset
+    const y = -panY / zoom + offset
 
     // Create node directly with default empty attributes
-    createNode(currentNetworkId, [centerX, centerY], { attributes: {} })
+    createNode(currentNetworkId, [x, y], { attributes: {} })
     props.handleClose()
   }
 

--- a/src/features/ToolBar/EditMenu/CreateNodeMenuItem.tsx
+++ b/src/features/ToolBar/EditMenu/CreateNodeMenuItem.tsx
@@ -41,6 +41,7 @@ export const CreateNodeMenuItem = (props: BaseMenuProps): ReactElement => {
 
   const getViewport = useRendererStore((state) => state.getViewport)
   const visualStyles = useVisualStyleStore((state) => state.visualStyles)
+  const visualStyleOption = useUiStateStore((state) => state.ui.visualStyleOptions[currentNetworkId])
 
   // Check if current view supports creation
   const canCreateInView = (): boolean => {
@@ -74,14 +75,17 @@ export const CreateNodeMenuItem = (props: BaseMenuProps): ReactElement => {
     // Random padding between 5 and 50, so multiple added nodes don't overlap exactly on top of each other
     const pad = Math.floor(Math.random() * 45) + 5
     // Get the default node width and height from the visual style
-    const defNodeWidth = visualStyles[currentNetworkId]?.nodeWidth?.defaultValue ?? 50
-    const defNodeHeight = visualStyles[currentNetworkId]?.nodeHeight?.defaultValue ?? 50
+    const style = visualStyles[currentNetworkId]
+    const defNodeWidth = style?.nodeWidth?.defaultValue ?? 50
+    const defNodeHeight = style?.nodeHeight?.defaultValue ?? 50
     // Calculate an offset to ensure the new node is fully visible within the viewport,
     // based on the default node size and the padding
-    const offset = Math.max(defNodeWidth as number, defNodeHeight as number) / 2 + pad
+    const nodeSizeLocked = visualStyleOption?.visualEditorProperties?.nodeSizeLocked
+    const offsetY = (defNodeHeight as number) / 2 + pad
+    const offsetX = nodeSizeLocked ? offsetY : (defNodeWidth as number) / 2 + pad // if node size locked, use height for both width and height
     // Calculate the position to place the new node in the top-left corner, adjusted for pan, zoom and offset
-    const x = -panX / zoom + offset
-    const y = -panY / zoom + offset
+    const x = -panX / zoom + offsetX
+    const y = -panY / zoom + offsetY
 
     // Create node directly with default empty attributes
     createNode(currentNetworkId, [x, y], { attributes: {} })


### PR DESCRIPTION
The new node is now added to top-left corner of the viewport, plus a small padding.
I think this is better than adding the node to the center, because the center of the viewport is usually more crowded than the corners, which means the new node would overlap other nodes more often.

When testing, please make sure to test with different zoom levels (after zooming in and out) and after panning the network. Also test with the option "Lock node width and height" checked and then unchecked--when unchecked, make sure the width and height have different values.

Issue: [CW-683](https://cytoscape.atlassian.net/jira/software/projects/CW/issues?jql=project+%3D+CW+ORDER+BY+updated+DESC%2C+cf%5B10005%5D+ASC&selectedIssue=CW-683&atlOrigin=eyJpIjoiZGRiN2VjZDM4NTZiNGYyZDkxMzc1YWJmMmMzZWIzYWUiLCJwIjoiaiJ9)

[CW-683]: https://cytoscape.atlassian.net/browse/CW-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ