### PR TITLE
Fix/cw 709

### DIFF
--- a/src/features/ToolBar/AnalysisMenu/index.tsx
+++ b/src/features/ToolBar/AnalysisMenu/index.tsx
@@ -1,29 +1,21 @@
-import Button from '@mui/material/Button'
-import Menu from '@mui/material/Menu'
-import { PrimeReactProvider } from 'primereact/api'
-import { OverlayPanel } from 'primereact/overlaypanel'
-import { TieredMenu } from 'primereact/tieredmenu'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 import {
   LLMQueryOptionsMenuItem,
   RunLLMQueryMenuItem,
 } from '../../LLMQuery/components'
 import { DropdownMenuProps } from '../DropdownMenuProps'
+import { DropdownMenu } from '../DropdownMenu'
 
 export const AnalysisMenu: React.FC<DropdownMenuProps> = (
   props: DropdownMenuProps,
 ) => {
   const { label } = props
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
+  const [open, setOpen] = useState(false)
 
   const handleClose = (): void => {
-    ;(op.current as any)?.hide()
-    setAnchorEl(null)
+    setOpen(false)
   }
-
-  const op = useRef(null)
 
   const menuItems = [
     {
@@ -37,24 +29,12 @@ export const AnalysisMenu: React.FC<DropdownMenuProps> = (
   ]
 
   return (
-    <PrimeReactProvider>
-      <Button
-        data-testid="toolbar-analysis-menu-button"
-        sx={{
-          color: 'white',
-          textTransform: 'none',
-        }}
-        id={label}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={(e) => (op.current as any)?.toggle(e)}
-      >
-        {label}
-      </Button>
-      <OverlayPanel ref={op} unstyled>
-        <TieredMenu model={menuItems} />
-      </OverlayPanel>
-    </PrimeReactProvider>
+    <DropdownMenu
+      id={label}
+      label={label}
+      menuItems={menuItems}
+      open={open}
+      onOpenChange={setOpen}
+    />
   )
 }

--- a/src/features/ToolBar/AppMenu/index.tsx
+++ b/src/features/ToolBar/AppMenu/index.tsx
@@ -1,8 +1,6 @@
-import { Button, Divider, useTheme } from '@mui/material'
+import { Divider } from '@mui/material'
 import { MenuItem } from 'primereact/menuitem'
-import { OverlayPanel } from 'primereact/overlaypanel'
-import { TieredMenu } from 'primereact/tieredmenu'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { logApp } from '../../../debug'
 import { useAppStore } from '../../../data/hooks/stores/AppStore'
@@ -18,12 +16,12 @@ import { TaskStatusDialog } from '../../AppManager/TaskStatusDialog'
 import { ConfirmationDialog } from '../../ConfirmationDialog'
 import { DropdownMenuProps } from '../DropdownMenuProps'
 import { createMenuItems } from './MenuFactory'
+import { DropdownMenu } from '../DropdownMenu'
 
 export const AppMenu = (props: DropdownMenuProps) => {
-  const theme = useTheme()
-
   const run = useServiceTaskRunner()
 
+  const [open, setOpen] = useState<boolean>(false)
   const [isInitialClick, setIsInitialClick] = useState<boolean>(false)
 
   // Actual CyApp objects
@@ -31,8 +29,6 @@ export const AppMenu = (props: DropdownMenuProps) => {
   const [appStateUpdated, setAppStateUpdated] = useState<boolean>(false)
 
   const { label } = props
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
 
   // For the app settings dialog
   const [openDialog, setOpenDialog] = useState<boolean>(false)
@@ -54,23 +50,17 @@ export const AppMenu = (props: DropdownMenuProps) => {
    */
   const [menuModel, setMenuModel] = useState<MenuItem[]>([])
 
-  const menuRef = useRef(null)
-
   const serviceApps: Record<string, ServiceApp> = useAppStore(
     (state) => state.serviceApps,
   )
 
   const handleOpenDialog = (isDialogOpen: boolean): void => {
-    setAnchorEl(null)
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.hide()
+    setOpen(false)
     setOpenDialog(isDialogOpen)
   }
 
   const handleRun = async (url: string): Promise<void> => {
-    setAnchorEl(null)
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.hide()
+    setOpen(false)
 
     // Now run the task
     setOpenTaskDialog(true)
@@ -95,9 +85,7 @@ export const AppMenu = (props: DropdownMenuProps) => {
   }
 
   const handleClose = (): void => {
-    setAnchorEl(null)
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.hide()
+    setOpen(false)
   }
 
   useEffect(() => {
@@ -165,8 +153,7 @@ export const AppMenu = (props: DropdownMenuProps) => {
   useEffect(() => {
     // Create base menu items
     setMenuModel(getBaseMenu())
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.hide()
+    setOpen(false)
   }, [])
 
   const createAppMenu = (): MenuItem[] => {
@@ -183,42 +170,25 @@ export const AppMenu = (props: DropdownMenuProps) => {
     return appMenuItems
   }
 
-  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
-    if (menuRef.current === null) {
-      return
-    }
-    if (!isInitialClick) {
+  // TODO test whether this behavior is still correct after refactoring (no more button click events)
+  useEffect(() => {
+    if (open && !isInitialClick) {
       setIsInitialClick(true)
       const appMenuItems: MenuItem[] = createAppMenu()
       const menuModel: MenuItem[] = createMenuItems(serviceApps, handleRun)
       setMenuModel([...appMenuItems, ...menuModel, ...getBaseMenu()])
     }
-
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.toggle(e)
-  }
+  }, [open])
 
   return (
     <>
-      <Button
-        data-testid="toolbar-app-menu-button"
-        sx={{
-          color: theme.palette.common.white,
-          textTransform: 'none',
-        }}
+      <DropdownMenu
         id={label}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={(e) => {
-          handleClick(e)
-        }}
-      >
-        {label}
-      </Button>
-      <OverlayPanel ref={menuRef} unstyled>
-        <TieredMenu style={{ width: 350 }} model={menuModel} />
-      </OverlayPanel>
+        label={label}
+        menuItems={menuModel}
+        open={open}
+        onOpenChange={setOpen}
+      />
       <AppSettingsDialog
         openDialog={openDialog}
         setOpenDialog={setOpenDialog}

--- a/src/features/ToolBar/DataMenu/index.tsx
+++ b/src/features/ToolBar/DataMenu/index.tsx
@@ -1,11 +1,7 @@
 import './menuItem.css'
 
 import { Divider } from '@mui/material'
-import Button from '@mui/material/Button'
-import { PrimeReactProvider } from 'primereact/api'
-import { OverlayPanel } from 'primereact/overlaypanel'
-import { TieredMenu } from 'primereact/tieredmenu'
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 
 import { JoinTableToNetworkMenuItem } from '../../TableDataLoader/components/JoinTableToNetwork/JoinTableToNetworkMenuItem'
 import { DropdownMenuProps } from '../DropdownMenuProps'
@@ -23,18 +19,16 @@ import { ResetLocalWorkspaceMenuItem } from './ResetLocalWorkspace'
 import { SaveToNDExMenuItem } from './SaveToNDExMenuItem'
 import { SaveWorkspaceToNDExMenuItem } from './SaveWorkspaceToNDEx'
 import { SaveWorkspaceToNDExOverwriteMenuItem } from './SaveWorkspaceToNDExOverwrite'
+import { DropdownMenu } from '../DropdownMenu'
 
 export const DataMenu: React.FC<DropdownMenuProps> = (
   props: DropdownMenuProps,
 ) => {
   const { label } = props
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const op = useRef(null)
-  const open = Boolean(anchorEl)
+  const [open, setOpen] = useState(false)
 
   const handleClose = (): void => {
-    ;(op.current as any)?.hide()
-    setAnchorEl(null)
+    setOpen(false)
   }
 
   const menuItems = [
@@ -133,24 +127,12 @@ export const DataMenu: React.FC<DropdownMenuProps> = (
   ]
 
   return (
-    <PrimeReactProvider>
-      <Button
-        data-testid="toolbar-data-menu-button"
-        sx={{
-          color: 'white',
-          textTransform: 'none',
-        }}
-        id={label}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={(e) => (op.current as any)?.toggle(e)}
-      >
-        {label}
-      </Button>
-      <OverlayPanel ref={op} unstyled>
-        <TieredMenu style={{ width: 350 }} model={menuItems} />
-      </OverlayPanel>
-    </PrimeReactProvider>
+    <DropdownMenu
+      id={label}
+      label={label}
+      menuItems={menuItems}
+      open={open}
+      onOpenChange={setOpen}
+    />
   )
 }

--- a/src/features/ToolBar/DropdownMenu.tsx
+++ b/src/features/ToolBar/DropdownMenu.tsx
@@ -23,19 +23,19 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   open = false,
   onOpenChange,
 }) => {
-  const overlayPanelRef = useRef(null)
+  const overlayPanelRef = useRef<OverlayPanel>(null)
 
   useEffect(() => {
     if (!open) {
-      (overlayPanelRef.current as any)?.hide()
+      overlayPanelRef.current?.hide()
     }
   }, [open])
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
-    (overlayPanelRef.current as any)?.toggle(event)
+    overlayPanelRef.current?.toggle(event)
   }
 
-  // If the cytoscape container exists, use its bounding rect to position the overlay,
+  // If the cytoscape container exists, use its bounding rect to position the "click outside" overlay,
   // otherwise default to covering the entire viewport
   const cyContainer = document.getElementById('cy-container')
   const overlayTarget = cyContainer ? cyContainer : 'body'
@@ -44,7 +44,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
   return (
     <>
     {open && (
-      // Invisible overlay to capture clicks outside the menu
+      // Invisible "click outside" overlay to capture clicks outside the menu
       <Box
         sx={{
           position: 'fixed',
@@ -55,7 +55,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
           zIndex: 1000, // Just below the menu
         }}
         onClick={() => {
-          ;(overlayPanelRef.current as any)?.hide()
+          overlayPanelRef.current?.hide()
           onOpenChange?.(false)
         }}
       />

--- a/src/features/ToolBar/DropdownMenu.tsx
+++ b/src/features/ToolBar/DropdownMenu.tsx
@@ -35,20 +35,28 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     (overlayPanelRef.current as any)?.toggle(event)
   }
 
+  // If the cytoscape container exists, use its bounding rect to position the overlay,
+  // otherwise default to covering the entire viewport
+  const cyContainer = document.getElementById('cy-container')
+  const overlayTarget = cyContainer ? cyContainer : 'body'
+  const overlayTargetRect = overlayTarget !== 'body' ? overlayTarget.getBoundingClientRect() : null
+
   return (
     <>
     {open && (
-      // Full-screen invisible overlay to capture clicks outside the menu
+      // Invisible overlay to capture clicks outside the menu
       <Box
         sx={{
-          position: 'fixed', 
-          top: 0, left: 0, 
-          width: '100vw', height: '100vh', 
+          position: 'fixed',
+          top: overlayTargetRect ? overlayTargetRect.top : 0,
+          left: overlayTargetRect ? overlayTargetRect.left : 0,
+          width: overlayTargetRect ? overlayTargetRect.width : '100vw',
+          height: overlayTargetRect ? overlayTargetRect.height : '100vh',
           zIndex: 1000, // Just below the menu
         }}
         onClick={() => {
-          (overlayPanelRef.current as any)?.hide();
-          onOpenChange?.(false);
+          ;(overlayPanelRef.current as any)?.hide()
+          onOpenChange?.(false)
         }}
       />
     )}

--- a/src/features/ToolBar/DropdownMenu.tsx
+++ b/src/features/ToolBar/DropdownMenu.tsx
@@ -1,54 +1,134 @@
-import Button from '@mui/material/Button'
-import Menu from '@mui/material/Menu'
-import MenuItem from '@mui/material/MenuItem'
+import { Button, Tooltip } from '@mui/material'
+import { Box } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { PrimeReactProvider } from 'primereact/api'
+import { OverlayPanel } from 'primereact/overlaypanel'
+import { TieredMenu } from 'primereact/tieredmenu'
 import * as React from 'react'
+import { useEffect, useRef } from 'react'
+
+
 interface DropdownMenuProps {
+  id: string
   label: string
-  children?: React.ReactNode
+  menuItems: any[]
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
-export const DropdownMenu: React.FC<DropdownMenuProps> = (props) => {
-  const { label } = props
+export const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  id,
+  label,
+  menuItems,
+  open = false,
+  onOpenChange,
+}) => {
+  const overlayPanelRef = useRef(null)
 
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
+  useEffect(() => {
+    if (!open) {
+      (overlayPanelRef.current as any)?.hide()
+    }
+  }, [open])
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
-    setAnchorEl(event.currentTarget)
+    (overlayPanelRef.current as any)?.toggle(event)
   }
-
-  const handleClose = (): void => {
-    setAnchorEl(null)
-  }
-
-  const labelId = `${label}-dropdown`
 
   return (
-    <div>
-      <Button
+    <>
+    {open && (
+      // Full-screen invisible overlay to capture clicks outside the menu
+      <Box
         sx={{
-          color: 'white',
-          textTransform: 'none',
+          position: 'fixed', 
+          top: 0, left: 0, 
+          width: '100vw', height: '100vh', 
+          zIndex: 1000, // Just below the menu
         }}
-        id={labelId}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={handleClick}
-      >
-        {label}
-      </Button>
-      <Menu
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        MenuListProps={{
-          'aria-labelledby': labelId,
+        onClick={() => {
+          (overlayPanelRef.current as any)?.hide();
+          onOpenChange?.(false);
         }}
-      >
-        <MenuItem onClick={handleClose}>Menu Item</MenuItem>
-        <MenuItem onClick={handleClose}>Menu Item</MenuItem>
-        <MenuItem onClick={handleClose}>Menu Item</MenuItem>
-      </Menu>
-    </div>
+      />
+    )}
+      <PrimeReactProvider>
+        <Button
+          data-testid={`toolbar-${id}-menu-button`}
+          sx={{
+            color: 'white',
+            textTransform: 'none',
+          }}
+          id={`${id}-dropdown`}
+          aria-controls={open ? 'basic-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClick}
+        >
+          {label}
+        </Button>
+        <OverlayPanel
+          ref={overlayPanelRef}
+          onShow={() => onOpenChange?.(true)}
+          onHide={() => onOpenChange?.(false)}
+          unstyled
+        >
+          <TieredMenu
+            style={{ 
+              minWidth: 350,
+              maxWidth: 500,
+              boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.15)',
+            }}
+            model={menuItems}
+          />
+        </OverlayPanel>
+      </PrimeReactProvider>
+    </>
+  )
+}
+
+interface DropdownMenuItemProps {
+  label: string
+  tooltip?: string
+  icon?: React.ReactNode
+  disabled?: boolean
+  onClick?: () => void
+}
+
+export const DropdownMenuItem: React.FC<DropdownMenuItemProps> = ({
+  label,
+  tooltip = '',
+  icon = null,
+  disabled = false,
+  onClick,
+}) => {
+  const theme = useTheme()
+
+  return (
+    <Tooltip title={tooltip} placement="right">
+      <span>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            padding: '4px 16px',
+            cursor: disabled ? 'default' : 'pointer',
+            color: disabled ? theme.palette.text.disabled : theme.palette.text.primary,
+            '&:hover': {
+              backgroundColor: disabled ? theme.palette.background.paper : theme.palette.action.hover,
+            },
+          }}
+          onClick={() => {
+            if (!disabled && onClick) {
+              onClick()
+            }
+          }}
+        >
+          <Box sx={{ width: 24, height: 24 }}>{icon}</Box>
+          <Box>{label}</Box>
+        </Box>
+      </span>
+    </Tooltip>
   )
 }

--- a/src/features/ToolBar/EditMenu/index.tsx
+++ b/src/features/ToolBar/EditMenu/index.tsx
@@ -1,5 +1,3 @@
-import Button from '@mui/material/Button'
-import Menu from '@mui/material/Menu'
 import { useState } from 'react'
 
 import { DropdownMenuProps } from '../DropdownMenuProps'
@@ -9,54 +7,48 @@ import { DeleteSelectedEdgesMenuItem } from './DeleteSelectedEdgesMenuItem'
 import { DeleteSelectedNodesMenuItem } from './DeleteSelectedNodesMenuItem'
 import { RedoMenuItem } from './RedoMenuItem'
 import { UndoMenuItem } from './UndoMenuItem'
+import { DropdownMenu } from '../DropdownMenu'
+import { Divider } from '@mui/material'
 
 export const EditMenu = (props: DropdownMenuProps): JSX.Element => {
   const { label } = props
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-
-  const handleOpenDropdownMenu = (
-    event: React.MouseEvent<HTMLButtonElement>,
-  ): void => {
-    setAnchorEl(event.currentTarget)
-  }
+  const [open, setOpen] = useState(false)
 
   const handleClose = (): void => {
-    setAnchorEl(null)
+    setOpen(false)
   }
 
+  const menuItems = [
+    {
+      template: <CreateNodeMenuItem handleClose={handleClose} />,
+    },
+    {
+      template: <CreateEdgeMenuItem handleClose={handleClose} />,
+    },
+    {
+      template: <DeleteSelectedNodesMenuItem handleClose={handleClose} />,
+    },
+    {
+      template: <DeleteSelectedEdgesMenuItem handleClose={handleClose} />,
+    },
+    {
+      template: <Divider />,
+    },
+    {
+      template: <UndoMenuItem handleClose={handleClose} />,
+    },
+    {
+      template: <RedoMenuItem handleClose={handleClose} />,
+    },
+  ]
+
   return (
-    <div>
-      <Button
-        data-testid="toolbar-edit-menu-button"
-        sx={{
-          color: 'white',
-          textTransform: 'none',
-        }}
-        id={label}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={handleOpenDropdownMenu}
-      >
-        {label}
-      </Button>
-      <Menu
-        data-testid="toolbar-edit-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
-        MenuListProps={{
-          'aria-labelledby': label,
-        }}
-      >
-        <CreateNodeMenuItem handleClose={handleClose} />
-        <CreateEdgeMenuItem handleClose={handleClose} />
-        <DeleteSelectedNodesMenuItem handleClose={handleClose} />
-        <DeleteSelectedEdgesMenuItem handleClose={handleClose} />
-        <UndoMenuItem handleClose={handleClose} />
-        <RedoMenuItem handleClose={handleClose} />
-      </Menu>
-    </div>
+    <DropdownMenu
+      id={label}
+      label={label}
+      menuItems={menuItems}
+      open={open}
+      onOpenChange={setOpen}
+    />
   )
 }

--- a/src/features/ToolBar/HelpMenu/index.tsx
+++ b/src/features/ToolBar/HelpMenu/index.tsx
@@ -1,11 +1,7 @@
 import '../DataMenu/menuItem.css'
 
 import { Divider } from '@mui/material'
-import Button from '@mui/material/Button'
-import { PrimeReactProvider } from 'primereact/api'
-import { OverlayPanel } from 'primereact/overlaypanel'
-import { TieredMenu } from 'primereact/tieredmenu'
-import { useRef } from 'react'
+import { useState } from 'react'
 
 import { DropdownMenuProps } from '../DropdownMenuProps'
 import { AboutCytoscapeWebMenuItem } from './AboutCytoscapeWebMenuItem'
@@ -16,13 +12,14 @@ import { DeveloperMenuItem } from './DeveloperMenuItem'
 import { ExportDatabaseMenuItem } from './ExportDatabaseMenuItem'
 import { ImportDatabaseMenuItem } from './ImportDatabaseMenuItem'
 import { TutorialMenuItem } from './TutorialMenuItem'
+import { DropdownMenu } from '../DropdownMenu'
 
 export const HelpMenu = (props: DropdownMenuProps): JSX.Element => {
   const { label } = props
-  const op = useRef(null)
+  const [open, setOpen] = useState<boolean>(false)
 
   const handleClose = (): void => {
-    ;(op.current as any)?.hide()
+    setOpen(false)
   }
 
   const menuItems = [
@@ -78,22 +75,12 @@ export const HelpMenu = (props: DropdownMenuProps): JSX.Element => {
   ]
 
   return (
-    <PrimeReactProvider>
-      <Button
-        data-testid="toolbar-help-menu-button"
-        sx={{
-          color: 'white',
-          textTransform: 'none',
-        }}
-        id={label}
-        aria-haspopup="true"
-        onClick={(e) => (op.current as any)?.toggle(e)}
-      >
-        {label}
-      </Button>
-      <OverlayPanel ref={op} unstyled>
-        <TieredMenu style={{ width: 350 }} model={menuItems} />
-      </OverlayPanel>
-    </PrimeReactProvider>
+    <DropdownMenu
+      id={label}
+      label={label}
+      menuItems={menuItems}
+      open={open}
+      onOpenChange={setOpen}
+    />
   )
 }

--- a/src/features/ToolBar/LayoutMenu/index.tsx
+++ b/src/features/ToolBar/LayoutMenu/index.tsx
@@ -22,6 +22,7 @@ import { DEFAULT_RENDERER_ID } from '../../../models/RendererModel/impl/defaultR
 import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
 import { isHCX } from '../../HierarchyViewer/utils/hierarchyUtil'
 import { LayoutOptionDialog } from './LayoutOptionDialog'
+import { DropdownMenu } from '../DropdownMenu'
 
 interface DropdownMenuProps {
   label: string
@@ -29,6 +30,7 @@ interface DropdownMenuProps {
 }
 
 export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
+  const [open, setOpen] = useState(false)
   const [openDialog, setOpenDialog] = useState<boolean>(false)
 
   // Counter to trigger fit function after layout is applied
@@ -100,21 +102,13 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
     targetNetworkId === '' // no network is selected
 
   const { label } = props
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-
-  const menuRef = useRef(null)
 
   const handleClose = (): void => {
-    setAnchorEl(null)
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.hide()
+    setOpen(false)
   }
 
   const handleOpenDialog = (open: boolean): void => {
-    setAnchorEl(null)
-    const menuRefCurrent = menuRef.current as any
-    menuRefCurrent.hide()
+    setOpen(false)
     setOpenDialog(open)
   }
 
@@ -309,34 +303,14 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
   }
 
   return (
-    <PrimeReactProvider>
-      <Button
-        data-testid="toolbar-layout-menu-button"
-        sx={{
-          color: 'white',
-          textTransform: 'none',
-        }}
+    <>
+      <DropdownMenu
         id={label}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={(e) => {
-          if (menuRef.current === null) {
-            return
-          }
-          const menuRefCurrent = menuRef.current as any
-          menuRefCurrent.toggle(e)
-        }}
-      >
-        {label}
-      </Button>
-      <OverlayPanel
-        ref={menuRef}
-        unstyled
-        style={{ minWidth: '25em', maxWidth: '25em' }}
-      >
-        <TieredMenu model={getMenuItems()} style={{ width: '100%' }} />
-      </OverlayPanel>
+        label={label}
+        menuItems={getMenuItems()}
+        open={open}
+        onOpenChange={setOpen}
+      />
       <LayoutOptionDialog
         afterLayout={afterLayout}
         network={target}
@@ -344,6 +318,6 @@ export const LayoutMenu = (props: DropdownMenuProps): JSX.Element => {
         setOpen={setOpenDialog}
         allDisabled={allDisabled}
       />
-    </PrimeReactProvider>
+    </>
   )
 }

--- a/src/features/ToolBar/ToolsMenu/index.tsx
+++ b/src/features/ToolBar/ToolsMenu/index.tsx
@@ -1,25 +1,18 @@
-import Button from '@mui/material/Button'
-import { PrimeReactProvider } from 'primereact/api'
-import { OverlayPanel } from 'primereact/overlaypanel'
-import { TieredMenu } from 'primereact/tieredmenu'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 import { DropdownMenuProps } from '../DropdownMenuProps'
 import { MergeNetwork } from './MergeNetwork'
+import { DropdownMenu } from '../DropdownMenu'
 
 export const ToolsMenu: React.FC<DropdownMenuProps> = (
   props: DropdownMenuProps,
 ) => {
   const { label } = props
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
+  const [open, setOpen] = useState(false)
 
   const handleClose = (): void => {
-    ;(op.current as any)?.hide()
-    setAnchorEl(null)
+    setOpen(false)
   }
-
-  const op = useRef(null)
 
   const menuItems = [
     {
@@ -29,24 +22,12 @@ export const ToolsMenu: React.FC<DropdownMenuProps> = (
   ]
 
   return (
-    <PrimeReactProvider>
-      <Button
-        data-testid="toolbar-tools-menu-button"
-        sx={{
-          color: 'white',
-          textTransform: 'none',
-        }}
-        id={label}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-        onClick={(e) => (op.current as any)?.toggle(e)}
-      >
-        {label}
-      </Button>
-      <OverlayPanel ref={op} unstyled>
-        <TieredMenu model={menuItems} />
-      </OverlayPanel>
-    </PrimeReactProvider>
+    <DropdownMenu
+      id={label}
+      label={label}
+      menuItems={menuItems}
+      open={open}
+      onOpenChange={setOpen}
+    />
   )
 }


### PR DESCRIPTION
The menus now close when clicking the Cytoscape area.
The solution was to add a "click outside" overlay that captures clicks occurring outside the opened menu. The overlay covers only the Cytoscape canvas, allowing other menu buttons to be clicked immediately.