### PR TITLE
feat(app-api): return full element data from ElementApi create/delete methods

### DIFF
--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -131,10 +131,13 @@ Returns an edge's source/target IDs and table attributes.
 | `NETWORK_NOT_FOUND` | `networkId` does not exist                 |
 | `EDGE_NOT_FOUND`    | `edgeId` does not exist in the network     |
 
-#### `createNode(networkId, position, options?): ApiResult<{ nodeId: IdType }>`
+#### `createNode(networkId, position, options?): ApiResult<{ nodeId: IdType; node: NodeData }>`
 
 Creates a new node at the given `[x, y, z?]` position. Adds an undo entry and,
 unless `autoSelect: false`, exclusively selects the new node.
+
+Returns the generated `nodeId` and a `node` object containing the final
+`attributes` and `position` that were written to the stores.
 
 If the node table has a `name` column and no `name` attribute is provided,
 defaults to `"Node <id>"`.
@@ -147,10 +150,13 @@ call required).
 | ------------------- | -------------------------- |
 | `NETWORK_NOT_FOUND` | `networkId` does not exist |
 
-#### `createEdge(networkId, sourceNodeId, targetNodeId, options?): ApiResult<{ edgeId: IdType }>`
+#### `createEdge(networkId, sourceNodeId, targetNodeId, options?): ApiResult<{ edgeId: IdType; edge: EdgeData }>`
 
 Creates a new edge. Edge IDs use the pattern `e<n>`. Adds an undo entry and,
 unless `autoSelect: false`, exclusively selects the new edge.
+
+Returns the generated `edgeId` and an `edge` object containing `sourceId`,
+`targetId`, and the final `attributes` that were written to the stores.
 
 If the edge table has a `name` column and no `name` attribute is provided,
 defaults to `"<source> (interacts with) <target>"`.
@@ -174,10 +180,16 @@ columns in the edge table if they exist. Adds an undo entry.
 | `EDGE_NOT_FOUND`    | `edgeId` does not exist                      |
 | `NODE_NOT_FOUND`    | `newSourceId` or `newTargetId` not found     |
 
-#### `deleteNodes(networkId, nodeIds): ApiResult<{ deletedNodeCount, deletedEdgeCount }>`
+#### `deleteNodes(networkId, nodeIds): ApiResult<{ deletedNodeCount, deletedEdgeCount, deletedNodes, deletedEdges }>`
 
 Deletes the specified nodes and any incident edges. Visual style bypasses for the
 deleted elements are cleaned up. Adds an undo entry.
+
+Returns:
+- `deletedNodeCount` / `deletedEdgeCount` — counts of removed elements
+- `deletedNodes: Array<{ id, attributes, position }>` — full `NodeData` for each deleted node
+- `deletedEdges: Array<{ id, sourceId, targetId, attributes }>` — full `EdgeData` for each
+  incidentally-deleted edge (edges connected to the deleted nodes)
 
 | Error Code          | Condition                               |
 | ------------------- | --------------------------------------- |
@@ -185,9 +197,13 @@ deleted elements are cleaned up. Adds an undo entry.
 | `INVALID_INPUT`     | `nodeIds` is empty                      |
 | `NODE_NOT_FOUND`    | None of the specified nodes exist       |
 
-#### `deleteEdges(networkId, edgeIds): ApiResult<{ deletedEdgeCount }>`
+#### `deleteEdges(networkId, edgeIds): ApiResult<{ deletedEdgeCount, deletedEdges }>`
 
 Deletes the specified edges. Visual style bypasses are cleaned up. Adds an undo entry.
+
+Returns:
+- `deletedEdgeCount` — number of removed edges
+- `deletedEdges: Array<{ id, sourceId, targetId, attributes }>` — full `EdgeData` for each deleted edge
 
 | Error Code          | Condition                               |
 | ------------------- | --------------------------------------- |

--- a/src/app-api/core/elementApi.test.ts
+++ b/src/app-api/core/elementApi.test.ts
@@ -444,7 +444,7 @@ describe('elementApi', () => {
       }
     })
 
-    it('returns ok with nodeId on success', () => {
+    it('returns ok with nodeId and node data on success', () => {
       mockNetworks.set('net1', makeNetwork('net1', [], []))
       mockTables['net1'] = {
         nodeTable: { rows: new Map(), columns: [] },
@@ -455,6 +455,10 @@ describe('elementApi', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.nodeId).toBe('0')
+        expect(result.data.node).toEqual({
+          attributes: {},
+          position: [100, 200],
+        })
       }
     })
 
@@ -585,7 +589,7 @@ describe('elementApi', () => {
       }
     })
 
-    it('returns ok with edgeId on success', () => {
+    it('returns ok with edgeId and edge data on success', () => {
       mockNetworks.set('net1', makeNetwork('net1', [{ id: 'n1' }, { id: 'n2' }], []))
       mockTables['net1'] = {
         nodeTable: { rows: new Map(), columns: [] },
@@ -596,6 +600,11 @@ describe('elementApi', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.edgeId).toBe('e0')
+        expect(result.data.edge).toEqual({
+          sourceId: 'n1',
+          targetId: 'n2',
+          attributes: {},
+        })
       }
     })
 
@@ -750,14 +759,14 @@ describe('elementApi', () => {
       }
     })
 
-    it('returns ok with deletion counts on success', () => {
+    it('returns ok with deletion counts and element data on success', () => {
       jest.mocked(deleteNodesCore).mockReturnValue({
         deletedNodeIds: ['n1'],
         deletedEdges: [{ id: 'e1', s: 'n1', t: 'n2' }],
-        deletedNodeViews: [],
+        deletedNodeViews: [{ id: 'n1', x: 10, y: 20, values: new Map() }],
         deletedEdgeViews: [],
-        deletedNodeRows: new Map(),
-        deletedEdgeRows: new Map(),
+        deletedNodeRows: new Map([['n1', { name: 'Node1' }]]),
+        deletedEdgeRows: new Map([['e1', { interaction: 'activates' }]]),
       })
 
       mockNetworks.set('net1', makeNetwork('net1', [{ id: 'n1' }], []))
@@ -767,6 +776,21 @@ describe('elementApi', () => {
       if (result.success) {
         expect(result.data.deletedNodeCount).toBe(1)
         expect(result.data.deletedEdgeCount).toBe(1)
+        expect(result.data.deletedNodes).toEqual([
+          {
+            id: 'n1',
+            attributes: { name: 'Node1' },
+            position: [10, 20],
+          },
+        ])
+        expect(result.data.deletedEdges).toEqual([
+          {
+            id: 'e1',
+            sourceId: 'n1',
+            targetId: 'n2',
+            attributes: { interaction: 'activates' },
+          },
+        ])
       }
     })
   })
@@ -803,11 +827,11 @@ describe('elementApi', () => {
       }
     })
 
-    it('returns ok with deletion count on success', () => {
+    it('returns ok with deletion count and edge data on success', () => {
       jest.mocked(deleteEdgesCore).mockReturnValue({
         deletedEdgeIds: ['e1'],
         deletedEdgeViews: [],
-        deletedEdgeRows: new Map(),
+        deletedEdgeRows: new Map([['e1', { weight: 0.5 }]]),
       })
 
       mockNetworks.set(
@@ -819,6 +843,14 @@ describe('elementApi', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.deletedEdgeCount).toBe(1)
+        expect(result.data.deletedEdges).toEqual([
+          {
+            id: 'e1',
+            sourceId: 'n1',
+            targetId: 'n2',
+            attributes: { weight: 0.5 },
+          },
+        ])
       }
     })
   })

--- a/src/app-api/core/elementApi.ts
+++ b/src/app-api/core/elementApi.ts
@@ -69,14 +69,14 @@ export interface ElementApi {
     networkId: IdType,
     position: [number, number, number?],
     options?: CreateNodeOptions,
-  ): ApiResult<{ nodeId: IdType }>
+  ): ApiResult<{ nodeId: IdType; node: NodeData }>
 
   createEdge(
     networkId: IdType,
     sourceNodeId: IdType,
     targetNodeId: IdType,
     options?: CreateEdgeOptions,
-  ): ApiResult<{ edgeId: IdType }>
+  ): ApiResult<{ edgeId: IdType; edge: EdgeData }>
 
   // --- Update ---
   moveEdge(
@@ -90,12 +90,20 @@ export interface ElementApi {
   deleteNodes(
     networkId: IdType,
     nodeIds: IdType[],
-  ): ApiResult<{ deletedNodeCount: number; deletedEdgeCount: number }>
+  ): ApiResult<{
+    deletedNodeCount: number
+    deletedEdgeCount: number
+    deletedNodes: Array<{ id: IdType } & NodeData>
+    deletedEdges: Array<{ id: IdType } & EdgeData>
+  }>
 
   deleteEdges(
     networkId: IdType,
     edgeIds: IdType[],
-  ): ApiResult<{ deletedEdgeCount: number }>
+  ): ApiResult<{
+    deletedEdgeCount: number
+    deletedEdges: Array<{ id: IdType } & EdgeData>
+  }>
 
   generateNextNodeId(networkId: IdType): IdType
   generateNextEdgeId(networkId: IdType): IdType
@@ -307,7 +315,7 @@ export const elementApi: ElementApi = {
     }
   },
 
-  createNode(networkId, position, options): ApiResult<{ nodeId: IdType }> {
+  createNode(networkId, position, options): ApiResult<{ nodeId: IdType; node: NodeData }> {
     try {
       const networkState = useNetworkStore.getState()
       const network = networkState.networks.get(networkId)
@@ -371,7 +379,7 @@ export const elementApi: ElementApi = {
         [networkId, [newNodeId], position, attributes],
       )
 
-      return ok({ nodeId: newNodeId })
+      return ok({ nodeId: newNodeId, node: { attributes, position } })
     } catch (e) {
       return fail(ApiErrorCode.OperationFailed, String(e))
     }
@@ -382,7 +390,7 @@ export const elementApi: ElementApi = {
     sourceNodeId,
     targetNodeId,
     options,
-  ): ApiResult<{ edgeId: IdType }> {
+  ): ApiResult<{ edgeId: IdType; edge: EdgeData }> {
     try {
       const networkState = useNetworkStore.getState()
       const network = networkState.networks.get(networkId)
@@ -466,7 +474,14 @@ export const elementApi: ElementApi = {
         [networkId, [newEdgeId], sourceNodeId, targetNodeId, attributes],
       )
 
-      return ok({ edgeId: newEdgeId })
+      return ok({
+        edgeId: newEdgeId,
+        edge: {
+          sourceId: sourceNodeId,
+          targetId: targetNodeId,
+          attributes,
+        },
+      })
     } catch (e) {
       return fail(ApiErrorCode.OperationFailed, String(e))
     }
@@ -547,7 +562,12 @@ export const elementApi: ElementApi = {
   deleteNodes(
     networkId,
     nodeIds,
-  ): ApiResult<{ deletedNodeCount: number; deletedEdgeCount: number }> {
+  ): ApiResult<{
+    deletedNodeCount: number
+    deletedEdgeCount: number
+    deletedNodes: Array<{ id: IdType } & NodeData>
+    deletedEdges: Array<{ id: IdType } & EdgeData>
+  }> {
     try {
       const network = useNetworkStore.getState().networks.get(networkId)
       if (network === undefined) {
@@ -653,9 +673,39 @@ export const elementApi: ElementApi = {
         [networkId, result.deletedNodeIds],
       )
 
+      // Reshape internal result into public API types
+      const deletedNodes: Array<{ id: IdType } & NodeData> =
+        result.deletedNodeIds.map((nodeId) => {
+          const row = result.deletedNodeRows.get(nodeId) ?? {}
+          const nodeView = result.deletedNodeViews.find((v) => v.id === nodeId)
+          const position: [number, number, number?] = nodeView
+            ? nodeView.z !== undefined
+              ? [nodeView.x, nodeView.y, nodeView.z]
+              : [nodeView.x, nodeView.y]
+            : [0, 0]
+          return {
+            id: nodeId,
+            attributes: row as Record<AttributeName, ValueType>,
+            position,
+          }
+        })
+
+      const deletedEdgesData: Array<{ id: IdType } & EdgeData> =
+        result.deletedEdges.map((edge) => {
+          const row = result.deletedEdgeRows.get(edge.id) ?? {}
+          return {
+            id: edge.id,
+            sourceId: edge.s,
+            targetId: edge.t,
+            attributes: row as Record<AttributeName, ValueType>,
+          }
+        })
+
       return ok({
         deletedNodeCount: result.deletedNodeIds.length,
         deletedEdgeCount: result.deletedEdges.length,
+        deletedNodes,
+        deletedEdges: deletedEdgesData,
       })
     } catch (e) {
       return fail(ApiErrorCode.OperationFailed, String(e))
@@ -665,7 +715,10 @@ export const elementApi: ElementApi = {
   deleteEdges(
     networkId,
     edgeIds,
-  ): ApiResult<{ deletedEdgeCount: number }> {
+  ): ApiResult<{
+    deletedEdgeCount: number
+    deletedEdges: Array<{ id: IdType } & EdgeData>
+  }> {
     try {
       const network = useNetworkStore.getState().networks.get(networkId)
       if (network === undefined) {
@@ -759,7 +812,22 @@ export const elementApi: ElementApi = {
         [networkId, result.deletedEdgeIds],
       )
 
-      return ok({ deletedEdgeCount: result.deletedEdgeIds.length })
+      // Reshape internal result into public API types
+      const deletedEdgesData: Array<{ id: IdType } & EdgeData> =
+        edgesToDelete.map((edge) => {
+          const row = result.deletedEdgeRows.get(edge.id) ?? {}
+          return {
+            id: edge.id,
+            sourceId: edge.s,
+            targetId: edge.t,
+            attributes: row as Record<AttributeName, ValueType>,
+          }
+        })
+
+      return ok({
+        deletedEdgeCount: result.deletedEdgeIds.length,
+        deletedEdges: deletedEdgesData,
+      })
     } catch (e) {
       return fail(ApiErrorCode.OperationFailed, String(e))
     }


### PR DESCRIPTION

Cecile needs this for her app because she was experimenting implementing expand/collapse via delete nodes/edges and add nodes/edges.  When she deletes nodes and edges, she needs the deleted elements so that she can restore them when she calls expand


- createNode now returns { nodeId, node: NodeData }
- createEdge now returns { edgeId, edge: EdgeData }
- deleteNodes now returns deletedNodes[] and deletedEdges[] with full data
- deleteEdges now returns deletedEdges[] with full data
- Updated tests and API documentation


