### PR TITLE
fix: convert Query object to comma-separated string before passing to…

### DIFF
--- a/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
+++ b/src/features/HierarchyViewer/components/SubNetworkPanel.tsx
@@ -272,13 +272,16 @@ export const SubNetworkPanel = ({
     interactionSourceUrl = ndexBaseUrl
   }
 
+  // Convert query nodeIds to comma-separated string for the NDEx interconnect API
+  const queryString = query?.nodeIds?.join(',') ?? ''
+
   const result = useQuery({
     queryKey: [
       hierarchyId,
       interactionSourceUrl,
       rootNetworkId,
       subsystemNodeId,
-      query,
+      queryString,
       interactionNetworkId,
     ],
     queryFn: async ({ queryKey }) => {


### PR DESCRIPTION
… NDEx interconnect API

refs #557
The queryKey was passing the raw Query object ({ nodeIds: number[] }) instead of a string to fetchNdexInterconnectQuery, which calls .split(',') on it. This caused 'parameters.split is not a function' at runtime.