### PR TITLE
Update the API specification for createDiscreteMapping

### DIFF
--- a/docs/design/module-federation/specifications/app-api-specification.md
+++ b/docs/design/module-federation/specifications/app-api-specification.md
@@ -459,6 +459,7 @@ interface VisualStyleApi {
     vpName: VisualPropertyName,
     attribute: AttributeName,
     attributeType: ValueTypeName,
+    mapping?: Record<string, VisualPropertyValueType>,
   ): ApiResult
 
   createContinuousMapping(

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -625,10 +625,12 @@ Sets a per-element override. `elementIds` must be non-empty.
 
 Removes per-element overrides.
 
-#### `createDiscreteMapping(networkId, vpName, attribute, attributeType): ApiResult`
+#### `createDiscreteMapping(networkId, vpName, attribute, attributeType, mapping?): ApiResult`
 
 Creates a discrete (lookup-table) mapping for `vpName` based on the specified
-node/edge attribute.
+node/edge attribute. `mapping` is an optional `Record<string, VisualPropertyValueType>`
+of attribute-value keys (stringified; parsed back to `integer`/`long`/`double` per
+`attributeType`) to visual property values.
 
 #### `createContinuousMapping(networkId, vpName, vpType, attribute, attributeValues, attributeType): ApiResult`
 

--- a/src/app-api/core/visualStyleApi.test.ts
+++ b/src/app-api/core/visualStyleApi.test.ts
@@ -190,6 +190,78 @@ describe('createDiscreteMapping', () => {
       expect(result.error.code).toBe(ApiErrorCode.NetworkNotFound)
     }
   })
+
+  it('builds a vpValueMap from string mapping entries when attributeType is string', () => {
+    mockVisualStyles['net1'] = {
+      [VPN.NodeBackgroundColor]: { type: 'color', defaultValue: '#89D0F5' },
+    }
+
+    const result = visualStyleApi.createDiscreteMapping(
+      'net1',
+      VPN.NodeBackgroundColor,
+      'type',
+      'string',
+      { protein: '#ff0000', rna: '#00ff00' },
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockSetMapping).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeBackgroundColor,
+      expect.objectContaining({
+        attribute: 'type',
+        type: 'discrete',
+        vpValueMap: new Map([
+          ['protein', '#ff0000'],
+          ['rna', '#00ff00'],
+        ]),
+      }),
+    )
+  })
+
+  it('parses mapping keys as numbers when attributeType is integer or double', () => {
+    mockVisualStyles['net1'] = {
+      [VPN.NodeHeight]: { type: 'number', defaultValue: 10 },
+    }
+
+    visualStyleApi.createDiscreteMapping(
+      'net1',
+      VPN.NodeHeight,
+      'degree',
+      'integer',
+      { '1': 20, '2': 40 },
+    )
+
+    expect(mockSetMapping).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeHeight,
+      expect.objectContaining({
+        vpValueMap: new Map([
+          [1, 20],
+          [2, 40],
+        ]),
+      }),
+    )
+
+    visualStyleApi.createDiscreteMapping(
+      'net1',
+      VPN.NodeHeight,
+      'score',
+      'double',
+      { '1.5': 20, '2.5': 40 },
+    )
+
+    expect(mockSetMapping).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeHeight,
+      expect.objectContaining({
+        vpValueMap: new Map([
+          [1.5, 20],
+          [2.5, 40],
+        ]),
+      }),
+    )
+  })
 })
 
 // --- createContinuousMapping -------------------------------------------------


### PR DESCRIPTION
- Updates the API specification for `createDiscreteMapping` (adds the `mapping` parameter).
- Adds unit tests that passes `mapping` values to `createDiscreteMapping`.

See issue #560 