### PR TITLE
docs,build: make Windows support automatic; drop stale manual setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,51 +115,9 @@ npm run test:e2e -- --project=chromium --project=webkit
 
 Available project names are `chromium`, `firefox`, and `webkit` (matching `playwright.config.ts`).
 
-### Windows-Specific Setup Instructions
+### Windows
 
-For Windows users, environment variables need to be set differently. Follow these steps to run the development server.
-
-1.  **Modify `package.json` scripts**
-    Update the `dev` and `buid` scripts in `package.json` like this
-
-    ```
-     "build": "set \"REACT_APP_GIT_COMMIT=%COMMIT_HASH%\" && set \"REACT_APP_BUILD_TIMESTAMP=%BUILD_TIMESTAMP%\" && webpack --mode production",
-     "dev": "set \"REACT_APP_GIT_COMMIT=%COMMIT_HASH%\" && set \"REACT_APP_BUILD_TIMESTAMP=%BUILD_TIMESTAMP%\" && webpack serve --open --mode development",
-    ```
-
-2.  **Manually set environment variables in the terminal**
-
-    Run the Git commands manually to get your commit hash, these values will be used in `.env` file:
-
-    ```bash
-      git rev-parse HEAD
-    ```
-
-    ```bash
-      git show -s --format=%cI HEAD
-    ```
-
-    Copy the output of the commands and update in `.env` file as follow :
-
-    ```env
-      REACT_APP_GIT_COMMIT=<your_commit_hash>
-      REACT_APP_BUILD_TIMESTAMP=<your_build_timestamp>
-    ```
-
-    For example, if your Git commit hash is `abc1234` and the timestamp is `2024-10-24T10:00:00`, your `.env` would look like this:
-
-    ```env
-      REACT_APP_GIT_COMMIT=abc1234
-      REACT_APP_BUILD_TIMESTAMP=2024-10-24T10:00:00
-    ```
-
-3.  **Start the development server**
-
-    After setting the environment variables, run:
-
-    ```
-     npm dev
-    ```
+No Windows-specific setup is required. Build metadata (git commit, timestamps) is computed automatically inside `vite.config.ts`, and scripts that set environment variables use `cross-env`, so `npm run dev`, `npm run build`, and the test commands work the same on Windows, macOS, and Linux.
 
 ## Deploy on Netlify
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:e2e": "npm run build:test-remote && playwright test",
     "test:e2e:chromium": "npm run build:test-remote && playwright test --project=chromium",
     "build:test-remote": "vite build --config test/fixtures/remote-app/vite.config.ts",
-    "verify:federation": "ts-node --transpileOnly --compilerOptions '{\"module\":\"commonjs\",\"moduleResolution\":\"node\"}' scripts/verify-federation-build.ts",
+    "verify:federation": "ts-node --transpileOnly --compilerOptions \"{\\\"module\\\":\\\"commonjs\\\",\\\"moduleResolution\\\":\\\"node\\\"}\" scripts/verify-federation-build.ts",
     "build:bundle": "cross-env vite build",
     "copy:dist": "cpy \"silent-check-sso.html\" \"src/assets/apps.json\" dist --flat",
     "copy:netlify": "cpy \"netlify/_redirects\" dist --flat",
@@ -54,7 +54,7 @@
     "lint:eslint": "eslint --ext .js,.ts,.jsx,.tsx src",
     "lint:tsc": "tsc --noEmit",
     "lint:fix": "eslint --ext .js,.ts,.jsx,.tsx src --fix",
-    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'"
+    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\""
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",


### PR DESCRIPTION
The README's "Windows-Specific Setup Instructions" predated the Vite migration and no longer applied. It told Windows users to rewrite their package.json scripts to invoke `webpack` and to manually populate `REACT_APP_GIT_COMMIT` / `REACT_APP_BUILD_TIMESTAMP` in a `.env` file. None of that is true anymore:

  - The project builds with Vite, not webpack.
  - Build metadata is computed at build time inside vite.config.ts via `execSync('git ...')` and injected through `define`. This runs identically on Windows, macOS, and Linux, so no env vars need to be set by hand.
  - The scripts that do set environment variables (build:bundle, build:netlify, build:analyze) already use `cross-env`, and the rest of the toolchain (npm-run-all, rimraf, cpy-cli) is cross-platform.

Following the stale steps would actively break a Windows setup, so the section is replaced with a short note stating that no Windows-specific setup is required and why.

While confirming the daily dev/build/test flow is cross-platform, two scripts still used bash-only single-quote idioms that cmd.exe and PowerShell do not strip:

  - `format`: single-quoted prettier glob
  - `verify:federation`: single-quoted --compilerOptions JSON

Both are switched to double quotes with backslash-escaped inner quotes, the form node's argv parser accepts on Windows and that bash unescapes identically. Verified the format glob still resolves (303 files matched) and that package.json remains valid JSON.