### PR TITLE
TableApi.deleteColumn syncs the column state in UiStateStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4109,9 +4109,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4129,9 +4126,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4149,9 +4143,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4169,9 +4160,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4189,9 +4177,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4209,9 +4194,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4310,7 +4292,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -4324,7 +4307,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -4338,7 +4322,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -4352,7 +4337,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -4366,7 +4352,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -4380,7 +4367,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -4390,14 +4378,12 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -4407,14 +4393,12 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -4424,14 +4408,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -4441,14 +4423,12 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -4458,14 +4438,12 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -4475,14 +4453,12 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -4492,14 +4468,12 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -4509,14 +4483,12 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -4526,14 +4498,12 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -4543,14 +4513,12 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -4560,14 +4528,12 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -4577,14 +4543,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -4594,14 +4558,12 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -4615,7 +4577,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -4629,7 +4592,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -4643,7 +4607,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -4657,7 +4622,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -4671,7 +4637,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -4685,7 +4652,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -13551,9 +13519,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13575,9 +13540,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13599,9 +13561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13623,9 +13582,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/app-api/core/tableApi.test.ts
+++ b/src/app-api/core/tableApi.test.ts
@@ -112,6 +112,9 @@ beforeEach(() => {
   mockEditRows.mockReset()
   mockApplyValueToElements.mockReset()
   mockUiStateSetState.mockReset()
+  // mockUiStateSetState is reset globally because both createColumn and
+  // deleteColumn schedule UiStateStore updates via setTimeout; all tests
+  // benefit from a clean mock state regardless of which API is under test.
   // Clear mock tables
   Object.keys(mockTables).forEach((k) => delete mockTables[k])
   mockNetworks.clear()

--- a/src/app-api/core/tableApi.test.ts
+++ b/src/app-api/core/tableApi.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // src/app-api/core/tableApi.test.ts
 // Plain Jest tests for tableApi core — no renderHook, no React context.
@@ -45,6 +45,17 @@ vi.mock('../../data/hooks/stores/NetworkStore', () => ({
   },
 }))
 
+// ── Mock: UiStateStore ───────────────────────────────────────────────────────
+
+// vi.hoisted ensures the mock is available when vi.mock factory runs (hoisted)
+const mockUiStateSetState = vi.hoisted(() => vi.fn())
+
+vi.mock('../../data/hooks/stores/UiStateStore', () => ({
+  useUiStateStore: {
+    setState: mockUiStateSetState,
+  },
+}))
+
 // ── Test helpers ─────────────────────────────────────────────────────────────
 
 function makeTableRecord(
@@ -65,6 +76,29 @@ function makeTableRecord(
   }
 }
 
+function makeUiState(
+  networkId: string,
+  tableType: 'node' | 'edge',
+  columnConfig: any[],
+) {
+  const configKey = tableType === 'node' ? 'nodeTable' : 'edgeTable'
+  return {
+    ui: {
+      visualStyleOptions: {
+        [networkId]: {
+          visualEditorProperties: {
+            tableDisplayConfiguration: {
+              [configKey]: {
+                columnConfiguration: columnConfig,
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -77,6 +111,7 @@ beforeEach(() => {
   mockSetValues.mockReset()
   mockEditRows.mockReset()
   mockApplyValueToElements.mockReset()
+  mockUiStateSetState.mockReset()
   // Clear mock tables
   Object.keys(mockTables).forEach((k) => delete mockTables[k])
   mockNetworks.clear()
@@ -228,6 +263,108 @@ describe('deleteColumn', () => {
     if (!result.success) {
       expect(result.error.code).toBe(ApiErrorCode.NetworkNotFound)
     }
+  })
+})
+
+// --- removeColumnFromTableDisplayConfig (via deleteColumn) -------------------
+
+describe('removeColumnFromTableDisplayConfig', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('removes the column entry from node table columnConfiguration', () => {
+    mockTables['net1'] = makeTableRecord()
+    const initialConfig = [
+      { attributeName: 'score', visible: true, columnWidth: undefined },
+      { attributeName: 'name', visible: true, columnWidth: undefined },
+    ]
+    const state = makeUiState('net1', 'node', initialConfig)
+
+    tableApi.deleteColumn('net1', 'node', 'score')
+    vi.runAllTimers()
+
+    expect(mockUiStateSetState).toHaveBeenCalledOnce()
+    const updater = mockUiStateSetState.mock.calls[0][0]
+    updater(state)
+
+    expect(
+      state.ui.visualStyleOptions['net1'].visualEditorProperties
+        .tableDisplayConfiguration.nodeTable.columnConfiguration,
+    ).toEqual([{ attributeName: 'name', visible: true, columnWidth: undefined }])
+  })
+
+  it('removes the column entry from edge table columnConfiguration', () => {
+    mockTables['net1'] = makeTableRecord()
+    const initialConfig = [
+      { attributeName: 'weight', visible: true, columnWidth: undefined },
+      { attributeName: 'interaction', visible: true, columnWidth: undefined },
+    ]
+    const state = makeUiState('net1', 'edge', initialConfig)
+
+    tableApi.deleteColumn('net1', 'edge', 'weight')
+    vi.runAllTimers()
+
+    expect(mockUiStateSetState).toHaveBeenCalledOnce()
+    const updater = mockUiStateSetState.mock.calls[0][0]
+    updater(state)
+
+    expect(
+      state.ui.visualStyleOptions['net1'].visualEditorProperties
+        .tableDisplayConfiguration.edgeTable.columnConfiguration,
+    ).toEqual([
+      { attributeName: 'interaction', visible: true, columnWidth: undefined },
+    ])
+  })
+
+  it('preserves all other columns when removing a specific column', () => {
+    mockTables['net1'] = makeTableRecord()
+    const initialConfig = [
+      { attributeName: 'score', visible: true, columnWidth: undefined },
+      { attributeName: 'name', visible: true, columnWidth: undefined },
+      { attributeName: 'age', visible: false, columnWidth: 100 },
+    ]
+    const state = makeUiState('net1', 'node', initialConfig)
+
+    tableApi.deleteColumn('net1', 'node', 'name')
+    vi.runAllTimers()
+
+    const updater = mockUiStateSetState.mock.calls[0][0]
+    updater(state)
+
+    const remainingConfig =
+      state.ui.visualStyleOptions['net1'].visualEditorProperties
+        .tableDisplayConfiguration.nodeTable.columnConfiguration
+    expect(remainingConfig).toHaveLength(2)
+    expect(remainingConfig.map((c: any) => c.attributeName)).toEqual([
+      'score',
+      'age',
+    ])
+  })
+
+  it('is a no-op when tableDisplayConfiguration is absent', () => {
+    mockTables['net1'] = makeTableRecord()
+    const state = { ui: {} }
+
+    tableApi.deleteColumn('net1', 'node', 'score')
+    vi.runAllTimers()
+
+    expect(mockUiStateSetState).toHaveBeenCalledOnce()
+    const updater = mockUiStateSetState.mock.calls[0][0]
+    const result = updater(state)
+    // State should be returned unchanged when no config is present
+    expect(result).toEqual({ ui: {} })
+  })
+
+  it('does not schedule UiStateStore update when network is not found', () => {
+    tableApi.deleteColumn('missing', 'node', 'score')
+    vi.runAllTimers()
+
+    expect(mockUiStateSetState).not.toHaveBeenCalled()
   })
 })
 

--- a/src/app-api/core/tableApi.ts
+++ b/src/app-api/core/tableApi.ts
@@ -187,6 +187,32 @@ function syncColumnToTableDisplayConfig(
   })
 }
 
+/**
+ * Remove a column from the tableDisplayConfiguration in UiStateStore so the
+ * Table Browser stops rendering a header for a deleted column. Without this,
+ * columns removed via the API disappear from the data but keep showing up
+ * as an empty column in the UI.
+ */
+function removeColumnFromTableDisplayConfig(
+  networkId: IdType,
+  tableType: AppTableType,
+  columnName: string,
+): void {
+  const configKey = tableType === 'node' ? 'nodeTable' : 'edgeTable'
+  useUiStateStore.setState((state: any) => {
+    const tdc =
+      state.ui?.visualStyleOptions?.[networkId]?.visualEditorProperties
+        ?.tableDisplayConfiguration
+    if (!tdc?.[configKey]?.columnConfiguration) return state
+
+    const colConfig = tdc[configKey].columnConfiguration
+    tdc[configKey].columnConfiguration = colConfig.filter(
+      (c: { attributeName: string }) => c.attributeName !== columnName,
+    )
+    return state
+  })
+}
+
 // ── Core implementation ──────────────────────────────────────────────────────
 
 export const tableApi: TableApi = {
@@ -266,6 +292,18 @@ export const tableApi: TableApi = {
         return fail(ApiErrorCode.NetworkNotFound, `Network ${networkId} not found`)
       }
       useTableStore.getState().deleteColumn(networkId, tableType, columnName)
+
+      // Schedule table display config sync asynchronously to avoid
+      // blocking page.evaluate() — the Immer + IndexedDB persist cycle
+      // in UiStateStore can hang when called synchronously from CDP.
+      setTimeout(() => {
+        try {
+          removeColumnFromTableDisplayConfig(networkId, tableType, columnName)
+        } catch {
+          // Best-effort
+        }
+      }, 0)
+
       return ok()
     } catch (e) {
       return fail(ApiErrorCode.OperationFailed, String(e))


### PR DESCRIPTION
-- See issue #553

This PR modifies `tableApi.ts`:
- adds the `removeColumnFromTableDisplayConfig` function, which mirrors the existing `syncColumnToTableDisplayConfig` used by `createColumn`, so the deleted column's stale entry is filtered out of UiStateStore's `tableDisplayConfiguration.columnConfiguration`.
- `tableApi.deleteColumn` now calls the new `removeColumnFromTableDisplayConfig` function.