### PR TITLE
Adds missing parameters to visualStyleApi.createContinuousMapping

### DIFF
--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -632,10 +632,14 @@ node/edge attribute. `mapping` is an optional `Record<string, VisualPropertyValu
 of attribute-value keys (stringified; parsed back to `integer`/`long`/`double` per
 `attributeType`) to visual property values.
 
-#### `createContinuousMapping(networkId, vpName, vpType, attribute, attributeValues, attributeType): ApiResult`
+#### `createContinuousMapping(networkId, vpName, vpType, attribute, attributeValues, attributeType, controlPoints?, ltMinVpValue?, gtMaxVpValue?): ApiResult`
 
 Creates a continuous (interpolated) mapping. `attributeValues` defines the
-control point values on the data axis.
+control point values on the data axis. By default, `min`/`max`/`controlPoints`/
+`ltMinVpValue`/`gtMaxVpValue` are computed automatically from `attributeValues`
+and `vpType`. Pass `controlPoints` to override the interpolation points (`min`/
+`max` are derived from the first/last entries); pass `ltMinVpValue`/`gtMaxVpValue`
+to override the values used below/above the range.
 
 #### `createPassthroughMapping(networkId, vpName, attribute, attributeType): ApiResult`
 

--- a/src/app-api/core/visualStyleApi.test.ts
+++ b/src/app-api/core/visualStyleApi.test.ts
@@ -13,13 +13,34 @@ const VPN = VisualPropertyName
 const mockSetDefault = vi.fn()
 const mockSetBypass = vi.fn()
 const mockDeleteBypass = vi.fn()
-const mockCreateContinuousMapping = vi.fn()
 const mockCreatePassthroughMapping = vi.fn()
 const mockRemoveMapping = vi.fn()
 const mockSetMapping = vi.fn()
+const mockSetContinuousMappingValues = vi.fn()
 
 // Mutable visualStyles map for tests
 const mockVisualStyles: Record<string, any> = {}
+
+// Mimics VisualStyleStore.createContinuousMapping: installs a default
+// continuous mapping so callers can read it back via visualStyles.
+const mockCreateContinuousMapping = vi.fn((networkId: string, vpName: string) => {
+  mockVisualStyles[networkId][vpName] = {
+    ...mockVisualStyles[networkId][vpName],
+    mapping: {
+      attribute: 'score',
+      type: 'continuous',
+      min: { value: 0, vpValue: 'defaultMin' },
+      max: { value: 100, vpValue: 'defaultMax' },
+      controlPoints: [
+        { value: 0, vpValue: 'defaultMin' },
+        { value: 50, vpValue: 'defaultMid' },
+        { value: 100, vpValue: 'defaultMax' },
+      ],
+      ltMinVpValue: 'defaultLtMin',
+      gtMaxVpValue: 'defaultGtMax',
+    },
+  }
+})
 
 vi.mock('../../data/hooks/stores/VisualStyleStore', () => ({
   useVisualStyleStore: {
@@ -30,6 +51,7 @@ vi.mock('../../data/hooks/stores/VisualStyleStore', () => ({
       deleteBypass: mockDeleteBypass,
       setMapping: mockSetMapping,
       createContinuousMapping: mockCreateContinuousMapping,
+      setContinuousMappingValues: mockSetContinuousMappingValues,
       createPassthroughMapping: mockCreatePassthroughMapping,
       removeMapping: mockRemoveMapping,
     })),
@@ -305,6 +327,125 @@ describe('createContinuousMapping', () => {
     if (!result.success) {
       expect(result.error.code).toBe(ApiErrorCode.NetworkNotFound)
     }
+    expect(mockSetContinuousMappingValues).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the computed defaults when no overrides are given', () => {
+    mockVisualStyles['net1'] = { [VPN.NodeHeight]: { type: 'number', defaultValue: 10 } }
+
+    visualStyleApi.createContinuousMapping(
+      'net1',
+      VPN.NodeHeight,
+      'double',
+      'score',
+      [0, 50, 100],
+      'double',
+    )
+
+    expect(mockSetContinuousMappingValues).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeHeight,
+      { value: 0, vpValue: 'defaultMin' },
+      { value: 100, vpValue: 'defaultMax' },
+      [
+        { value: 0, vpValue: 'defaultMin' },
+        { value: 50, vpValue: 'defaultMid' },
+        { value: 100, vpValue: 'defaultMax' },
+      ],
+      'defaultLtMin',
+      'defaultGtMax',
+    )
+  })
+
+  it('overrides controlPoints, deriving min/max from the first/last entries', () => {
+    mockVisualStyles['net1'] = { [VPN.NodeHeight]: { type: 'number', defaultValue: 10 } }
+
+    const controlPoints = [
+      { value: 10, vpValue: 20 },
+      { value: 60, vpValue: 40 },
+      { value: 90, vpValue: 60 },
+    ]
+
+    visualStyleApi.createContinuousMapping(
+      'net1',
+      VPN.NodeHeight,
+      'double',
+      'score',
+      [0, 50, 100],
+      'double',
+      controlPoints,
+    )
+
+    expect(mockSetContinuousMappingValues).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeHeight,
+      { value: 10, vpValue: 20 },
+      { value: 90, vpValue: 60 },
+      controlPoints,
+      'defaultLtMin',
+      'defaultGtMax',
+    )
+  })
+
+  it('preserves an explicit inclusive flag on overridden control points', () => {
+    mockVisualStyles['net1'] = { [VPN.NodeBackgroundColor]: { type: 'color', defaultValue: '#ffffff' } }
+
+    const controlPoints = [
+      { value: 0, vpValue: '#000000', inclusive: true },
+      { value: 100, vpValue: '#ff0000' },
+    ]
+
+    visualStyleApi.createContinuousMapping(
+      'net1',
+      VPN.NodeBackgroundColor,
+      'color',
+      'score',
+      [0, 100],
+      'double',
+      controlPoints,
+      '#ffffff',
+      '#ff0000',
+    )
+
+    expect(mockSetContinuousMappingValues).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeBackgroundColor,
+      { value: 0, vpValue: '#000000', inclusive: true },
+      { value: 100, vpValue: '#ff0000' },
+      controlPoints,
+      '#ffffff',
+      '#ff0000',
+    )
+  })
+
+  it('overrides ltMinVpValue and gtMaxVpValue while keeping computed control points', () => {
+    mockVisualStyles['net1'] = { [VPN.NodeHeight]: { type: 'number', defaultValue: 10 } }
+
+    visualStyleApi.createContinuousMapping(
+      'net1',
+      VPN.NodeHeight,
+      'double',
+      'score',
+      [0, 50, 100],
+      'double',
+      undefined,
+      'customLtMin',
+      'customGtMax',
+    )
+
+    expect(mockSetContinuousMappingValues).toHaveBeenCalledWith(
+      'net1',
+      VPN.NodeHeight,
+      { value: 0, vpValue: 'defaultMin' },
+      { value: 100, vpValue: 'defaultMax' },
+      [
+        { value: 0, vpValue: 'defaultMin' },
+        { value: 50, vpValue: 'defaultMid' },
+        { value: 100, vpValue: 'defaultMax' },
+      ],
+      'customLtMin',
+      'customGtMax',
+    )
   })
 })
 

--- a/src/app-api/core/visualStyleApi.ts
+++ b/src/app-api/core/visualStyleApi.ts
@@ -6,6 +6,8 @@ import { useVisualStyleStore } from '../../data/hooks/stores/VisualStyleStore'
 import { IdType } from '../../models/IdType'
 import { AttributeName, ValueType, ValueTypeName } from '../../models/TableModel'
 import {
+  ContinuousFunctionControlPoint,
+  ContinuousMappingFunction,
   MappingFunctionType,
   VisualPropertyName,
   VisualPropertyValueType,
@@ -50,6 +52,9 @@ export interface VisualStyleApi {
     attribute: AttributeName,
     attributeValues: ValueType[],
     attributeType: ValueTypeName,
+    controlPoints?: ContinuousFunctionControlPoint[],
+    ltMinVpValue?: VisualPropertyValueType,
+    gtMaxVpValue?: VisualPropertyValueType,
   ): ApiResult
 
   createPassthroughMapping(
@@ -168,25 +173,50 @@ export const visualStyleApi: VisualStyleApi = {
     attribute,
     attributeValues,
     attributeType,
+    controlPoints,
+    ltMinVpValue,
+    gtMaxVpValue,
   ): ApiResult {
     try {
-      const visualStyles = useVisualStyleStore.getState().visualStyles
-      if (visualStyles[networkId] === undefined) {
+      const store = useVisualStyleStore.getState()
+      if (store.visualStyles[networkId] === undefined) {
         return fail(
           ApiErrorCode.NetworkNotFound,
           `Network ${networkId} not found`,
         )
       }
-      useVisualStyleStore
-        .getState()
-        .createContinuousMapping(
+      store.createContinuousMapping(
+        networkId,
+        vpName,
+        vpType,
+        attribute,
+        attributeValues,
+        attributeType,
+      )
+
+      // createContinuousMapping computes default min/max/controlPoints/lt/gt values;
+      // read them back so any caller-supplied overrides can fall back to those defaults.
+      const currentMapping = useVisualStyleStore.getState().visualStyles[networkId][
+        vpName
+      ].mapping as ContinuousMappingFunction | undefined
+      if (currentMapping) {
+        const effectiveControlPoints = controlPoints ?? currentMapping.controlPoints
+        const min: ContinuousFunctionControlPoint = controlPoints
+          ? controlPoints[0]
+          : currentMapping.min
+        const max: ContinuousFunctionControlPoint = controlPoints
+          ? controlPoints[controlPoints.length - 1]
+          : currentMapping.max
+        useVisualStyleStore.getState().setContinuousMappingValues(
           networkId,
           vpName,
-          vpType,
-          attribute,
-          attributeValues,
-          attributeType,
+          min,
+          max,
+          effectiveControlPoints,
+          ltMinVpValue ?? currentMapping.ltMinVpValue,
+          gtMaxVpValue ?? currentMapping.gtMaxVpValue,
         )
+      }
       return ok()
     } catch (e) {
       return fail(ApiErrorCode.OperationFailed, String(e))


### PR DESCRIPTION
-- See issue #561 

- Adds these parameters to `visualStyleApi.createContinuousMapping`: 
  - `controlPoints`,
  - `ltMinVpValue`,
  - `gtMaxVpValue`.
- Adds unit tests for the new parameters.
- Updates the API documentation.

I think that, from an App perspective, this makes more sense than creating an new API function for `setContinuousMappingValues`, because apps will usually set continuous mappings at once, differently from the CW UI, which allows the user to set new control points after the mapping has been created. But let me know if you think this is not the best approach.