### PR TITLE
fix(auth): disable keycloak silent SSO full-page redirect fallback (CW-663

### DIFF
--- a/src/init.tsx
+++ b/src/init.tsx
@@ -14,7 +14,11 @@ import { EmailVerificationModal } from './features/EmailVerification'
 import ErrorBoundary from './features/ErrorBoundary'
 import { FeatureAvailabilityProvider } from './features/FeatureAvailability'
 import { initializeGoogleAnalytics } from './init/googleAnalytics'
-import { initializeKeycloak, KeycloakContext } from './init/keycloak'
+import {
+  buildKeycloakInitOptions,
+  initializeKeycloak,
+  KeycloakContext,
+} from './init/keycloak'
 import { BootScreen } from './init/BootScreen'
 import { initializeTabManager } from './init/tabManager'
 
@@ -121,16 +125,10 @@ const initializeApp = () => {
         renderAppOnce({ authenticated: false })
       }, AUTH_INIT_TIMEOUT_MS)
 
-  const keycloakInitOptions = isLocalDevHost
-    ? {
-        checkLoginIframe: false,
-      }
-    : {
-        onLoad: 'check-sso' as const,
-        checkLoginIframe: false,
-        silentCheckSsoRedirectUri:
-          window.location.origin + urlBaseName + 'silent-check-sso.html',
-      }
+  const keycloakInitOptions = buildKeycloakInitOptions(
+    isLocalDevHost,
+    urlBaseName,
+  )
 
   keycloak
     .init(keycloakInitOptions)

--- a/src/init/init_docs/init.md
+++ b/src/init/init_docs/init.md
@@ -75,8 +75,9 @@ Handles Keycloak authentication setup and user verification.
 **Design Decisions:**
 
 1. **Silent SSO Check**: Uses `check-sso` mode to check authentication without redirect
-2. **Error Message Parsing**: Extracts user info from NDEx error messages to populate verification modal
-3. **Verification Check**: Only checks verification for authenticated users to avoid unnecessary API calls
+2. **No Full-Page Fallback (CW-663)**: `silentCheckSsoFallback` is disabled. When third-party cookies are blocked (e.g. incognito), keycloak-js would otherwise fall back to a full-page redirect whose `redirect_uri` is `location.href` — including user-supplied query params such as `?import=<url>` — which NDEx Keycloak can reject with "Invalid parameter: redirect_uri". With the fallback off, the silent iframe check simply resolves unauthenticated.
+3. **Error Message Parsing**: Extracts user info from NDEx error messages to populate verification modal
+4. **Verification Check**: Only checks verification for authenticated users to avoid unnecessary API calls
 
 ### loadingScreen.ts
 

--- a/src/init/keycloak.test.ts
+++ b/src/init/keycloak.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildKeycloakInitOptions } from './keycloak'
+
+describe('buildKeycloakInitOptions', () => {
+  it('skips SSO check entirely on local dev hosts', () => {
+    const options = buildKeycloakInitOptions(true, '/')
+
+    expect(options).toEqual({ checkLoginIframe: false })
+  })
+
+  it('uses silent check-sso against silent-check-sso.html on deployed hosts', () => {
+    const options = buildKeycloakInitOptions(false, '/')
+
+    expect(options.onLoad).toEqual('check-sso')
+    expect(options.checkLoginIframe).toEqual(false)
+    expect(options.silentCheckSsoRedirectUri).toEqual(
+      window.location.origin + '/silent-check-sso.html',
+    )
+  })
+
+  // CW-663: when third-party cookies are blocked (incognito), keycloak-js
+  // falls back from silent check-sso to a full-page redirect that sends
+  // location.href — including user-supplied params such as ?import=<url> —
+  // as redirect_uri, which NDEx Keycloak can reject with
+  // "Invalid parameter: redirect_uri". The fallback must stay disabled.
+  it('disables the full-page redirect fallback for silent check-sso', () => {
+    const options = buildKeycloakInitOptions(false, '/')
+
+    expect(options.silentCheckSsoFallback).toEqual(false)
+  })
+})

--- a/src/init/keycloak.ts
+++ b/src/init/keycloak.ts
@@ -1,11 +1,33 @@
 import { NDExAuthError, NDExClient } from '@js4cytoscape/ndex-client'
-import Keycloak from 'keycloak-js'
+import Keycloak, { KeycloakInitOptions } from 'keycloak-js'
 import { createContext } from 'react'
 
 import appConfig from '../assets/config.json'
 import { getNDExBaseUrl } from '../data/external-api/ndex/config'
 
 export const KeycloakContext = createContext<Keycloak>(new Keycloak())
+
+export const buildKeycloakInitOptions = (
+  isLocalDevHost: boolean,
+  urlBaseName: string,
+): KeycloakInitOptions => {
+  if (isLocalDevHost) {
+    return { checkLoginIframe: false }
+  }
+  return {
+    onLoad: 'check-sso',
+    checkLoginIframe: false,
+    // CW-663: with third-party cookies blocked (e.g. incognito), keycloak-js
+    // would otherwise fall back to a full-page redirect check-sso whose
+    // redirect_uri is location.href — including user-supplied params such as
+    // ?import=<url> — which NDEx Keycloak can reject with
+    // "Invalid parameter: redirect_uri". With the fallback disabled, the
+    // silent iframe check still runs and simply resolves unauthenticated.
+    silentCheckSsoFallback: false,
+    silentCheckSsoRedirectUri:
+      window.location.origin + urlBaseName + 'silent-check-sso.html',
+  }
+}
 
 export const initializeKeycloak = () => {
   const { keycloakConfig, urlBaseName } = appConfig


### PR DESCRIPTION


With third-party cookies blocked (e.g. incognito), keycloak-js falls back from silent check-sso to a full-page redirect whose redirect_uri is location.href — including user-supplied query params such as ?import=<url>. NDEx Keycloak can reject that redirect_uri with "Invalid parameter: redirect_uri", stranding the user on the Keycloak error page before the app loads.

Setting silentCheckSsoFallback: false keeps the check in the hidden iframe, which resolves unauthenticated without any top-level navigation. Init options are extracted to buildKeycloakInitOptions() with unit tests covering the local-dev and deployed paths.



## What was wrong
The ?import= parameter was leaking into the OAuth redirect_uri. The sequence, confirmed by inspecting the bundle deployed at web.cytoscape.org:

On startup, keycloak.init runs a silent SSO check (check-sso + silent-check-sso.html in a hidden iframe). This requires third-party cookies.
In incognito, third-party cookies are blocked. keycloak-js detects this, and because silentCheckSsoFallback defaults to true (we never set it), it discards the silent iframe approach and performs a full-page redirect to NDEx Keycloak instead.
That fallback uses location.href as the redirect_uri — i.e. https://web.cytoscape.org/?import=http://localhost:8000/valid.cx2, with the user-supplied import URL embedded.
If Keycloak rejects that redirect_uri, the user is stranded on Keycloak's "Invalid parameter: redirect_uri" page — visibly, because this is a top-level navigation, unlike the hidden iframe.
Without ?import=, the redirect_uri is the clean origin, so the bounce succeeds invisibly — which is why plain incognito loads "worked" (they were actually doing a hidden round-trip to Keycloak on every load). The auth server never fetches or cares about the import URL itself; it just fails to validate the page URL carrying it.

## How to reproduce
NDEx production Keycloak currently accepts the ticket's exact URL (verified by direct probes), so that literal URL no longer errors — the server config has likely been loosened since the report, or Manju's URL carried an extra character. Two deterministic reproductions still exist:

Invalid characters (production): Keycloak rejects redirect_uris that fail strict URI parsing, and browsers pass { } | ^ \ and stray % through raw in query strings. In incognito, load https://web.cytoscape.org/?import=http://localhost:8000/valid{1}.cx2 → Keycloak error page. The file doesn't need to exist — the failure happens before any fetch. The same URL in a normal window loads fine.
Branch deploy (clean URL): Netlify branch deploys use dev1 Keycloak, which rejects the Netlify origin outright. In incognito, https://development--incredible-meringue-aa83b1.netlify.app/?import=http://localhost:8000/valid.cx2 shows the identical error with the unmodified URL.
To observe the mechanism on any URL: DevTools → Network with Preserve log, load in incognito, and look for a top-level request to .../auth2/realms/ndex/protocol/openid-connect/auth whose redirect_uri contains the ?import= parameter.

The fix (commit 37af04fc)
Set silentCheckSsoFallback: false in the Keycloak init options. With the fallback disabled, the silent check still runs in the hidden iframe when third-party cookies are blocked and simply resolves unauthenticated — no top-level redirect, no user-controlled redirect_uri, no error page. Incognito users just aren't auto-signed-in (which was already the effective outcome); the explicit Login button flow is unchanged, as is local dev.

Init options were extracted into buildKeycloakInitOptions() in src/init/keycloak.ts with unit tests (src/init/keycloak.test.ts), including a regression test pinning the fallback off. Full unit suite passes (2116 tests), lint and tsc clean.

Verification after deploy: repeat either repro against the fix branch's deploy (cw-663-fix-incognito-import-redirect--incredible-meringue-aa83b1.netlify.app once pushed) — the Network log should show no top-level /auth2/... navigation, and the app should load logged-out with no error.

