### PR TITLE
fix: add null check for the continuous mapping form

### DIFF
--- a/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousDiscreteMappingForm.tsx
+++ b/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousDiscreteMappingForm.tsx
@@ -1,14 +1,23 @@
 import AddIcon from '@mui/icons-material/Add'
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
+import ArrowLeftIcon from '@mui/icons-material/ArrowLeft'
+import ArrowRightIcon from '@mui/icons-material/ArrowRight'
 import ClearIcon from '@mui/icons-material/Clear'
 import {
   Box,
-  Divider,
+  Button,
   IconButton,
   Paper,
+  Popover,
   Tooltip,
-  Typography,
 } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { AxisBottom } from '@visx/axis'
+import { scaleLinear } from '@visx/scale'
+import { extent } from 'd3-array'
+import debounce from 'lodash/debounce'
 import * as React from 'react'
+import Draggable from 'react-draggable'
 
 import { useVisualStyleStore } from '../../../../../data/hooks/stores/VisualStyleStore'
 import { useUndoStack } from '../../../../../data/hooks/useUndoStack'
@@ -18,51 +27,44 @@ import {
   VisualProperty,
   VisualPropertyValueType,
 } from '../../../../../models/VisualStyleModel'
-import {
-  ContinuousFunctionControlPoint,
-  ContinuousMappingFunction,
-} from '../../../../../models/VisualStyleModel/VisualMappingFunction'
+import { ContinuousMappingFunction } from '../../../../../models/VisualStyleModel/VisualMappingFunction'
+import { ContinuousFunctionControlPoint } from '../../../../../models/VisualStyleModel/VisualMappingFunction/ContinuousMappingFunction'
 import { VisualPropertyValueForm } from '../../VisualPropertyValueForm'
 import { ExpandableNumberInput } from './ExpandableNumberInput'
+import { addHandle, editHandle, Handle, removeHandle } from './handleUtil'
 
-interface Point {
-  value: number
-  vpValue: VisualPropertyValueType
-}
-
-// CW-569: editor for a continuous (step-function) mapping on a discrete-valued
-// visual property such as edge line type or node shape. The numeric attribute
-// is divided into bands by the boundary values; each band renders a discrete
-// visual-property value.
 export function ContinuousDiscreteMappingForm(props: {
   currentNetworkId: IdType
   visualProperty: VisualProperty<VisualPropertyValueType>
 }): React.ReactElement {
+  const theme = useTheme()
   const m = props.visualProperty?.mapping as ContinuousMappingFunction | null
 
-  const setContinuousMappingValues = useVisualStyleStore(
-    (state) => state.setContinuousMappingValues,
-  )
-  const { postEdit } = useUndoStack()
+  const { min, max, controlPoints } = m ?? {
+    min: { value: 0, vpValue: props.visualProperty.defaultValue },
+    max: { value: 0, vpValue: props.visualProperty.defaultValue },
+    controlPoints: [] as ContinuousFunctionControlPoint[],
+  }
 
-  // Ordered boundary points: [min, ...intermediate, max].
-  const initialPoints: Point[] = React.useMemo(() => {
-    if (m == null) return []
-    const pts: Point[] = [
-      { value: m.min.value as number, vpValue: m.min.vpValue },
-      ...m.controlPoints
-        .filter(
-          (cp) =>
-            cp.value !== m.min.value && cp.value !== m.max.value,
-        )
+  const [minState, setMinState] = React.useState(min)
+  const [maxState, setMaxState] = React.useState(max)
+
+  const [handles, setHandles] = React.useState<Handle[]>(() => {
+    const pts = [
+      { value: min.value as number, vpValue: min.vpValue },
+      ...controlPoints
+        .filter((cp) => cp.value !== min.value && cp.value !== max.value)
         .map((cp) => ({ value: cp.value as number, vpValue: cp.vpValue })),
-      { value: m.max.value as number, vpValue: m.max.vpValue },
+      { value: max.value as number, vpValue: max.vpValue },
     ].sort((a, b) => a.value - b.value)
-    return pts
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed from mapping identity only
-  }, [props.visualProperty.mapping])
 
-  const [points, setPoints] = React.useState<Point[]>(initialPoints)
+    return pts.map((pt, index) => ({
+      ...pt,
+      inclusive: false,
+      id: index,
+    }))
+  })
+
   const [ltMin, setLtMin] = React.useState<VisualPropertyValueType>(
     (m?.ltMinVpValue ?? m?.min.vpValue) as VisualPropertyValueType,
   )
@@ -70,202 +72,670 @@ export function ContinuousDiscreteMappingForm(props: {
     (m?.gtMaxVpValue ?? m?.max.vpValue) as VisualPropertyValueType,
   )
 
+  const [addHandleFormValue, setAddHandleFormValue] = React.useState(0)
+  const [addHandleFormVpValue, setAddHandleFormVpValue] = React.useState(
+    props.visualProperty.defaultValue,
+  )
+  const [lastDraggedHandleId, setlastDraggedHandleId] = React.useState<
+    number | null
+  >(null)
+
+  const [createHandleAnchorEl, setCreateHandleAnchorEl] =
+    React.useState<HTMLButtonElement | null>(null)
+
+  const showCreateHandleMenu = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ): void => {
+    setCreateHandleAnchorEl(event.currentTarget)
+  }
+
+  const hideCreateHandleMenu = (): void => {
+    setCreateHandleAnchorEl(null)
+  }
+
+  const NUM_GRADIENT_STEPS = 140
+  const GRADIENT_STEP_WIDTH = 4
+  const GRADIENT_HEIGHT = 100
+  const GRADIENT_AXIS_HORIZONTAL_PADDING = 30
+  const GRADIENT_AXIS_VERTICAL_PADDING = 100
+  const GRADIENT_AXIS_OFFSET_LEFT = 10
+
+  const setContinuousMappingValues = useVisualStyleStore(
+    (state) => state.setContinuousMappingValues,
+  )
+  const { postEdit } = useUndoStack()
+
+  const valueDomain = [
+    minState.value as number,
+    ...handles.map((h) => h.value as number),
+    maxState.value as number,
+  ]
+
+  const valuePixelScale = scaleLinear({
+    range: [0, NUM_GRADIENT_STEPS * GRADIENT_STEP_WIDTH],
+    domain: extent(valueDomain) as [number, number],
+  })
+
+  const latest = React.useRef({ m, props, postEdit })
+  latest.current = { m, props, postEdit }
+
+  const updateContinuousMapping = React.useMemo(
+    () =>
+      debounce(
+        (
+          min: ContinuousFunctionControlPoint,
+          max: ContinuousFunctionControlPoint,
+          handles: Handle[],
+          ltMinVpValue: VisualPropertyValueType,
+          gtMaxVpValue: VisualPropertyValueType,
+        ) => {
+          const { m, props, postEdit } = latest.current
+          if (m == null) return
+          const nextMapping: ContinuousMappingFunction = {
+            ...m,
+            min,
+            max,
+            controlPoints: handles.map((h) => {
+              return {
+                value: h.value,
+                vpValue: h.vpValue,
+                inclusive: false,
+              }
+            }),
+            ltMinVpValue,
+            gtMaxVpValue,
+          }
+
+          postEdit(
+            UndoCommandType.SET_CONTINUOUS_MAPPING,
+            `Update ${props.visualProperty.displayName} continuous mapping`,
+            [
+              props.currentNetworkId,
+              props.visualProperty.name,
+              props.visualProperty.mapping,
+            ],
+            [props.currentNetworkId, props.visualProperty.name, nextMapping],
+          )
+
+          setContinuousMappingValues(
+            props.currentNetworkId,
+            props.visualProperty.name,
+            min,
+            max,
+            nextMapping.controlPoints,
+            ltMinVpValue,
+            gtMaxVpValue,
+          )
+        },
+        200,
+        { trailing: true },
+      ),
+    [setContinuousMappingValues],
+  )
+
   React.useEffect(() => {
-    setPoints(initialPoints)
-    setLtMin((m?.ltMinVpValue ?? m?.min.vpValue) as VisualPropertyValueType)
-    setGtMax((m?.gtMaxVpValue ?? m?.max.vpValue) as VisualPropertyValueType)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- resync on mapping change
+    if (props.visualProperty.mapping == null) return
+    const nextMapping = props.visualProperty
+      .mapping as ContinuousMappingFunction
+    const nextMin = nextMapping.min ?? minState
+    const nextMax = nextMapping.max ?? maxState
+    const nextControlPoints =
+      nextMapping.controlPoints ?? ([] as ContinuousFunctionControlPoint[])
+
+    setMinState(nextMin)
+    setMaxState(nextMax)
+
+    const pts = [
+      { value: nextMin.value as number, vpValue: nextMin.vpValue },
+      ...nextControlPoints
+        .filter(
+          (cp) => cp.value !== nextMin.value && cp.value !== nextMax.value,
+        )
+        .map((cp) => ({ value: cp.value as number, vpValue: cp.vpValue })),
+      { value: nextMax.value as number, vpValue: nextMax.vpValue },
+    ].sort((a, b) => a.value - b.value)
+
+    setHandles(
+      pts.map((pt, index) => ({
+        ...pt,
+        inclusive: false,
+        id: index,
+      })),
+    )
+
+    setLtMin(
+      (nextMapping.ltMinVpValue ??
+        nextMapping.min.vpValue) as VisualPropertyValueType,
+    )
+    setGtMax(
+      (nextMapping.gtMaxVpValue ??
+        nextMapping.max.vpValue) as VisualPropertyValueType,
+    )
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.visualProperty.mapping?.attribute])
+
+  const createHandle = (
+    value: number,
+    vpValue: VisualPropertyValueType,
+  ): void => {
+    const newHandles = addHandle(handles, value, vpValue)
+    setHandles(newHandles)
+    updateContinuousMapping(minState, maxState, newHandles, ltMin, gtMax)
+  }
+
+  const deleteHandle = (id: number): void => {
+    const newHandles = removeHandle(handles, id)
+    setHandles(newHandles)
+    updateContinuousMapping(minState, maxState, newHandles, ltMin, gtMax)
+  }
+
+  const setHandle = (
+    id: number,
+    value: number,
+    vpValue: VisualPropertyValueType,
+  ): void => {
+    const newHandles = editHandle(handles, id, value, vpValue)
+    setHandles(newHandles)
+    updateContinuousMapping(minState, maxState, newHandles, ltMin, gtMax)
+  }
+
+  React.useEffect(() => {
+    const [min, max] = extent(handles.map((h) => h.value as number))
+    const minValue: number = minState.value as number
+    if (min != null && min < minValue) {
+      setMinState({ ...minState, value: min })
+    }
+
+    const maxValue: number = maxState.value as number
+    if (max != null && max > maxValue) {
+      setMaxState({ ...maxState, value: max })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handles])
+
+  React.useEffect(() => {
+    const newHandles = [...handles]
+      .map((h) => {
+        return {
+          ...h,
+          value: Math.max(h.value as number, minState.value as number),
+        }
+      })
+      .sort((a, b) => (a.value as number) - (b.value as number))
+
+    newHandles[0].value = minState.value as number
+    newHandles[0].vpValue = minState.vpValue
+    setHandles(newHandles)
+    updateContinuousMapping(minState, maxState, newHandles, ltMin, gtMax)
+    setAddHandleFormValue(
+      ((minState.value as number) + (maxState.value as number)) / 2,
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [minState])
+
+  React.useEffect(() => {
+    const newHandles = [...handles]
+      .map((h) => {
+        return {
+          ...h,
+          value: Math.min(h.value as number, maxState.value as number),
+        }
+      })
+      .sort((a, b) => (a.value as number) - (b.value as number))
+
+    newHandles[newHandles.length - 1].value = maxState.value as number
+    newHandles[newHandles.length - 1].vpValue = maxState.vpValue
+    setHandles(newHandles)
+    updateContinuousMapping(minState, maxState, newHandles, ltMin, gtMax)
+    setAddHandleFormValue(
+      ((minState.value as number) + (maxState.value as number)) / 2,
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [maxState])
 
   if (m == null) {
     return <Box></Box>
   }
 
-  const commit = (
-    nextPoints: Point[],
-    nextLtMin: VisualPropertyValueType,
-    nextGtMax: VisualPropertyValueType,
-  ): void => {
-    const sorted = [...nextPoints].sort((a, b) => a.value - b.value)
-    const min: ContinuousFunctionControlPoint = {
-      value: sorted[0].value,
-      vpValue: sorted[0].vpValue,
-      inclusive: false,
-    }
-    const max: ContinuousFunctionControlPoint = {
-      value: sorted[sorted.length - 1].value,
-      vpValue: sorted[sorted.length - 1].vpValue,
-      inclusive: false,
-    }
-    const controlPoints: ContinuousFunctionControlPoint[] = sorted.map((p) => ({
-      value: p.value,
-      vpValue: p.vpValue,
-    }))
-
-    const nextMapping: ContinuousMappingFunction = {
-      ...m,
-      min,
-      max,
-      controlPoints,
-      ltMinVpValue: nextLtMin,
-      gtMaxVpValue: nextGtMax,
-    }
-
-    postEdit(
-      UndoCommandType.SET_CONTINUOUS_MAPPING,
-      `Update ${props.visualProperty.displayName} continuous mapping`,
-      [
-        props.currentNetworkId,
-        props.visualProperty.name,
-        props.visualProperty.mapping,
-      ],
-      [props.currentNetworkId, props.visualProperty.name, nextMapping],
-    )
-
-    setContinuousMappingValues(
-      props.currentNetworkId,
-      props.visualProperty.name,
-      min,
-      max,
-      controlPoints,
-      nextLtMin,
-      nextGtMax,
-    )
-  }
-
-  const updatePointValue = (index: number, value: number): void => {
-    const next = points.map((p, i) => (i === index ? { ...p, value } : p))
-    setPoints(next)
-    commit(next, ltMin, gtMax)
-  }
-
-  const updatePointVpValue = (
-    index: number,
-    vpValue: VisualPropertyValueType,
-  ): void => {
-    const next = points.map((p, i) => (i === index ? { ...p, vpValue } : p))
-    setPoints(next)
-    commit(next, ltMin, gtMax)
-  }
-
-  const addPoint = (): void => {
-    const lo = points[0].value
-    const hi = points[points.length - 1].value
-    const next: Point[] = [
-      ...points,
-      { value: (lo + hi) / 2, vpValue: points[0].vpValue },
-    ].sort((a, b) => a.value - b.value)
-    setPoints(next)
-    commit(next, ltMin, gtMax)
-  }
-
-  const removePoint = (index: number): void => {
-    const next = points.filter((_, i) => i !== index)
-    setPoints(next)
-    commit(next, ltMin, gtMax)
-  }
-
-  const isEndpoint = (index: number): boolean =>
-    index === 0 || index === points.length - 1
-
   return (
-    <Paper variant="outlined" sx={{ p: 2, minWidth: 420 }}>
-      <Typography variant="body2" sx={{ mb: 1 }}>
-        {`Map ranges of "${m.attribute}" to ${props.visualProperty.displayName} values.`}
-      </Typography>
-
+    <Paper variant="filled" sx={{ px: 8, py: 1 }}>
       <Box
         sx={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'space-between',
-          py: 0.5,
+          mt: 12,
+          mb: 1,
+          justifyContent: 'center',
         }}
       >
-        <Typography variant="caption" sx={{ minWidth: 140 }}>
-          {`Below minimum`}
-        </Typography>
-        <VisualPropertyValueForm
-          currentValue={ltMin}
-          visualProperty={props.visualProperty}
-          currentNetworkId={props.currentNetworkId}
-          onValueChange={(newValue) => {
-            setLtMin(newValue)
-            commit(points, newValue, gtMax)
-          }}
-        />
-      </Box>
-      <Divider />
-
-      {points.map((p, index) => (
-        <Box
-          key={index}
+        <Paper
+          variant="outlined"
           sx={{
             display: 'flex',
+            flexDirection: 'column',
             alignItems: 'center',
-            justifyContent: 'space-between',
-            py: 0.5,
+            position: 'relative',
+            userSelect: 'none',
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant="caption">
-              {index === 0
-                ? 'Minimum'
-                : index === points.length - 1
-                  ? 'Maximum'
-                  : 'Threshold'}
-            </Typography>
-            <ExpandableNumberInput
-              value={p.value}
-              onConfirm={(newVal) => updatePointValue(index, newVal)}
-            />
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <VisualPropertyValueForm
-              currentValue={p.vpValue}
-              visualProperty={props.visualProperty}
-              currentNetworkId={props.currentNetworkId}
-              onValueChange={(newValue) => updatePointVpValue(index, newValue)}
-            />
-            {!isEndpoint(index) && (
-              <Tooltip title="Remove point">
-                <IconButton size="small" onClick={() => removePoint(index)}>
-                  <ClearIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            )}
-          </Box>
-        </Box>
-      ))}
+          <Box sx={{ p: 1.5 }}>
+            <Tooltip
+              title="Click to add new handle"
+              placement="top"
+              followCursor
+            >
+              <Paper
+                sx={{
+                  display: 'flex',
+                  position: 'relative',
+                  '&:hover': { cursor: 'copy' },
+                }}
+                onClickCapture={(e) => {
+                  const trackElement = e.currentTarget
+                  const rect = trackElement.getBoundingClientRect()
+                  const positionX = e.clientX - rect.x
+                  const newHandleValue = Math.max(
+                    minState.value as number,
+                    Math.min(
+                      valuePixelScale.invert(positionX),
+                      maxState.value as number,
+                    ),
+                  )
+                  createHandle(
+                    newHandleValue,
+                    props.visualProperty.defaultValue,
+                  )
+                }}
+              >
+                <Box sx={{ display: 'flex' }}>
+                  <Box
+                    sx={{
+                      width: NUM_GRADIENT_STEPS * GRADIENT_STEP_WIDTH,
+                      height: GRADIENT_HEIGHT,
+                      backgroundColor: theme.palette.action.hover,
+                      border: `1px solid ${theme.palette.divider}`,
+                    }}
+                  />
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      left: -GRADIENT_AXIS_OFFSET_LEFT,
+                    }}
+                  >
+                    <svg
+                      width={
+                        GRADIENT_AXIS_HORIZONTAL_PADDING +
+                        NUM_GRADIENT_STEPS * GRADIENT_STEP_WIDTH
+                      }
+                      height={GRADIENT_AXIS_VERTICAL_PADDING + GRADIENT_HEIGHT}
+                    >
+                      <AxisBottom
+                        scale={valuePixelScale}
+                        left={GRADIENT_AXIS_OFFSET_LEFT}
+                        top={GRADIENT_HEIGHT}
+                        labelProps={{
+                          fontSize: 14,
+                          textAnchor: 'middle',
+                          fill: theme.palette.text.secondary,
+                        }}
+                        label={m.attribute}
+                        stroke={theme.palette.text.secondary}
+                        tickStroke={theme.palette.text.secondary}
+                        tickLabelProps={() => ({
+                          fill: theme.palette.text.secondary,
+                          fontSize: 10,
+                          textAnchor: 'middle',
+                          verticalAnchor: 'end',
+                          dy: 2,
+                        })}
+                      />
+                    </svg>
+                  </Box>
+                </Box>
+              </Paper>
+            </Tooltip>
+            {handles.map((h, index) => {
+              const isEndHandle = index === 0 || index === handles.length - 1
+              const isMinHandle = index === 0
+              const isMaxHandle = index === handles.length - 1
 
-      <Divider />
-      <Box
+              return (
+                <Draggable
+                  key={h.id}
+                  disabled={isEndHandle}
+                  bounds="parent"
+                  axis="x"
+                  handle=".handle"
+                  onStart={() => setlastDraggedHandleId(h.id)}
+                  onStop={() => setlastDraggedHandleId(h.id)}
+                  onDrag={(e, data) => {
+                    const newValue = valuePixelScale.invert(data.x)
+                    setHandle(h.id, newValue, h.vpValue)
+                  }}
+                  position={{
+                    x: valuePixelScale(h.value as number),
+                    y: 0,
+                  }}
+                >
+                  <Box
+                    onClick={() => setlastDraggedHandleId(h.id)}
+                    sx={{
+                      width: 2,
+                      height: 1,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      position: 'absolute',
+                      zIndex:
+                        lastDraggedHandleId === h.id ? 3 : isEndHandle ? 1 : 2,
+                    }}
+                  >
+                    <Paper
+                      variant={isEndHandle ? 'outlined' : 'elevation'}
+                      elevation={isEndHandle ? 0 : 4}
+                      sx={{
+                        p: 0.5,
+                        position: 'relative',
+                        top: -195,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        zIndex:
+                          lastDraggedHandleId === h.id
+                            ? 3
+                            : isEndHandle
+                              ? 1
+                              : 2,
+                      }}
+                    >
+                      {handles.length >= 3 && !isEndHandle ? (
+                        <IconButton
+                          size="small"
+                          onClick={() => deleteHandle(h.id)}
+                          sx={{
+                            position: 'absolute',
+                            top: -10,
+                            right: -10,
+                            width: 20,
+                            height: 20,
+                            backgroundColor: (theme) =>
+                              theme.palette.text.secondary,
+                            color: (theme) => theme.palette.background.default,
+                            '&:hover': {
+                              cursor: 'pointer',
+                              backgroundColor: (theme) =>
+                                theme.palette.text.primary,
+                              color: (theme) => theme.palette.background.paper,
+                            },
+                          }}
+                        >
+                          <ClearIcon sx={{ fontSize: 16 }} />
+                        </IconButton>
+                      ) : !isEndHandle ? (
+                        <ClearIcon
+                          sx={{
+                            position: 'absolute',
+                            top: -10,
+                            right: -10,
+                            width: 20,
+                            height: 20,
+                            fontSize: 16,
+                            color: (theme) => theme.palette.text.disabled,
+                            pointerEvents: 'none',
+                          }}
+                        />
+                      ) : null}
+
+                      <Box sx={{ pl: 1.8, pr: 1.8, mb: 1 }}>
+                        <VisualPropertyValueForm
+                          currentValue={h.vpValue ?? null}
+                          visualProperty={props.visualProperty}
+                          currentNetworkId={props.currentNetworkId}
+                          onValueChange={(newValue) => {
+                            const val = newValue as VisualPropertyValueType
+                            if (isMinHandle) {
+                              setMinState({ ...minState, vpValue: val })
+                            } else if (isMaxHandle) {
+                              setMaxState({ ...maxState, vpValue: val })
+                            }
+                            setHandle(h.id, h.value as number, val)
+                          }}
+                        />
+                      </Box>
+                      <Box sx={{ mb: 1 }}>
+                        <ExpandableNumberInput
+                          value={h.value as number}
+                          onConfirm={(newValue) => {
+                            if (isMinHandle) {
+                              setMinState({ ...minState, value: newValue })
+                            } else if (isMaxHandle) {
+                              setMaxState({ ...maxState, value: newValue })
+                            } else {
+                              setHandle(h.id, newValue, h.vpValue)
+                            }
+                          }}
+                          min={
+                            isMinHandle
+                              ? undefined
+                              : (minState.value as number)
+                          }
+                          max={
+                            isMaxHandle
+                              ? undefined
+                              : (maxState.value as number)
+                          }
+                        />
+                      </Box>
+                    </Paper>
+
+                    <IconButton
+                      disabled={isEndHandle}
+                      className="handle"
+                      size="large"
+                      sx={{
+                        position: 'relative',
+                        top: -220,
+                        '&:hover': { cursor: 'col-resize' },
+                      }}
+                    >
+                      <ArrowDropDownIcon
+                        sx={{
+                          fontSize: '40px',
+                          color: (theme) =>
+                            isEndHandle
+                              ? theme.palette.text.disabled
+                              : theme.palette.text.secondary,
+                          zIndex: 3,
+                        }}
+                      />
+                    </IconButton>
+                  </Box>
+                </Draggable>
+              )
+            })}
+            <Tooltip
+              title={`${m.attribute} values less than the min (${minState.value}) will be mapped to this value.`}
+            >
+              <Paper
+                variant="outlined"
+                sx={{
+                  width: 50,
+                  height: 50,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  position: 'relative',
+                  top: -70,
+                  left: -70,
+                }}
+              >
+                <ArrowLeftIcon
+                  sx={{
+                    fontSize: 40,
+                    position: 'absolute',
+                    left: -27,
+                    color: (theme) => theme.palette.text.disabled,
+                  }}
+                />
+                <VisualPropertyValueForm
+                  currentValue={ltMin}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    const val = newValue as VisualPropertyValueType
+                    setLtMin(val)
+                    updateContinuousMapping(
+                      minState,
+                      maxState,
+                      handles,
+                      val,
+                      gtMax,
+                    )
+                  }}
+                />
+              </Paper>
+            </Tooltip>
+            <Tooltip
+              title={`${m.attribute} values greater than the max (${maxState.value}) will be mapped to this value.`}
+            >
+              <Paper
+                variant="outlined"
+                sx={{
+                  width: 50,
+                  height: 50,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  position: 'relative',
+                  top: -120,
+                  left: 580,
+                }}
+              >
+                <ArrowRightIcon
+                  sx={{
+                    fontSize: 40,
+                    position: 'absolute',
+                    left: 35,
+                    color: (theme) => theme.palette.text.disabled,
+                  }}
+                />
+                <VisualPropertyValueForm
+                  currentValue={gtMax}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) => {
+                    const val = newValue as VisualPropertyValueType
+                    setGtMax(val)
+                    updateContinuousMapping(
+                      minState,
+                      maxState,
+                      handles,
+                      ltMin,
+                      val,
+                    )
+                  }}
+                />
+              </Paper>
+            </Tooltip>
+          </Box>
+        </Paper>
+      </Box>
+
+      <Paper
+        variant="outlined"
         sx={{
           display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          py: 0.5,
+          p: 1,
+          justifyContent: 'space-evenly',
         }}
       >
-        <Typography variant="caption" sx={{ minWidth: 140 }}>
-          {`Above maximum`}
-        </Typography>
-        <VisualPropertyValueForm
-          currentValue={gtMax}
-          visualProperty={props.visualProperty}
-          currentNetworkId={props.currentNetworkId}
-          onValueChange={(newValue) => {
-            setGtMax(newValue)
-            commit(points, ltMin, newValue)
-          }}
-        />
-      </Box>
-
-      <Box sx={{ mt: 1, display: 'flex', justifyContent: 'flex-end' }}>
-        <IconButton size="small" onClick={addPoint} aria-label="add point">
-          <AddIcon fontSize="small" />
-        </IconButton>
-      </Box>
+        <Button
+          onClick={showCreateHandleMenu}
+          variant="outlined"
+          size="small"
+          startIcon={<AddIcon />}
+        >
+          New Handle
+        </Button>
+        <Popover
+          open={createHandleAnchorEl != null}
+          anchorEl={createHandleAnchorEl}
+          onClose={hideCreateHandleMenu}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+        >
+          <Box
+            sx={{ p: 1, display: 'flex', flexDirection: 'column', width: 200 }}
+          >
+            <Box sx={{ p: 1, display: 'flex', flexDirection: 'column' }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <Box
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {m.attribute}:
+                </Box>
+                <ExpandableNumberInput
+                  value={addHandleFormValue}
+                  onConfirm={(newValue) => setAddHandleFormValue(newValue)}
+                  min={minState.value as number}
+                  max={maxState.value as number}
+                />
+              </Box>
+              <Box
+                sx={{
+                  mt: 1,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
+                <Box
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    fontSize: '0.875rem',
+                  }}
+                >
+                  {props.visualProperty.displayName}:
+                </Box>
+                <VisualPropertyValueForm
+                  currentValue={addHandleFormVpValue}
+                  visualProperty={props.visualProperty}
+                  currentNetworkId={props.currentNetworkId}
+                  onValueChange={(newValue) =>
+                    setAddHandleFormVpValue(
+                      newValue as VisualPropertyValueType,
+                    )
+                  }
+                />
+              </Box>
+            </Box>
+            <Button
+              sx={{ alignSelf: 'flex-end', mt: 1 }}
+              size="small"
+              onClick={() => {
+                createHandle(addHandleFormValue, addHandleFormVpValue)
+                hideCreateHandleMenu()
+              }}
+            >
+              Add Handle
+            </Button>
+          </Box>
+        </Popover>
+      </Paper>
     </Paper>
   )
 }

--- a/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -277,16 +277,48 @@ export function ContinuousNumberMappingForm(props: {
     )
   }
 
+  //   const setHandle = (id: number, value: number, vpValue: number): void => {
+  //   setHandles((prevHandles) => {
+  //     const h = prevHandles.map((handle) => {
+  //       if (handle.id === id) {
+  //         return { ...handle, value, vpValue }
+  //       }
+  //       return handle
+  //     })
+
+  //     let nextMinState = minState
+  //     let nextMaxState = maxState
+
+  //     // Keep minState and maxState vpValue in sync when handles are updated
+  //     if (h[0] && h[0].id === id) {
+  //       nextMinState = { ...minState, vpValue }
+  //       setMinState(nextMinState)
+  //     }
+  //     if (h.length > 0 && h[h.length - 1].id === id) {
+  //       nextMaxState = { ...maxState, vpValue }
+  //       setMaxState(nextMaxState)
+  //     }
+
+  //     updateContinuousMapping(
+  //       nextMinState,
+  //       nextMaxState,
+  //       h,
+  //       m.ltMinVpValue,
+  //       m.gtMaxVpValue,
+  //     )
+  //     return h
+  //   })
+  // }
   const setHandle = (id: number, value: number, vpValue: number): void => {
     const newHandles = editHandle(handles, id, value, vpValue)
     setHandles(newHandles)
-    updateContinuousMapping(
+      updateContinuousMapping(
       minState,
       maxState,
       newHandles,
-      m.ltMinVpValue,
-      m.gtMaxVpValue,
-    )
+        m.ltMinVpValue,
+        m.gtMaxVpValue,
+      )
   }
 
   // when someone changes a handle, the new handle values may contain a new min/max value

--- a/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
+++ b/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/ContinuousNumberMappingForm.tsx
@@ -277,38 +277,6 @@ export function ContinuousNumberMappingForm(props: {
     )
   }
 
-  //   const setHandle = (id: number, value: number, vpValue: number): void => {
-  //   setHandles((prevHandles) => {
-  //     const h = prevHandles.map((handle) => {
-  //       if (handle.id === id) {
-  //         return { ...handle, value, vpValue }
-  //       }
-  //       return handle
-  //     })
-
-  //     let nextMinState = minState
-  //     let nextMaxState = maxState
-
-  //     // Keep minState and maxState vpValue in sync when handles are updated
-  //     if (h[0] && h[0].id === id) {
-  //       nextMinState = { ...minState, vpValue }
-  //       setMinState(nextMinState)
-  //     }
-  //     if (h.length > 0 && h[h.length - 1].id === id) {
-  //       nextMaxState = { ...maxState, vpValue }
-  //       setMaxState(nextMaxState)
-  //     }
-
-  //     updateContinuousMapping(
-  //       nextMinState,
-  //       nextMaxState,
-  //       h,
-  //       m.ltMinVpValue,
-  //       m.gtMaxVpValue,
-  //     )
-  //     return h
-  //   })
-  // }
   const setHandle = (id: number, value: number, vpValue: number): void => {
     const newHandles = editHandle(handles, id, value, vpValue)
     setHandles(newHandles)

--- a/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/index.tsx
+++ b/src/features/Vizmapper/Forms/MappingForm/ContinuousMappingForm/index.tsx
@@ -29,14 +29,14 @@ export function ContinuousMappingForm(props: {
   const edgeTable = tables[props.currentNetworkId]?.edgeTable
   const table = group === VisualPropertyGroup.Node ? nodeTable : edgeTable
 
+  if (m == null) {
+    return <Box></Box>
+  }
+
   const { attribute } = m
   const attributeType = table.columns.find((c) => c.name === attribute)?.type
 
   const { min, max, controlPoints } = m
-
-  if (m == null) {
-    return <Box></Box>
-  }
 
   if (
     attributeType !== ValueTypeName.Double &&

--- a/src/models/CxModel/impl/converters/visualStyleConverter.test.ts
+++ b/src/models/CxModel/impl/converters/visualStyleConverter.test.ts
@@ -43,7 +43,9 @@ describe('mapping robustness (regression: R2-19/R2-20)', () => {
     expect(mapping).toBeDefined()
     expect(mapping.type).toBe(MappingFunctionType.Continuous)
     expect(mapping.min.value).toBe(0)
+    expect(mapping.min.vpValue).toBe(10) // 2-entry maps fallback to out-of-bounds for the missing in-bounds
     expect(mapping.max.value).toBe(100)
+    expect(mapping.max.vpValue).toBe(50) // 2-entry maps fallback to out-of-bounds for the missing in-bounds
     expect(mapping.controlPoints).toEqual([])
     // gt/lt values are the already-converted boundary values, not
     // re-converted ones (the old code double-converted them)

--- a/src/models/CxModel/impl/converters/visualStyleConverter.ts
+++ b/src/models/CxModel/impl/converters/visualStyleConverter.ts
@@ -266,16 +266,20 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
 
               let min = null
               let max = null
+              let ltMinVpValue: VisualPropertyValueType | null = null
+              let gtMaxVpValue: VisualPropertyValueType | null = null
 
               if (
                 cxMapping.definition.map[0].max != null &&
                 cxMapping.definition.map[0].maxVPValue != null
               ) {
+                const outOfBoundsVal = cxMapping.definition.map[0].maxVPValue
+                const inBoundsVal = numMapEntries > 2 ? cxMapping.definition.map[1].minVPValue : outOfBoundsVal
+                
+                ltMinVpValue = converter.valueConverter(outOfBoundsVal as CXVisualPropertyValue)
                 min = {
                   value: cxMapping.definition.map[0].max as ValueType,
-                  vpValue: converter.valueConverter(
-                    cxMapping.definition.map[0].maxVPValue,
-                  ),
+                  vpValue: converter.valueConverter(inBoundsVal as CXVisualPropertyValue),
                   inclusive: cxMapping.definition.map[0].includeMax,
                 }
               }
@@ -284,13 +288,14 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                 cxMapping.definition.map[numMapEntries - 1].min != null &&
                 cxMapping.definition.map[numMapEntries - 1].minVPValue != null
               ) {
+                const outOfBoundsVal = cxMapping.definition.map[numMapEntries - 1].minVPValue
+                const inBoundsVal = numMapEntries > 2 ? cxMapping.definition.map[numMapEntries - 2].maxVPValue : outOfBoundsVal
+                
+                gtMaxVpValue = converter.valueConverter(outOfBoundsVal as CXVisualPropertyValue)
                 max = {
                   value: cxMapping.definition.map[numMapEntries - 1]
                     .min as ValueType,
-                  vpValue: converter.valueConverter(
-                    cxMapping.definition.map[numMapEntries - 1]
-                      .minVPValue as CXVisualPropertyValue,
-                  ),
+                  vpValue: converter.valueConverter(inBoundsVal as CXVisualPropertyValue),
                   inclusive:
                     cxMapping.definition.map[numMapEntries - 1].includeMin,
                 }
@@ -305,14 +310,18 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                 if (mapEntry.minVPValue != null && mapEntry.min != null) {
                   controlPoints.push({
                     value: mapEntry.min as ValueType,
-                    vpValue: converter.valueConverter(mapEntry.minVPValue),
+                    vpValue: converter.valueConverter(
+                      mapEntry.minVPValue as CXVisualPropertyValue,
+                    ),
                   })
                 }
 
                 if (mapEntry.maxVPValue != null && mapEntry.max != null) {
                   controlPoints.push({
                     value: mapEntry.max as ValueType,
-                    vpValue: converter.valueConverter(mapEntry.maxVPValue),
+                    vpValue: converter.valueConverter(
+                      mapEntry.maxVPValue as CXVisualPropertyValue,
+                    ),
                   })
                 }
               }
@@ -335,11 +344,8 @@ export const createVisualStyleFromCx = (cx: Cx2): VisualStyle => {
                   controlPoints: sortedCtrlPts,
                   visualPropertyType: vp.type,
                   defaultValue: vp.defaultValue,
-                  // min/max vpValues were already converted above — a
-                  // second valueConverter pass corrupts non-idempotent
-                  // converters (REVIEW.md R2-20)
-                  gtMaxVpValue: max.vpValue,
-                  ltMinVpValue: min.vpValue,
+                  gtMaxVpValue: gtMaxVpValue ?? max.vpValue,
+                  ltMinVpValue: ltMinVpValue ?? min.vpValue,
                   attributeType: cxMapping.definition.type,
                 }
                 visualStyle[vpName].mapping = m


### PR DESCRIPTION
This pull request focuses on improving the robustness and correctness of continuous mapping conversion from CX format, particularly for edge cases with only two mapping entries. The changes ensure that out-of-bounds visual property values are handled consistently and that value conversions are not applied multiple times, addressing issues with non-idempotent converters. Additionally, the pull request includes minor UI and test updates to support these changes.

**Improvements to continuous mapping conversion logic:**

* Updated the logic in `createVisualStyleFromCx` (`visualStyleConverter.ts`) to correctly assign in-bounds and out-of-bounds visual property values (`vpValue`, `ltMinVpValue`, `gtMaxVpValue`) for continuous mappings with only two entries, preventing double conversion and ensuring fallback to out-of-bounds values when needed. [[1]](diffhunk://#diff-1889d7d1a0c5693dc812e26931df794b4ee1ddc84214c1aa144df522a6f3e872R269-R282) [[2]](diffhunk://#diff-1889d7d1a0c5693dc812e26931df794b4ee1ddc84214c1aa144df522a6f3e872R291-R298) [[3]](diffhunk://#diff-1889d7d1a0c5693dc812e26931df794b4ee1ddc84214c1aa144df522a6f3e872L338-R348)
* Ensured that value conversion for control points is only applied once to avoid corrupting non-idempotent converters.

**Testing and validation:**

* Added and updated tests in `visualStyleConverter.test.ts` to verify that two-entry continuous mappings correctly fallback to out-of-bounds values for missing in-bounds values.

**UI and code cleanup:**

* Moved null check for mapping (`m == null`) earlier in the render logic of `ContinuousMappingForm/index.tsx` to prevent unnecessary computation.
* Removed old, commented-out logic for handle state management in `ContinuousNumberMappingForm.tsx` to clean up the code.