### PR TITLE
Fix/627 table browser

### DIFF
--- a/src/features/TableBrowser/ListValueEditorDialog.tsx
+++ b/src/features/TableBrowser/ListValueEditorDialog.tsx
@@ -247,7 +247,7 @@ export const ListValueEditorDialog = ({
         </Box>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>Cancel</Button>
+        <Button data-testid="list-value-editor-cancel" onClick={onCancel}>Cancel</Button>
         {tab === 0 ? (
           <>
             <Button

--- a/src/features/TableBrowser/TableBrowser.tsx
+++ b/src/features/TableBrowser/TableBrowser.tsx
@@ -58,6 +58,7 @@ import {
   SortType,
   valueDisplay,
 } from '../../models/TableModel/impl/valueTypeImpl'
+import { handleCellEdit } from './utils/cellEditHandler'
 import { Ui } from '../../models/UiModel'
 import { Panel } from '../../models/UiModel/Panel'
 import { PanelState } from '../../models/UiModel/PanelState'
@@ -1007,119 +1008,25 @@ export default function TableBrowser(props: {
 
   const onCellEdited = React.useCallback(
     (cell: Item, newValue: EditableGridCell) => {
-      const [columnIndex, rowIndex] = cell
-      const rowData = rows?.[rowIndex]
-      const cxId = rowData?.id
-      const column = columns?.[columnIndex]
-      const columnKey = column?.id
-      let data = newValue.data
-
-      if (rowData == null || cxId == null || column == null || data == null)
-        return
-      const prevCellValue = (rowData as any)?.[columnKey]
-
-      if (isListType(column.type)) {
-        if (serializedStringIsValid(column.type, data as string)) {
-          data = deserializeValueList(column.type, data as string)
-          postEdit(
-            UndoCommandType.SET_CELL_VALUE,
-            'Set cell value',
-            [
-              props.currentNetworkId,
-              currentTable == nodeTable ? 'node' : 'edge',
-              cxId,
-              columnKey,
-              prevCellValue,
-            ],
-            [
-              props.currentNetworkId,
-              currentTable == nodeTable ? 'node' : 'edge',
-              cxId,
-              columnKey,
-              data as ValueType,
-            ],
-          )
-          setCellValue(
-            props.currentNetworkId,
-            currentTable === nodeTable ? 'node' : 'edge',
-            `${cxId}`,
-            columnKey,
-            data as ValueType,
-          )
-          setNetworkModified(networkId, true)
-        }
-      } else {
-        if (
-          column.type !== ValueTypeName.Integer &&
-          column.type !== ValueTypeName.Long
-        ) {
-          postEdit(
-            UndoCommandType.SET_CELL_VALUE,
-            'Set cell value',
-            [
-              props.currentNetworkId,
-              currentTable == nodeTable ? 'node' : 'edge',
-              cxId,
-              columnKey,
-              prevCellValue,
-            ],
-            [
-              props.currentNetworkId,
-              currentTable == nodeTable ? 'node' : 'edge',
-              cxId,
-              columnKey,
-              data as ValueType,
-            ],
-          )
-          setCellValue(
-            props.currentNetworkId,
-            currentTable === nodeTable ? 'node' : 'edge',
-            `${cxId}`,
-            columnKey,
-            data as ValueType,
-          )
-          setNetworkModified(networkId, true)
-        } else {
-          if (Number.isInteger(data)) {
-            postEdit(
-              UndoCommandType.SET_CELL_VALUE,
-              'Set cell value',
-              [
-                props.currentNetworkId,
-                currentTable == nodeTable ? 'node' : 'edge',
-                cxId,
-                columnKey,
-                prevCellValue,
-              ],
-              [
-                props.currentNetworkId,
-                currentTable == nodeTable ? 'node' : 'edge',
-                cxId,
-                columnKey,
-                parseFloat(data as string),
-              ],
-            )
-            setCellValue(
-              props.currentNetworkId,
-              currentTable === nodeTable ? 'node' : 'edge',
-              `${cxId}`,
-              columnKey,
-              parseFloat(data as string),
-            )
-            setNetworkModified(networkId, true)
-          } else {
-            // the user is trying to assign a double value to a integer column.  Ignore this value.
-          }
-        }
-      }
+      handleCellEdit({
+        cell,
+        newValue,
+        rows,
+        allColumns,
+        currentTable,
+        nodeTable,
+        currentNetworkId: props.currentNetworkId,
+        postEdit,
+        setCellValue,
+        setNetworkModified: (id, modified) => setNetworkModified(id, modified),
+      })
     },
     [
       props.currentNetworkId,
       currentTable,
       rows,
-      columns,
+      allColumns,
       postEdit,
-      networkId,
       setNetworkModified,
       nodeTable,
       setCellValue,

--- a/src/features/TableBrowser/TableBrowser.tsx
+++ b/src/features/TableBrowser/TableBrowser.tsx
@@ -39,7 +39,6 @@ import { TableGrid } from './components/TableGrid'
 import { Ui } from '../../models/UiModel'
 import { Panel } from '../../models/UiModel/Panel'
 import { PanelState } from '../../models/UiModel/PanelState'
-import { NetworkView } from '../../models/ViewModel'
 import { ListValueEditorDialog } from './ListValueEditorDialog'
 
 import NetworkInfoPanel from './NetworkInfoPanel'
@@ -50,6 +49,10 @@ import { useListEditor } from './hooks/useListEditor';
 import { createHeaderIcons, handleDrawHeader } from './utils/tableRenderers';
 import { TabPanel } from './components/TabPanel'
 import { TableBrowserTabs } from './components/TableBrowserTabs'
+import { useTableMinMaxIds } from './hooks/useTableMinMaxIds'
+import { useTableScrollToTop } from './hooks/useTableScrollToTop'
+import { useIsContextCellVirtual } from './hooks/useIsContextCellVirtual'
+import { useDataEditorTheme } from './hooks/useDataEditorTheme'
 
 export interface TableColumn {
   id: string
@@ -58,6 +61,8 @@ export interface TableColumn {
   index: number
   width?: number
 }
+
+const EMPTY_ARRAY: IdType[] = []
 
 // Used for calculating proper height for the Data Grid
 const TABS_HEIGHT = 32
@@ -131,11 +136,12 @@ export default function TableBrowser(props: {
   )
   const setMapping = useVisualStyleStore((state) => state.setMapping)
 
-  const viewModel: NetworkView | undefined = useViewModelStore((state) =>
-    state.getViewModel(networkId),
+  const selectedNodes = useViewModelStore(
+    (state) => state.getViewModel(networkId)?.selectedNodes ?? EMPTY_ARRAY
   )
-  const selectedNodes = useViewModelStore(() => viewModel?.selectedNodes ?? [])
-  const selectedEdges = useViewModelStore(() => viewModel?.selectedEdges ?? [])
+  const selectedEdges = useViewModelStore(
+    (state) => state.getViewModel(networkId)?.selectedEdges ?? EMPTY_ARRAY
+  )
 
   const tableDisplayConfiguration = useUiStateStore(
     (state) =>
@@ -196,21 +202,15 @@ export default function TableBrowser(props: {
   const edgeTable = tables[networkId]?.edgeTable
   const network = useNetworkStore((state) => state.networks.get(networkId))
 
-  const nodeIds = Array.from(nodeTable?.rows?.keys() ?? new Map()).map(
-    (v) => +v,
+  const { minNodeId, maxNodeId, minEdgeId, maxEdgeId } = useTableMinMaxIds(
+    nodeTable,
+    edgeTable,
   )
-  const edgeIds = Array.from(edgeTable?.rows?.keys() ?? new Map()).map(
-    (v) => +v.slice(1),
-  )
-  const maxNodeId = nodeIds.sort((a, b) => b - a)[0]
-  const minNodeId = nodeIds.sort((a, b) => a - b)[0]
-  const maxEdgeId = edgeIds.sort((a, b) => b - a)[0]
-  const minEdgeId = edgeIds.sort((a, b) => a - b)[0]
+
   // Temporary fix: fallback to table columns if tableDisplayConfiguration is not found
   // Memoized so downstream memos (columns/allColumns) keep stable identities
   const {
     currentTable,
-    sort,
     setSort,
     allColumns,
     columns,
@@ -230,18 +230,7 @@ export default function TableBrowser(props: {
 
   
 
-  React.useEffect(() => {
-    // scroll to the first result anytime someone changes the filtered rows
-    // e.g. when the user selects nodes in the network view, scroll to the top of the list in the table
-    nodeDataEditorRef.current?.scrollTo(0, 0, 'both', 0, 0, {
-      vAlign: 'start',
-      hAlign: 'start',
-    })
-    edgeDataEditorRef.current?.scrollTo(0, 0, 'both', 0, 0, {
-      vAlign: 'start',
-      hAlign: 'start',
-    })
-  }, [selectedElements])
+  useTableScrollToTop(nodeDataEditorRef, edgeDataEditorRef, selectedElements)
 
   const handleChange = (
     event: React.SyntheticEvent,
@@ -429,13 +418,13 @@ export default function TableBrowser(props: {
 
 
   // scan the visual properties to see if the selected column name is used in any mappings
-  const visualPropertiesDependentOnSelectedColumn = Object.values(
-    visualStyle ?? {},
-  ).filter(
-    (vpValue) =>
-      selectedColumn?.id != null &&
-      vpValue?.mapping?.attribute === selectedColumn.id,
-  )
+  const visualPropertiesDependentOnSelectedColumn = React.useMemo(() => {
+    return Object.values(visualStyle ?? {}).filter(
+      (vpValue) =>
+        selectedColumn?.id != null &&
+        vpValue?.mapping?.attribute === selectedColumn.id,
+    )
+  }, [visualStyle, selectedColumn?.id])
   const tableBrowserToolbar = (
     <TableToolbar
       currentNetworkId={props.currentNetworkId}
@@ -465,29 +454,9 @@ export default function TableBrowser(props: {
     />
   )
 
-  const isContextCellVirtual =
-    contextMenu !== null &&
-    allColumns[contextMenu.cell[0]] &&
-    (allColumns[contextMenu.cell[0]] as any).isVirtual === true
+  const isContextCellVirtual = useIsContextCellVirtual(contextMenu, allColumns)
 
-  const dataEditorTheme = {
-    bgHeader: theme.palette.background.default,
-    bgHeaderHovered: theme.palette.action.hover,
-    bgHeaderHasFocus: theme.palette.action.focus,
-    textHeader: theme.palette.text.primary,
-    textHeaderSelected: theme.palette.primary.contrastText,
-    bgIconHeader: theme.palette.text.disabled,
-    fgIconHeader: theme.palette.background.default,
-    bgCell: theme.palette.background.paper,
-    bgCellMedium: theme.palette.background.paper,
-    bgCellLight: theme.palette.background.paper,
-    accentColor: theme.palette.primary.main,
-    accentLight: theme.palette.action.selected,
-    textDark: theme.palette.text.secondary,
-    textMedium: theme.palette.text.disabled,
-    textLight: theme.palette.text.disabled,
-    borderColor: theme.palette.divider,
-  }
+  const dataEditorTheme = useDataEditorTheme()
 
   return (
     <Box
@@ -547,8 +516,8 @@ export default function TableBrowser(props: {
           editorRef={nodeDataEditorRef}
           selection={selection}
           onGridSelectionChange={onGridSelectionChange}
-          minId={minNodeId}
-          maxId={maxNodeId}
+          minId={minNodeId ?? 0}
+          maxId={maxNodeId ?? 0}
           onCellContextMenu={onCellContextMenu}
           onCellActivated={onCellActivated}
           onPaste={onPaste}
@@ -572,8 +541,8 @@ export default function TableBrowser(props: {
           editorRef={edgeDataEditorRef}
           selection={selection}
           onGridSelectionChange={onGridSelectionChange}
-          minId={minEdgeId}
-          maxId={maxEdgeId}
+          minId={minEdgeId ?? 0}
+          maxId={maxEdgeId ?? 0}
           onCellContextMenu={onCellContextMenu}
           onCellActivated={onCellActivated}
           onPaste={onPaste}

--- a/src/features/TableBrowser/TableBrowser.tsx
+++ b/src/features/TableBrowser/TableBrowser.tsx
@@ -48,7 +48,7 @@ import { useTableData } from './hooks/useTableData';
 import { useListEditor } from './hooks/useListEditor';
 import { createHeaderIcons, handleDrawHeader } from './utils/tableRenderers';
 import { TabPanel } from './components/TabPanel'
-import { TableBrowserTabs } from './components/TableBrowserTabs'
+import { TableBrowserTabs, TableBrowserTab } from './components/TableBrowserTabs'
 import { useTableMinMaxIds } from './hooks/useTableMinMaxIds'
 import { useTableScrollToTop } from './hooks/useTableScrollToTop'
 import { useIsContextCellVirtual } from './hooks/useIsContextCellVirtual'
@@ -509,7 +509,7 @@ export default function TableBrowser(props: {
           </IconButton>
         </Tooltip>
       </Box>
-      <TabPanel value={currentTabIndex} index={0}>
+      <TabPanel value={currentTabIndex} index={TableBrowserTab.NODES}>
         {tableBrowserToolbar}
         <TableGrid
           testId="table-browser-node-editor"
@@ -534,7 +534,7 @@ export default function TableBrowser(props: {
           drawHeader={handleDrawHeader}
         />
       </TabPanel>
-      <TabPanel value={currentTabIndex} index={1}>
+      <TabPanel value={currentTabIndex} index={TableBrowserTab.EDGES}>
         {tableBrowserToolbar}
         <TableGrid
           testId="table-browser-edge-editor"
@@ -559,7 +559,7 @@ export default function TableBrowser(props: {
           drawHeader={handleDrawHeader}
         />
       </TabPanel>
-      <TabPanel value={currentTabIndex} index={2}>
+      <TabPanel value={currentTabIndex} index={TableBrowserTab.NETWORK}>
         <NetworkInfoPanel height={props.height - TOOLBAR_HEIGHT - 1} />
       </TabPanel>
       <TableContextMenu

--- a/src/features/TableBrowser/TableBrowser.tsx
+++ b/src/features/TableBrowser/TableBrowser.tsx
@@ -2,39 +2,19 @@ import '../../assets/icons.css'
 
 import {
   CellClickedEventArgs,
-  CompactSelection,
-  DataEditor,
   DataEditorRef,
   EditableGridCell,
   GridCell,
-  GridCellKind,
   GridColumn,
-  GridColumnIcon,
-  GridSelection,
   Item,
-  DrawHeaderCallback,
 } from '@glideapps/glide-data-grid'
-import {
-  CheckBoxOutlined as CheckBoxOutlinedIcon,
-  ContentCopy,
-  ContentPaste,
-} from '@mui/icons-material'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import {
-  Button,
-  Divider,
   IconButton,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
   Tooltip,
 } from '@mui/material'
 import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
-import Tab from '@mui/material/Tab'
-import Tabs from '@mui/material/Tabs'
-import orderBy from 'lodash/orderBy'
 import * as React from 'react'
 import { useEffect, useRef } from 'react'
 
@@ -47,40 +27,29 @@ import { useWorkspaceStore } from '../../data/hooks/stores/WorkspaceStore'
 import { useUndoStack } from '../../data/hooks/useUndoStack'
 import { useWindowSize } from '../../data/hooks/useWindowSize'
 import { IdType } from '../../models/IdType'
-import { CellEdit } from '../../models/StoreModel/TableStoreModel'
-import { UndoCommandType } from '../../models/StoreModel/UndoStoreModel'
-import { Table, ValueType, ValueTypeName } from '../../models/TableModel'
+import { Table, ValueTypeName } from '../../models/TableModel'
 import {
-  deserializeValue,
-  deserializeValueList,
-  isListType,
-  serializedStringIsValid,
-  SortType,
-  valueDisplay,
-} from '../../models/TableModel/impl/valueTypeImpl'
+  handleGetCellContent,
+} from './utils/cellContentHandler'
 import { handleCellEdit } from './utils/cellEditHandler'
+import { handleColumnMove, handleColumnResize } from './utils/columnHandlers'
+import { handlePaste } from './utils/pasteHandler'
+import { TableContextMenu } from './components/TableContextMenu'
+import { TableGrid } from './components/TableGrid'
 import { Ui } from '../../models/UiModel'
 import { Panel } from '../../models/UiModel/Panel'
 import { PanelState } from '../../models/UiModel/PanelState'
 import { NetworkView } from '../../models/ViewModel'
-import type { ColumnConfiguration } from '../../models/VisualStyleModel/VisualStyleOptions'
-import { isValidUrl } from '../../utils/urlUtil'
-import { useJoinTableToNetworkStore } from '../TableDataLoader/store/joinTableToNetworkStore'
-import { DuplicateIcon, EditIcon, SortAscIcon, SortDescIcon } from './Icon'
 import { ListValueEditorDialog } from './ListValueEditorDialog'
-import { getElementId, ID_COLUMN_ID, ID_COLUMN_TITLE } from './idColumn'
+
 import NetworkInfoPanel from './NetworkInfoPanel'
-import {
-  CreateTableColumnForm,
-  DeleteTableColumnForm,
-  EditTableColumnForm,
-} from './TableColumnForm'
-import { getValueTypeNameSVG, getBadgeWidth } from '../../models/TableModel/impl/valueTypeNameIcons'
-interface TabPanelProps {
-  children?: React.ReactNode
-  index: number
-  value: number
-}
+import { TableToolbar } from './components/TableToolbar'
+import { useTableSelection } from './hooks/useTableSelection';
+import { useTableData } from './hooks/useTableData';
+import { useListEditor } from './hooks/useListEditor';
+import { createHeaderIcons, handleDrawHeader } from './utils/tableRenderers';
+import { TabPanel } from './components/TabPanel'
+import { TableBrowserTabs } from './components/TableBrowserTabs'
 
 export interface TableColumn {
   id: string
@@ -97,119 +66,6 @@ const TOOLBAR_HEIGHT = 36
 // Adjust Data Grid size
 const GRID_GAP = TABS_HEIGHT + TOOLBAR_HEIGHT + 15
 
-const ButtonTooltip = ({
-  title,
-  children,
-}: {
-  title: string
-  children: React.ReactElement
-}) => (
-  <Tooltip
-    title={title}
-    placement="top"
-    PopperProps={{
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            offset: [0, -16],
-          },
-        },
-      ],
-    }}
-  >
-    {children}
-  </Tooltip>
-)
-
-const ToolbarIconButton = ({
-  title,
-  disabled = false,
-  onClick,
-  children,
-}: {
-  title: string
-  disabled?: boolean
-  onClick: () => void
-  children: React.ReactElement
-}) => (
-  <ButtonTooltip title={title}>
-    <span>
-      <Button
-        disabled={disabled}
-        onClick={onClick}
-        sx={{
-          minWidth: 48,
-          maxWidth: 48,
-          height: 48,
-          p: 0,
-          color: (theme) => theme.palette.text.primary,
-        }}
-      >
-        {children}
-      </Button>
-    </span>
-  </ButtonTooltip>
-)
-
-const ToolbarTextButton = ({
-  onClick,
-  children,
-}: {
-  onClick: () => void
-  children: React.ReactNode
-}) => (
-  <Button
-    variant="outlined"
-    size="small"
-    onClick={onClick}
-    sx={{
-      textTransform: 'none',
-      color: (theme) => theme.palette.text.primary,
-      borderColor: (theme) => theme.palette.text.secondary,
-      borderRadius: 4,
-    }}
-  >
-    {children}
-  </Button>
-)
-
-function TabPanel(props: TabPanelProps): React.ReactElement {
-  const { children, value, index, ...other } = props
-
-  return (
-    <Box
-      role="tabpanel"
-      hidden={value !== index}
-      id={`simple-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
-      sx={{ flexGrow: 1 }}
-      {...other}
-    >
-      {value === index && <>{children}</>}
-    </Box>
-  )
-}
-
-export const getCellKind = (type: ValueTypeName): GridCellKind => {
-  const valueTypeName2CellTypeMap: Record<ValueTypeName, GridCellKind> = {
-    [ValueTypeName.String]: GridCellKind.Text,
-    [ValueTypeName.Long]: GridCellKind.Number,
-    [ValueTypeName.Integer]: GridCellKind.Number,
-    [ValueTypeName.Double]: GridCellKind.Number,
-    [ValueTypeName.Boolean]: GridCellKind.Boolean,
-    [ValueTypeName.ListString]: GridCellKind.Text,
-    [ValueTypeName.ListLong]: GridCellKind.Text,
-    [ValueTypeName.ListInteger]: GridCellKind.Text,
-    [ValueTypeName.ListDouble]: GridCellKind.Text,
-    [ValueTypeName.ListBoolean]: GridCellKind.Text,
-  }
-  return valueTypeName2CellTypeMap[type] ?? GridCellKind.Text
-}
-
-export const getHeaderIconForType = (type: ValueTypeName): GridColumnIcon | string => {
-  return type as string
-}
 
 export default function TableBrowser(props: {
   currentNetworkId: IdType
@@ -225,41 +81,8 @@ export default function TableBrowser(props: {
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
 
-  const headerIcons = React.useMemo(() => {
-    const icons: Record<string, () => string> = {}
-    Object.values(ValueTypeName).forEach((type) => {
-      icons[type] = () => getValueTypeNameSVG(type, isDark)
-    })
-    return icons
-  }, [isDark])
+  const headerIcons = React.useMemo(() => createHeaderIcons(isDark), [isDark])
   
-  const handleDrawHeader = React.useCallback<DrawHeaderCallback>(({ ctx, column }) => {
-    // Only apply to columns that have our custom SVG badge type
-    const colType = (column as any).type as ValueTypeName
-    if (!colType || !Object.values(ValueTypeName).includes(colType)) {
-      return false
-    }
-
-    const badgeWidth = getBadgeWidth(colType)
-    const gap = 8
-
-    // glide-data-grid advances the text by Math.ceil(headerIconSize * 1.3)
-    const defaultAdvance = Math.ceil(badgeWidth * 1.3)
-    const desiredAdvance = badgeWidth + gap
-    const shift = desiredAdvance - defaultAdvance
-
-    const originalFillText = ctx.fillText
-    ctx.fillText = function (text, x, y, maxWidth) {
-      ctx.fillText = originalFillText
-      if (text === column.title) {
-        originalFillText.call(this, text, x + shift, y, maxWidth)
-      } else {
-        originalFillText.call(this, text, x, y, maxWidth)
-      }
-    }
-
-    return false
-  }, [])
   
   const setUi = useUiStateStore((state) => state.setUi)
   const currentTabIndex = ui.tableUi.activeTabIndex
@@ -281,24 +104,7 @@ export default function TableBrowser(props: {
     setUi(nextUi)
   }
 
-  const showTableJoinForm = useJoinTableToNetworkStore((state) => state.setShow)
-
   const setColumnWidth = useUiStateStore((state) => state.setColumnWidth)
-
-  const [showCreateColumnForm, setShowCreateColumnForm] = React.useState(false)
-  const [createColumnFormError, setCreateColumnFormError] = React.useState<
-    string | undefined
-  >(undefined)
-
-  const [showDeleteColumnForm, setShowDeleteColumnForm] = React.useState(false)
-  const [deleteColumnFormError, setDeleteColumnFormError] = React.useState<
-    string | undefined
-  >(undefined)
-
-  const [showEditColumnForm, setShowEditColumnForm] = React.useState(false)
-  const [columnFormError, setColumnFormError] = React.useState<
-    string | undefined
-  >(undefined)
 
   const [contextMenu, setContextMenu] = React.useState<{
     anchorPosition: { top: number; left: number }
@@ -309,44 +115,15 @@ export default function TableBrowser(props: {
     setContextMenu(null)
   }, [])
 
-  const [nodeSelection, setNodeSelection] = React.useState<GridSelection>({
-    columns: CompactSelection.empty(),
-    rows: CompactSelection.empty(),
-  })
-
-  const [edgeSelection, setEdgeSelection] = React.useState<GridSelection>({
-    columns: CompactSelection.empty(),
-    rows: CompactSelection.empty(),
-  })
-
-  const selection = currentTabIndex === 0 ? nodeSelection : edgeSelection
-  const setSelection =
-    currentTabIndex === 0 ? setNodeSelection : setEdgeSelection
-
-  const onGridSelectionChange = React.useCallback(
-    (newSelection: GridSelection) => {
-      setSelection(newSelection)
-    },
-    [setSelection],
-  )
+  const {
+    selection,
+    setSelection,
+    onGridSelectionChange,
+  } = useTableSelection({ currentTabIndex })
 
   const nodeDataEditorRef = React.useRef<DataEditorRef>(null)
   const edgeDataEditorRef = React.useRef<DataEditorRef>(null)
 
-  const [sort, setSort] = React.useState<SortType>({
-    column: undefined,
-    direction: undefined,
-    valueType: undefined,
-  })
-
-  // State for the dedicated list-value editor dialog (CW-563)
-  const [listEditor, setListEditor] = React.useState<{
-    cxId: IdType
-    columnKey: string
-    columnName: string
-    type: ValueTypeName
-    value: ValueType | null
-  } | null>(null)
 
   const networkId = props.currentNetworkId
   const visualStyle = useVisualStyleStore(
@@ -417,12 +194,7 @@ export default function TableBrowser(props: {
 
   const nodeTable = tables[networkId]?.nodeTable
   const edgeTable = tables[networkId]?.edgeTable
-  const currentTable = currentTabIndex === 0 ? nodeTable : edgeTable
   const network = useNetworkStore((state) => state.networks.get(networkId))
-  const currentTableConfig =
-    currentTabIndex === 0
-      ? tableDisplayConfiguration?.nodeTable
-      : tableDisplayConfiguration?.edgeTable
 
   const nodeIds = Array.from(nodeTable?.rows?.keys() ?? new Map()).map(
     (v) => +v,
@@ -436,291 +208,27 @@ export default function TableBrowser(props: {
   const minEdgeId = edgeIds.sort((a, b) => a - b)[0]
   // Temporary fix: fallback to table columns if tableDisplayConfiguration is not found
   // Memoized so downstream memos (columns/allColumns) keep stable identities
-  const modelColumns = React.useMemo(
-    () =>
-      currentTableConfig?.columnConfiguration ??
-      currentTable?.columns?.map((col) => ({
-        attributeName: col.name,
-        visible: true,
-        columnWidth: undefined,
-      })) ??
-      [],
-    [currentTableConfig, currentTable],
-  )
-
-  // Utility function to create a new TableDisplayConfiguration with updates
-  const createUpdatedTableDisplayConfiguration = React.useCallback(
-    (updates: {
-      columnConfiguration?: ColumnConfiguration[]
-      sortColumn?: string
-      sortDirection?: 'ascending' | 'descending'
-    }) => {
-      const isNodeTable = currentTable === nodeTable
-      // Temporary fix: create default config from table columns if tableDisplayConfiguration is missing
-      const defaultNodeConfig = {
-        columnConfiguration:
-          nodeTable?.columns?.map((col) => ({
-            attributeName: col.name,
-            visible: true,
-            columnWidth: undefined,
-          })) ?? [],
-        sortColumn: undefined,
-        sortDirection: undefined,
-      }
-      const defaultEdgeConfig = {
-        columnConfiguration:
-          edgeTable?.columns?.map((col) => ({
-            attributeName: col.name,
-            visible: true,
-            columnWidth: undefined,
-          })) ?? [],
-        sortColumn: undefined,
-        sortDirection: undefined,
-      }
-      const currentConfig = isNodeTable
-        ? (tableDisplayConfiguration?.nodeTable ?? defaultNodeConfig)
-        : (tableDisplayConfiguration?.edgeTable ?? defaultEdgeConfig)
-      const otherConfig = isNodeTable
-        ? (tableDisplayConfiguration?.edgeTable ?? defaultEdgeConfig)
-        : (tableDisplayConfiguration?.nodeTable ?? defaultNodeConfig)
-
-      const updatedConfig = {
-        ...currentConfig,
-        ...updates,
-      }
-
-      return isNodeTable
-        ? {
-            nodeTable: updatedConfig,
-            edgeTable: otherConfig,
-          }
-        : {
-            nodeTable: otherConfig,
-            edgeTable: updatedConfig,
-          }
-    },
-    [tableDisplayConfiguration, currentTable, nodeTable, edgeTable],
-  )
-
-  // Initialize sort state from tableDisplayConfiguration
-  React.useEffect(() => {
-    if (currentTableConfig?.sortColumn && currentTableConfig?.sortDirection) {
-      // Find the column type for the sort column
-      const sortColumn = currentTable?.columns?.find(
-        (c) => c.name === currentTableConfig.sortColumn,
-      )
-
-      setSort({
-        column: currentTableConfig.sortColumn,
-        direction:
-          currentTableConfig.sortDirection === 'ascending' ? 'asc' : 'desc',
-        valueType: sortColumn?.type ?? ValueTypeName.String,
-      })
-    }
-  }, [
-    tableDisplayConfiguration,
-    currentTabIndex,
+  const {
     currentTable,
-    currentTableConfig,
-  ])
+    sort,
+    setSort,
+    allColumns,
+    columns,
+    rows,
+    selectedElements,
+    createUpdatedTableDisplayConfiguration,
+  } = useTableData({
+    currentTabIndex,
+    nodeTable,
+    edgeTable,
+    network,
+    tableDisplayConfiguration,
+    selectedNodes,
+    selectedEdges,
+  })
 
-  const columns = React.useMemo(
-    () =>
-      modelColumns.map((col, index) => {
-        const columnType = currentTable?.columns?.find(
-          (c) => c?.name === col?.attributeName,
-        )?.type
 
-        const attributeName = col?.attributeName ?? ''
-        const resolvedType = columnType ?? ValueTypeName.String
-
-        const badgeWidth = getBadgeWidth(resolvedType)
-        const charWidth = 8
-        const padding = 48
-        const calculatedWidth = Math.max(100, attributeName.length * charWidth + badgeWidth + padding)
-
-        const baseColumn = {
-          id: attributeName,
-          title: attributeName,
-          icon: getHeaderIconForType(resolvedType),
-          themeOverride: { headerIconSize: badgeWidth },
-          type: resolvedType,
-          index,
-        }
-
-        return col?.columnWidth !== undefined
-          ? { ...baseColumn, width: col.columnWidth }
-          : { ...baseColumn, width: calculatedWidth }
-      }),
-    [modelColumns, currentTable],
-  )
-
-  // Add virtual columns for edge table to show source and target node names
-  const virtualColumns = React.useMemo(() => {
-    if (currentTable !== edgeTable) {
-      return []
-    }
-
-    // Create a map of node ID to node name/label for lookup
-    const nodeNameMap = new Map<string, string>()
-    if (nodeTable) {
-      nodeTable.rows.forEach((nodeData, nodeId) => {
-        const nodeName =
-          (nodeData.name as string) ||
-          (nodeData.label as string) ||
-          (nodeData.nodeLabel as string) ||
-          (nodeData.displayName as string) ||
-          (nodeData.title as string) ||
-          nodeId.toString()
-        nodeNameMap.set(nodeId.toString(), nodeName)
-      })
-    }
-
-    return [
-      {
-        id: '__sourceNodeName',
-        title: 'Source Node',
-        icon: GridColumnIcon.ProtectedColumnOverlay,
-        style: 'highlight' as const,
-        type: ValueTypeName.String,
-        index: 0,
-        width: 150,
-        isVirtual: true,
-        getValue: (edgeData: any) => {
-          // Get edge id from edgeData
-          const edgeId = edgeData?.id?.toString()
-          // Look up edge in network model
-          const edge = network?.edges?.find(
-            (e: any) => e.id?.toString() === edgeId,
-          )
-          const sourceId = edge?.s?.toString()
-          return sourceId ? nodeNameMap.get(sourceId) || `Node ${sourceId}` : ''
-        },
-      },
-      {
-        id: '__targetNodeName',
-        title: 'Target Node',
-        icon: GridColumnIcon.ProtectedColumnOverlay,
-        style: 'highlight' as const,
-
-        type: ValueTypeName.String,
-        index: 1,
-        width: 150,
-        isVirtual: true,
-        getValue: (edgeData: any) => {
-          const edgeId = edgeData?.id?.toString()
-          const edge = network?.edges?.find(
-            (e: any) => e.id?.toString() === edgeId,
-          )
-          const targetId = edge?.t?.toString()
-          return targetId ? nodeNameMap.get(targetId) || `Node ${targetId}` : ''
-        },
-      },
-    ]
-  }, [currentTable, edgeTable, nodeTable, network])
-
-  // Read-only virtual column exposing the element id, so users can discover the
-  // ids consumed by the selectednodes / selectededges URL parameters (CW-537).
-  const idColumn = React.useMemo(
-    () => ({
-      id: ID_COLUMN_ID,
-      title: ID_COLUMN_TITLE,
-      icon: GridColumnIcon.ProtectedColumnOverlay,
-      style: 'highlight' as const,
-      type: ValueTypeName.String,
-      index: 0,
-      width: 120,
-      isVirtual: true,
-      getValue: (dataRow: any) => getElementId(dataRow),
-    }),
-    [],
-  )
-
-  // Combine the id column, regular columns, and (for edges) the source/target
-  // virtual columns. The id column leads both tables.
-  const allColumns = React.useMemo(
-    () =>
-      currentTable === edgeTable
-        ? [idColumn, ...virtualColumns, ...columns]
-        : [idColumn, ...columns],
-    [currentTable, edgeTable, idColumn, virtualColumns, columns],
-  )
-
-  const selectedElements = currentTabIndex === 0 ? selectedNodes : selectedEdges
-
-  // Filtered (by selection) and sorted rows, memoized so grid callbacks that
-  // depend on `rows` keep a stable identity between unrelated renders
-  const rows = React.useMemo(() => {
-    const selectedElementsSet = new Set(selectedElements)
-    const rowsWithIds = Array.from(
-      (currentTable?.rows ?? new Map()).entries(),
-    ).map(([key, value]) => ({ ...value, id: key }))
-    let result =
-      selectedElements?.length > 0
-        ? rowsWithIds.filter((r) => selectedElementsSet.has(r.id))
-        : rowsWithIds
-
-    if (
-      sort.column != null &&
-      sort.direction != null &&
-      sort.valueType != null
-    ) {
-      // Handle sorting for virtual columns
-      if (
-        sort.column === '__sourceNodeName' ||
-        sort.column === '__targetNodeName'
-      ) {
-        // Create a map of node ID to node name for lookup
-        const nodeNameMap = new Map<string, string>()
-        if (nodeTable) {
-          nodeTable.rows.forEach((nodeData, nodeId) => {
-            const nodeName =
-              (nodeData.name as string) ||
-              (nodeData.label as string) ||
-              (nodeData.nodeLabel as string) ||
-              (nodeData.displayName as string) ||
-              (nodeData.title as string) ||
-              nodeId.toString()
-            nodeNameMap.set(nodeId.toString(), nodeName)
-          })
-        }
-
-        result = orderBy(
-          result,
-          (o) => {
-            if (sort.column === '__sourceNodeName') {
-              const sourceId = (o as any).s?.toString()
-              return sourceId
-                ? nodeNameMap.get(sourceId) || `Node ${sourceId}`
-                : ''
-            } else if (sort.column === '__targetNodeName') {
-              const targetId = (o as any).t?.toString()
-              return targetId
-                ? nodeNameMap.get(targetId) || `Node ${targetId}`
-                : ''
-            }
-            return ''
-          },
-          sort.direction,
-        )
-      } else if (sort.column === ID_COLUMN_ID) {
-        // The id lives on the row as `id`, not under the virtual column key.
-        result = orderBy(result, (o) => getElementId(o), sort.direction)
-      } else {
-        // Regular column sorting
-        result = orderBy(
-          result,
-          (o) =>
-            (o as Record<string, ValueType>)[
-              sort.column as string
-            ] as ValueType,
-          sort.direction,
-        )
-      }
-    }
-
-    return result
-  }, [selectedElements, currentTable, sort, nodeTable])
+  
 
   React.useEffect(() => {
     // scroll to the first result anytime someone changes the filtered rows
@@ -744,162 +252,45 @@ export default function TableBrowser(props: {
 
   const getContent = React.useCallback(
     (cell: Item): GridCell => {
-      const [columnIndex, rowIndex] = cell
-      const dataRow = rows?.[rowIndex]
-      const column = allColumns?.[columnIndex]
-      const columnKey = column?.id
-
-      // Handle virtual columns
-      if ((column as any).isVirtual) {
-        const virtualColumn = column as any
-        const cellValue = virtualColumn.getValue(dataRow)
-        return {
-          cursor: 'not-allowed',
-          themeOverride: {
-            bgCell: '#D9D9D9',
-          },
-          allowOverlay: false, // Virtual columns are read-only
-          readonly: true,
-          kind: GridCellKind.Text,
-          displayData: String(cellValue),
-          data: String(cellValue),
-        }
-      }
-
-      if (dataRow == null || column == null) {
-        return {
-          allowOverlay: true,
-          readonly: false,
-          kind: GridCellKind.Text,
-          displayData: '',
-          data: '',
-        }
-      }
-
-      // Handle regular columns
-      const cellValue = (dataRow as any)?.[columnKey]
-      if (cellValue == null) {
-        return {
-          allowOverlay: true,
-          readonly: false,
-          kind: GridCellKind.Text,
-          displayData: '',
-          data: '',
-        }
-      }
-
-      const cellType = getCellKind(column.type)
-      const processedCellValue = valueDisplay(cellValue, column.type)
-
-      // List-typed cells (CW-563) are not edited inline: typing into a text
-      // overlay collapsed multi-item lists into a single element. They are
-      // shown read-only here and edited through the dedicated list editor
-      // dialog, opened via onCellActivated.
-      if (isListType(column.type)) {
-        return {
-          kind: GridCellKind.Text,
-          allowOverlay: false,
-          readonly: true,
-          displayData: String(processedCellValue),
-          data: String(processedCellValue),
-        }
-      }
-
-      // These cells generally prevent users from inputting mismatched data types
-      // e.g. a user can't but a boolean in a number, a string in a number, etc.
-      // The exception is that users can still input floats into integer columns
-      // Extra validation for this logic is done in onCellEdited
-      if (cellType === GridCellKind.Boolean) {
-        return {
-          allowOverlay: false,
-          kind: cellType,
-          readonly: false,
-          data: processedCellValue as boolean,
-        }
-      } else if (cellType === GridCellKind.Number) {
-        return {
-          allowOverlay: true,
-          kind: cellType,
-          readonly: false,
-          displayData: String(processedCellValue),
-          data: processedCellValue as number,
-        }
-      } else {
-        if (isValidUrl(String(processedCellValue))) {
-          return {
-            kind: GridCellKind.Uri,
-            allowOverlay: true,
-            readonly: false,
-            data: processedCellValue as string,
-          }
-        }
-        return {
-          kind: GridCellKind.Text,
-          allowOverlay: true,
-          displayData: String(processedCellValue),
-          readonly: false,
-          data: processedCellValue as string,
-        }
-      }
+      return handleGetCellContent({ cell, rows, allColumns })
     },
     [rows, allColumns],
   )
 
+
+  const {
+    listEditor,
+    setListEditor,
+    onCellActivated,
+    handleListEditorSave,
+  } = useListEditor({
+    allColumns,
+    rows,
+    currentTable,
+    nodeTable,
+    currentNetworkId: props.currentNetworkId,
+    networkId,
+    postEdit,
+    setCellValue,
+    setNetworkModified,
+  })
+
   const onColMoved = React.useCallback(
     (startIndex: number, endIndex: number): void => {
-      // Don't allow moving virtual columns
-      const startColumn = allColumns[startIndex]
-      const endColumn = allColumns[endIndex]
-      if ((startColumn as any)?.isVirtual || (endColumn as any)?.isVirtual) {
-        return
-      }
-
-      // offset the virtual column indices
-      const realColumns = allColumns.filter((col) => !(col as any).isVirtual)
-      const startColId = allColumns[startIndex]?.id
-      const endColId = allColumns[endIndex]?.id
-      const realStartIndex = realColumns.findIndex(
-        (col) => col.id === startColId,
-      )
-      const realEndIndex = realColumns.findIndex((col) => col.id === endColId)
-      if (realStartIndex === -1 || realEndIndex === -1) return
-
-      moveColumn(
+      handleColumnMove({
+        startIndex,
+        endIndex,
+        allColumns,
         networkId,
-        currentTable === nodeTable ? 'node' : 'edge',
-        realStartIndex,
-        realEndIndex,
-      )
-
-      // Create updated column configuration with moved column
-      // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
-      const defaultConfig = {
-        columnConfiguration:
-          (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map(
-            (col) => ({
-              attributeName: col.name,
-              visible: true,
-              columnWidth: undefined,
-            }),
-          ) ?? [],
-        sortColumn: undefined,
-        sortDirection: undefined,
-      }
-      const currentConfig =
-        currentTable === nodeTable
-          ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
-          : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
-      const nextColumnConfig = [...currentConfig.columnConfiguration]
-      const [movedColumn] = nextColumnConfig.splice(realStartIndex, 1)
-      nextColumnConfig.splice(realEndIndex, 0, movedColumn)
-
-      // Use utility function to create new configuration
-      const newTableDisplayConfiguration =
-        createUpdatedTableDisplayConfiguration({
-          columnConfiguration: nextColumnConfig,
-        })
-      setTableDisplayConfiguration(networkId, newTableDisplayConfiguration)
-      setNetworkModified(networkId, true)
+        currentTable,
+        nodeTable,
+        edgeTable,
+        tableDisplayConfiguration,
+        moveColumn,
+        createUpdatedTableDisplayConfiguration,
+        setTableDisplayConfiguration,
+        setNetworkModified: (id, modified) => setNetworkModified(id, modified),
+      })
     },
     [
       allColumns,
@@ -932,51 +323,21 @@ export default function TableBrowser(props: {
 
   const onColumnResize = React.useCallback(
     (column: GridColumn, newSize: number, colIndex: number): void => {
-      if (column?.id !== undefined) {
-        // Don't allow resizing virtual columns
-        const columnData = allColumns[colIndex]
-        if ((columnData as any)?.isVirtual) {
-          return
-        }
-
-        setColumnWidth(
-          networkId,
-          currentTable === nodeTable ? 'node' : 'edge',
-          column.id,
-          newSize,
-        )
-
-        // Update the width in the tableDisplayConfiguration using utility function
-        // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
-        const defaultConfig = {
-          columnConfiguration:
-            (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map(
-              (col) => ({
-                attributeName: col.name,
-                visible: true,
-                columnWidth: undefined,
-              }),
-            ) ?? [],
-          sortColumn: undefined,
-          sortDirection: undefined,
-        }
-        const currentConfig =
-          currentTable === nodeTable
-            ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
-            : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
-        const nextColumnConfig = currentConfig.columnConfiguration.map((col) =>
-          col.attributeName === column.id
-            ? { ...col, columnWidth: newSize }
-            : col,
-        )
-
-        const newTableDisplayConfiguration =
-          createUpdatedTableDisplayConfiguration({
-            columnConfiguration: nextColumnConfig,
-          })
-        setTableDisplayConfiguration(networkId, newTableDisplayConfiguration)
-        setNetworkModified(networkId, true)
-      }
+      handleColumnResize({
+        column,
+        newSize,
+        colIndex,
+        allColumns,
+        networkId,
+        currentTable,
+        nodeTable,
+        edgeTable,
+        tableDisplayConfiguration,
+        setColumnWidth,
+        createUpdatedTableDisplayConfiguration,
+        setTableDisplayConfiguration,
+        setNetworkModified: (id, modified) => setNetworkModified(id, modified),
+      })
     },
     [
       allColumns,
@@ -1033,124 +394,21 @@ export default function TableBrowser(props: {
     ],
   )
 
-  // Open the dedicated list editor when a list-typed cell is activated
-  // (double-click / Enter). CW-563.
-  const onCellActivated = React.useCallback(
-    (cell: Item): void => {
-      const [columnIndex, rowIndex] = cell
-      const column = allColumns?.[columnIndex]
-      const rowData = rows?.[rowIndex]
-      if (column == null || rowData == null || (column as any).isVirtual) return
-      if (!isListType(column.type)) return
-      const cxId = rowData.id
-      if (cxId == null) return
-      setListEditor({
-        cxId,
-        columnKey: column.id,
-        // Use the raw attribute name, not the header title (which now carries
-        // the data-type abbreviation, CW-562).
-        columnName: column.id,
-        type: column.type,
-        value: (rowData as any)?.[column.id] ?? null,
-      })
-    },
-    [allColumns, rows],
-  )
-
-  // Commit a value chosen in the list editor dialog, mirroring onCellEdited's
-  // undo bookkeeping and store update.
-  const handleListEditorSave = React.useCallback(
-    (newValue: ValueType): void => {
-      if (listEditor == null) return
-      const { cxId, columnKey } = listEditor
-      const elementType = currentTable === nodeTable ? 'node' : 'edge'
-      postEdit(
-        UndoCommandType.SET_CELL_VALUE,
-        'Set cell value',
-        [props.currentNetworkId, elementType, cxId, columnKey, listEditor.value],
-        [props.currentNetworkId, elementType, cxId, columnKey, newValue],
-      )
-      setCellValue(
-        props.currentNetworkId,
-        elementType,
-        `${cxId}`,
-        columnKey,
-        newValue,
-      )
-      setNetworkModified(networkId, true)
-      setListEditor(null)
-    },
-    [
-      listEditor,
-      currentTable,
-      nodeTable,
-      postEdit,
-      props.currentNetworkId,
-      setCellValue,
-      setNetworkModified,
-      networkId,
-    ],
-  )
 
   const onPaste = React.useCallback(
     (target: Item, values: readonly (readonly string[])[]) => {
-      const [startCol, startRow] = target
-      const cellEdits: CellEdit[] = []
-      const prevCellEdits: CellEdit[] = []
-
-      for (let dy = 0; dy < values.length; dy++) {
-        const rowIndex = startRow + dy
-        const rowData = rows?.[rowIndex]
-        if (rowData == null) continue
-
-        for (let dx = 0; dx < values[dy].length; dx++) {
-          const colIndex = startCol + dx
-          const column = allColumns?.[colIndex]
-          if (column == null || (column as any).isVirtual) continue
-
-          const pastedString = values[dy][dx]
-          if (!serializedStringIsValid(column.type, pastedString)) continue
-
-          const newValue = deserializeValue(column.type, pastedString)
-          const prevValue = (rowData as any)?.[column.id] as ValueType
-
-          cellEdits.push({
-            row: rowData.id,
-            column: column.id,
-            value: newValue as ValueType,
-          })
-          prevCellEdits.push({
-            row: rowData.id,
-            column: column.id,
-            value: prevValue,
-          })
-        }
-      }
-
-      if (cellEdits.length > 0) {
-        postEdit(
-          UndoCommandType.APPLY_VALUE_TO_SELECTED,
-          'Paste cell values',
-          [
-            props.currentNetworkId,
-            currentTable === nodeTable ? 'node' : 'edge',
-            prevCellEdits,
-          ],
-          [
-            props.currentNetworkId,
-            currentTable === nodeTable ? 'node' : 'edge',
-            cellEdits,
-          ],
-        )
-        setValues(
-          props.currentNetworkId,
-          currentTable === nodeTable ? 'node' : 'edge',
-          cellEdits,
-        )
-        setNetworkModified(networkId, true)
-      }
-
-      return false
+      return handlePaste({
+        target,
+        values,
+        rows,
+        allColumns,
+        currentNetworkId: props.currentNetworkId,
+        currentTable,
+        nodeTable,
+        postEdit,
+        setValues,
+        setNetworkModified: (id, modified) => setNetworkModified(id, modified),
+      })
     },
     [
       rows,
@@ -1161,16 +419,14 @@ export default function TableBrowser(props: {
       postEdit,
       setValues,
       setNetworkModified,
-      networkId,
+
     ],
   )
 
   const selectedColumn =
     selection.columns.length > 0 ? allColumns[selection.columns.first()!] : null
 
-  // Check if the selected column is a virtual column
-  const isSelectedColumnVirtual =
-    selectedColumn && (selectedColumn as any).isVirtual
+
 
   // scan the visual properties to see if the selected column name is used in any mappings
   const visualPropertiesDependentOnSelectedColumn = Object.values(
@@ -1180,613 +436,33 @@ export default function TableBrowser(props: {
       selectedColumn?.id != null &&
       vpValue?.mapping?.attribute === selectedColumn.id,
   )
-  const selectedColumnToolbar =
-    selectedColumn != null && !isSelectedColumnVirtual ? (
-      <>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: 2,
-          }}
-        >
-          <ToolbarIconButton
-            title="Sort ascending"
-            onClick={() => {
-              if (selectedColumn != null) {
-                const columnKey = selectedColumn.id
-                const columnType = selectedColumn.type
-
-                setSort({
-                  column: columnKey,
-                  direction: 'asc',
-                  valueType: columnType,
-                })
-
-                // Use utility function to update tableDisplayConfiguration with sort info
-                const newTableDisplayConfiguration =
-                  createUpdatedTableDisplayConfiguration({
-                    sortColumn: columnKey,
-                    sortDirection: 'ascending',
-                  })
-
-                setTableDisplayConfiguration(
-                  networkId,
-                  newTableDisplayConfiguration,
-                )
-                setNetworkModified(networkId, true)
-              }
-            }}
-          >
-            <SortAscIcon fill={theme.palette.text.primary} />
-          </ToolbarIconButton>
-          <ToolbarIconButton
-            title="Sort descending"
-            onClick={() => {
-              if (selectedColumn != null) {
-                const columnKey = selectedColumn.id
-                const columnType = selectedColumn.type
-                setSort({
-                  column: columnKey,
-                  direction: 'desc',
-                  valueType: columnType,
-                })
-
-                // Use utility function to update tableDisplayConfiguration with sort info
-                const newTableDisplayConfiguration =
-                  createUpdatedTableDisplayConfiguration({
-                    sortColumn: columnKey,
-                    sortDirection: 'descending',
-                  })
-                setTableDisplayConfiguration(
-                  networkId,
-                  newTableDisplayConfiguration,
-                )
-                setNetworkModified(networkId, true)
-              }
-            }}
-          >
-            <SortDescIcon fill={theme.palette.text.primary} />
-          </ToolbarIconButton>
-          <ToolbarIconButton
-            title="Duplicate column"
-            onClick={() => {
-              if (
-                selectedColumn !== null &&
-                !(selectedColumn as any)?.isVirtual
-              ) {
-                const columnKey = selectedColumn.id
-                duplicateColumn(
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  columnKey,
-                )
-                setNetworkModified(networkId, true)
-
-                setSelection({
-                  ...selection,
-                  columns: CompactSelection.fromSingleSelection(
-                    selectedColumn.index + 1, // select the newly created column
-                  ),
-                })
-
-                // Update tableDisplayConfiguration for duplicate
-                // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
-                const defaultConfig = {
-                  columnConfiguration:
-                    (currentTable === nodeTable
-                      ? nodeTable
-                      : edgeTable
-                    )?.columns?.map((col) => ({
-                      attributeName: col.name,
-                      visible: true,
-                      columnWidth: undefined,
-                    })) ?? [],
-                  sortColumn: undefined,
-                  sortDirection: undefined,
-                }
-                const currentConfig =
-                  currentTable === nodeTable
-                    ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
-                    : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
-                // Find the duplicated column in the config
-                const duplicatedCol = currentConfig.columnConfiguration.find(
-                  (col) => col.attributeName === columnKey,
-                )
-                // The new column will have a new name, which should be the next column in the table
-                // We'll assume the duplicated column is inserted right after the original
-                // Find the new column name by checking the columns array
-                const allColumnNames = columns.map((c) => c.id)
-                const originalIndex = allColumnNames.indexOf(columnKey)
-                const newColumnName = allColumnNames[originalIndex + 1]
-                if (duplicatedCol && newColumnName) {
-                  const newColConfig = [
-                    ...currentConfig.columnConfiguration.slice(
-                      0,
-                      originalIndex + 1,
-                    ),
-                    { ...duplicatedCol, attributeName: newColumnName },
-                    ...currentConfig.columnConfiguration.slice(
-                      originalIndex + 1,
-                    ),
-                  ]
-                  const newTableDisplayConfiguration =
-                    createUpdatedTableDisplayConfiguration({
-                      columnConfiguration: newColConfig,
-                    })
-                  setTableDisplayConfiguration(
-                    networkId,
-                    newTableDisplayConfiguration,
-                  )
-                  setNetworkModified(networkId, true)
-                }
-              }
-            }}
-            disabled={(selectedColumn as any)?.isVirtual}
-          >
-            <DuplicateIcon fill={theme.palette.text.primary} />
-          </ToolbarIconButton>
-          <ToolbarIconButton
-            title="Rename column"
-            onClick={() => setShowEditColumnForm(true)}
-            disabled={(selectedColumn as any)?.isVirtual}
-          >
-            <EditIcon fill={theme.palette.text.primary} />
-          </ToolbarIconButton>
-          <ToolbarIconButton
-            title="Delete column"
-            onClick={() => {
-              setShowDeleteColumnForm(true)
-            }}
-            disabled={(selectedColumn as any)?.isVirtual}
-          >
-            <span className="icon">&#46;</span>
-          </ToolbarIconButton>
-        </Box>
-        <EditTableColumnForm
-          error={columnFormError}
-          dependentVisualProperties={visualPropertiesDependentOnSelectedColumn}
-          open={showEditColumnForm}
-          column={selectedColumn}
-          onClose={() => {
-            setShowEditColumnForm(false)
-            setColumnFormError(undefined)
-          }}
-          onSubmit={(newColumnName: string, mappingUpdateType) => {
-            const columnNameSet = new Set(columns?.map((c) => c.id))
-            if (columnNameSet.has(newColumnName)) {
-              setColumnFormError(
-                `${newColumnName} already exists.  Please enter a new unique column name`,
-              )
-            } else {
-              postEdit(
-                UndoCommandType.RENAME_COLUMN,
-                `Rename column '${selectedColumn.title}' to '${newColumnName}'`,
-                [
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  newColumnName,
-                  selectedColumn.id,
-                ],
-                [
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  selectedColumn.id,
-                  newColumnName,
-                ],
-              )
-              setColumnName(
-                props.currentNetworkId,
-                currentTable === nodeTable ? 'node' : 'edge',
-                selectedColumn.id,
-                newColumnName,
-              )
-              setNetworkModified(networkId, true)
-
-              // Update tableDisplayConfiguration for rename
-              // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
-              const defaultConfig = {
-                columnConfiguration:
-                  (currentTable === nodeTable
-                    ? nodeTable
-                    : edgeTable
-                  )?.columns?.map((col) => ({
-                    attributeName: col.name,
-                    visible: true,
-                    columnWidth: undefined,
-                  })) ?? [],
-                sortColumn: undefined,
-                sortDirection: undefined,
-              }
-              const currentConfig =
-                currentTable === nodeTable
-                  ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
-                  : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
-              const newColumnConfig = currentConfig.columnConfiguration.map(
-                (col) =>
-                  col.attributeName === selectedColumn.id
-                    ? { ...col, attributeName: newColumnName }
-                    : col,
-              )
-              const newTableDisplayConfiguration =
-                createUpdatedTableDisplayConfiguration({
-                  columnConfiguration: newColumnConfig,
-                })
-              setTableDisplayConfiguration(
-                networkId,
-                newTableDisplayConfiguration,
-              )
-              setNetworkModified(networkId, true)
-
-              if (mappingUpdateType === 'rename') {
-                visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
-                  if (vp.mapping != null) {
-                    setMapping(props.currentNetworkId, vp.name, {
-                      ...vp.mapping,
-                      attribute: newColumnName,
-                    })
-                  }
-                })
-              } else if (mappingUpdateType === 'delete') {
-                visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
-                  setMapping(props.currentNetworkId, vp.name, undefined)
-                })
-              }
-              setColumnFormError(undefined)
-              setShowEditColumnForm(false)
-            }
-          }}
-        />
-        <DeleteTableColumnForm
-          error={deleteColumnFormError}
-          dependentVisualProperties={visualPropertiesDependentOnSelectedColumn}
-          open={showDeleteColumnForm}
-          column={selectedColumn}
-          onClose={() => {
-            setShowDeleteColumnForm(false)
-            setDeleteColumnFormError(undefined)
-          }}
-          onSubmit={(mappingUpdateType) => {
-            postEdit(
-              UndoCommandType.DELETE_COLUMN,
-              `Delete ${currentTable === nodeTable ? 'node' : 'edge'} column ${selectedColumn.title}`,
-              [
-                props.currentNetworkId,
-                currentTable === nodeTable ? 'node' : 'edge',
-                currentTable,
-                selectedColumn,
-              ],
-              [
-                props.currentNetworkId,
-                currentTable === nodeTable ? 'node' : 'edge',
-                currentTable,
-                selectedColumn,
-              ],
-            )
-            deleteColumn(
-              props.currentNetworkId,
-              currentTable === nodeTable ? 'node' : 'edge',
-              selectedColumn.id,
-            )
-            setNetworkModified(networkId, true)
-
-            // Update tableDisplayConfiguration for delete
-            // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
-            const defaultConfig = {
-              columnConfiguration:
-                (currentTable === nodeTable
-                  ? nodeTable
-                  : edgeTable
-                )?.columns?.map((col) => ({
-                  attributeName: col.name,
-                  visible: true,
-                  columnWidth: undefined,
-                })) ?? [],
-              sortColumn: undefined,
-              sortDirection: undefined,
-            }
-            const currentConfig =
-              currentTable === nodeTable
-                ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
-                : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
-            const newColumnConfig = currentConfig.columnConfiguration.filter(
-              (col) => col.attributeName !== selectedColumn.id,
-            )
-            const newTableDisplayConfiguration =
-              createUpdatedTableDisplayConfiguration({
-                columnConfiguration: newColumnConfig,
-              })
-            setTableDisplayConfiguration(
-              networkId,
-              newTableDisplayConfiguration,
-            )
-            setNetworkModified(networkId, true)
-
-            if (mappingUpdateType === 'delete') {
-              visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
-                setMapping(props.currentNetworkId, vp.name, undefined)
-              })
-            }
-            setShowDeleteColumnForm(false)
-            setDeleteColumnFormError(undefined)
-            setSelection({
-              columns: CompactSelection.empty(),
-              rows: CompactSelection.empty(),
-            })
-          }}
-        />
-      </>
-    ) : null
-
-  const selectedCell = selection.current?.cell ?? null
-
-  // Check if the selected cell is in a virtual column
-  const isSelectedCellVirtual =
-    selectedCell != null &&
-    allColumns[selectedCell[0]] &&
-    (allColumns[selectedCell[0]] as any).isVirtual
-
-  const selectedCellToolbar =
-    selectedCell != null && !isSelectedCellVirtual ? (
-      <>
-        <Box
-          sx={{
-            display: 'flex',
-            gap: 1,
-            ml: 2,
-            backgroundColor: 'transparent',
-            minWidth: '540px',
-          }}
-        >
-          <ToolbarTextButton
-            onClick={() => {
-              const [columnIndex, rowIndex] = selectedCell
-              const rowData = rows?.[rowIndex]
-              const column = allColumns?.[columnIndex]
-              const columnKey = column.id
-              const cellValue = (rowData as any)?.[columnKey]
-              const cellEdits: CellEdit[] = []
-              const prevColumnValues: CellEdit[] = []
-              Array.from(currentTable.rows.entries()).map(([k, v]) => {
-                cellEdits.push({
-                  row: k,
-                  column: columnKey,
-                  value: cellValue,
-                })
-
-                prevColumnValues.push({
-                  row: k,
-                  column: columnKey,
-                  value: (v as any)?.[columnKey] as ValueType,
-                })
-              })
-              postEdit(
-                UndoCommandType.APPLY_VALUE_TO_COLUMN,
-                'Apply value to column',
-                [
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  prevColumnValues,
-                ],
-                [
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  cellEdits,
-                ],
-              )
-              applyValueToElemenets(
-                props.currentNetworkId,
-                currentTable === nodeTable ? 'node' : 'edge',
-                columnKey,
-                cellValue,
-                undefined,
-              )
-              setNetworkModified(networkId, true)
-            }}
-          >
-            Apply Value to Column
-          </ToolbarTextButton>
-          <ToolbarTextButton
-            onClick={() => {
-              const [columnIndex, rowIndex] = selectedCell
-              const rowData = rows?.[rowIndex]
-              const column = allColumns?.[columnIndex]
-              const columnKey = column.id
-              const cellValue = (rowData as any)?.[columnKey]
-              const cellEdits: CellEdit[] = []
-              const prevColumnValues: CellEdit[] = []
-
-              rows.forEach((r) => {
-                const rowId = r.id
-                cellEdits.push({
-                  row: rowId,
-                  column: columnKey,
-                  value: cellValue,
-                })
-
-                prevColumnValues.push({
-                  row: rowId,
-                  column: columnKey,
-                  value: (r as any)?.[columnKey] as ValueType,
-                })
-              })
-
-              postEdit(
-                UndoCommandType.APPLY_VALUE_TO_SELECTED,
-                'Apply value to selected elements',
-                [
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  prevColumnValues,
-                ],
-                [
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  cellEdits,
-                ],
-              )
-              applyValueToElemenets(
-                props.currentNetworkId,
-                currentTable === nodeTable ? 'node' : 'edge',
-                columnKey,
-                cellValue,
-                rows.map((r) => r.id),
-              )
-              setNetworkModified(networkId, true)
-            }}
-          >
-            {`Apply Value to Selected ${
-              currentTable === nodeTable ? 'Nodes' : 'Edges'
-            }`}
-          </ToolbarTextButton>
-        </Box>
-      </>
-    ) : null
-
-  const selectedRowToolbar =
-    selection.rows.length > 0 ? (
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          ml: 2,
-          backgroundColor: 'transparent',
-        }}
-      >
-        <ToolbarTextButton
-          onClick={() => {
-            const rowsToSelect = selection.rows.toArray()
-            const rowIds = rowsToSelect
-              .map((r) => rows?.[r].id)
-              .filter((id) => id !== undefined)
-            if (currentTable === nodeTable) {
-              exclusiveSelect(props.currentNetworkId, rowIds, [])
-            } else {
-              exclusiveSelect(props.currentNetworkId, [], rowIds)
-            }
-            setSelection({
-              ...selection,
-              rows: CompactSelection.empty(),
-            })
-          }}
-        >
-          {`Select ${currentTable === nodeTable ? 'Nodes' : 'Edges'}`}{' '}
-        </ToolbarTextButton>
-      </Box>
-    ) : null
-
   const tableBrowserToolbar = (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 2,
-        ml: 1,
-        backgroundColor: 'transparent',
-      }}
-    >
-      <ToolbarIconButton
-        title="Insert new column"
-        disabled={tables[props.currentNetworkId] === undefined}
-        onClick={() => setShowCreateColumnForm(true)}
-      >
-        <span className="icon">&#8209;</span>
-      </ToolbarIconButton>
-      <ToolbarIconButton
-        title="Import table from file..."
-        disabled={tables[props.currentNetworkId] === undefined}
-        onClick={() => showTableJoinForm(true)}
-      >
-        <span className="icon">&#44;</span>
-      </ToolbarIconButton>
-      <CreateTableColumnForm
-        error={createColumnFormError}
-        open={showCreateColumnForm}
-        onClose={() => {
-          setShowCreateColumnForm(false)
-          setCreateColumnFormError(undefined)
-        }}
-        onSubmit={(
-          columnName: string,
-          dataType: ValueTypeName,
-          value: string,
-        ) => {
-          const columnNameSet = new Set(columns?.map((c) => c.id))
-          const columnNameAlreadyExists = columnNameSet.has(columnName)
-          const valueIsValid = serializedStringIsValid(dataType, value)
-          if (columnNameAlreadyExists) {
-            setCreateColumnFormError(
-              `${columnName} already exists.  Please enter a new unique column name`,
-            )
-          } else {
-            if (!valueIsValid) {
-              setCreateColumnFormError(
-                `Default value ${value} is not a valid ${dataType}.  Please enter a valid ${dataType}`,
-              )
-            } else {
-              const valueType = deserializeValue(dataType, value)
-              addColumn(
-                props.currentNetworkId,
-                currentTable === nodeTable ? 'node' : 'edge',
-                columnName,
-                dataType,
-                valueType,
-              )
-              setNetworkModified(networkId, true)
-
-              // Also add the new column to the tableDisplayConfiguration
-              // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
-              const defaultConfig = {
-                columnConfiguration:
-                  (currentTable === nodeTable
-                    ? nodeTable
-                    : edgeTable
-                  )?.columns?.map((col) => ({
-                    attributeName: col.name,
-                    visible: true,
-                    columnWidth: undefined,
-                  })) ?? [],
-                sortColumn: undefined,
-                sortDirection: undefined,
-              }
-              const currentConfig =
-                currentTable === nodeTable
-                  ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
-                  : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
-              const newColumnConfig = [
-                {
-                  attributeName: columnName,
-                  visible: true,
-                  columnWidth: undefined,
-                },
-                ...currentConfig.columnConfiguration,
-              ]
-              const newTableDisplayConfiguration =
-                createUpdatedTableDisplayConfiguration({
-                  columnConfiguration: newColumnConfig,
-                })
-              setTableDisplayConfiguration(
-                networkId,
-                newTableDisplayConfiguration,
-              )
-              setNetworkModified(networkId, true)
-
-              setCreateColumnFormError(undefined)
-              setSelection({
-                ...selection,
-                columns: CompactSelection.fromSingleSelection(0), // the new column is always placed at the most left side
-              })
-              setShowCreateColumnForm(false)
-            }
-          }
-        }}
-      />
-      {selectedColumnToolbar}
-      {selectedCellToolbar}
-      {selectedRowToolbar}
-    </Box>
+    <TableToolbar
+      currentNetworkId={props.currentNetworkId}
+      currentTable={currentTable}
+      nodeTable={nodeTable}
+      edgeTable={edgeTable}
+      tables={tables}
+      selection={selection}
+      setSelection={setSelection}
+      rows={rows}
+      allColumns={allColumns}
+      tableDisplayConfiguration={tableDisplayConfiguration}
+      createUpdatedTableDisplayConfiguration={createUpdatedTableDisplayConfiguration}
+      setTableDisplayConfiguration={setTableDisplayConfiguration}
+      setNetworkModified={setNetworkModified}
+      postEdit={postEdit}
+      addColumn={addColumn}
+      deleteColumn={deleteColumn}
+      setColumnName={setColumnName}
+      applyValueToElements={applyValueToElemenets}
+      exclusiveSelect={exclusiveSelect}
+      visualPropertiesDependentOnSelectedColumn={visualPropertiesDependentOnSelectedColumn}
+      setMapping={setMapping}
+      setSort={setSort}
+      duplicateColumn={duplicateColumn}
+      columns={columns}
+    />
   )
 
   const isContextCellVirtual =
@@ -1835,57 +511,13 @@ export default function TableBrowser(props: {
           backgroundColor: (theme) => theme.palette.background.subtle,
         }}
       >
-        <Tabs
-          data-testid="table-browser-tabs"
-          value={currentTabIndex}
-          onChange={handleChange}
-          aria-label="tabs"
-          sx={{
-            height: TABS_HEIGHT,
-            minHeight: TABS_HEIGHT,
-            '& button': {
-              minHeight: TABS_HEIGHT,
-              height: TABS_HEIGHT,
-              width: 200, // Reverting to original width as it fits better with counts
-            },
-          }}
-        >
-          <Tab
-            data-testid="table-browser-nodes-tab"
-            label={
-              <Tooltip
-                title={
-                  selectedNodes.length > 0
-                    ? `The table is showing ${selectedNodes.length} selected nodes. Deselect all nodes in the network view to show the complete list of nodes.`
-                    : 'The table is showing all nodes in the network. Select one or more nodes in the network to filter this table.'
-                }
-              >
-                <>
-                  Nodes
-                  {selectedNodes.length > 0 ? ` (${selectedNodes.length})` : ''}
-                </>
-              </Tooltip>
-            }
-          />
-          <Tab
-            data-testid="table-browser-edges-tab"
-            label={
-              <Tooltip
-                title={
-                  selectedEdges.length > 0
-                    ? `The table is showing ${selectedEdges.length} selected edges. Deselect all edges in the network view to show the complete list of edges.`
-                    : 'The table is showing all edges in the network. Select one or more edges in the network to filter this table.'
-                }
-              >
-                <>
-                  Edges
-                  {selectedEdges.length > 0 ? ` (${selectedEdges.length})` : ''}
-                </>
-              </Tooltip>
-            }
-          />
-          <Tab data-testid="table-browser-network-tab" label="Network" />
-        </Tabs>
+        <TableBrowserTabs
+          currentTabIndex={currentTabIndex}
+          handleChange={handleChange}
+          selectedNodesCount={selectedNodes.length}
+          selectedEdgesCount={selectedEdges.length}
+          tabsHeight={TABS_HEIGHT}
+        />
         <Tooltip title="Close panel">
           <IconButton
             data-testid="network-browser-panel-close-button"
@@ -1910,34 +542,24 @@ export default function TableBrowser(props: {
       </Box>
       <TabPanel value={currentTabIndex} index={0}>
         {tableBrowserToolbar}
-        <DataEditor
-          data-testid="table-browser-node-editor"
-          ref={nodeDataEditorRef}
-          gridSelection={selection}
+        <TableGrid
+          testId="table-browser-node-editor"
+          editorRef={nodeDataEditorRef}
+          selection={selection}
           onGridSelectionChange={onGridSelectionChange}
-          rowSelectionBlending="mixed"
-          rangeSelectionBlending="mixed"
-          columnSelectionBlending="mixed"
-          rangeSelect="rect"
-          rowSelect={'multi'}
-          rowMarkers={'checkbox'}
-          rowMarkerWidth={35}
-          rowMarkerStartIndex={minNodeId}
+          minId={minNodeId}
+          maxId={maxNodeId}
           onCellContextMenu={onCellContextMenu}
           onCellActivated={onCellActivated}
           onPaste={onPaste}
-          getCellsForSelection={true}
           onColumnMoved={onColMoved}
-          onItemHovered={(e) => onItemHovered(e.location)}
-          overscrollX={10}
-          overscrollY={10}
+          onItemHovered={onItemHovered}
           onColumnResizeEnd={onColumnResize}
           width={width}
           height={props.height - GRID_GAP}
           getCellContent={getContent}
           onCellEdited={onCellEdited}
           columns={allColumns}
-          rows={maxNodeId - minNodeId + 1}
           theme={dataEditorTheme}
           headerIcons={headerIcons}
           drawHeader={handleDrawHeader}
@@ -1945,34 +567,24 @@ export default function TableBrowser(props: {
       </TabPanel>
       <TabPanel value={currentTabIndex} index={1}>
         {tableBrowserToolbar}
-        <DataEditor
-          data-testid="table-browser-edge-editor"
-          ref={edgeDataEditorRef}
-          gridSelection={selection}
+        <TableGrid
+          testId="table-browser-edge-editor"
+          editorRef={edgeDataEditorRef}
+          selection={selection}
           onGridSelectionChange={onGridSelectionChange}
-          rowSelectionBlending="mixed"
-          rangeSelectionBlending="mixed"
-          columnSelectionBlending="mixed"
-          rangeSelect="rect"
-          rowSelect={'multi'}
-          rowMarkers={'checkbox'}
-          rowMarkerWidth={35}
-          rowMarkerStartIndex={minEdgeId}
+          minId={minEdgeId}
+          maxId={maxEdgeId}
           onCellContextMenu={onCellContextMenu}
           onCellActivated={onCellActivated}
           onPaste={onPaste}
-          getCellsForSelection={true}
           onColumnMoved={onColMoved}
-          onItemHovered={(e) => onItemHovered(e.location)}
-          overscrollX={10}
-          overscrollY={10}
+          onItemHovered={onItemHovered}
           onColumnResizeEnd={onColumnResize}
           width={width}
           height={props.height - GRID_GAP}
           getCellContent={getContent}
           onCellEdited={onCellEdited}
           columns={allColumns}
-          rows={maxEdgeId - minEdgeId + 1}
           theme={dataEditorTheme}
           headerIcons={headerIcons}
           drawHeader={handleDrawHeader}
@@ -1981,273 +593,27 @@ export default function TableBrowser(props: {
       <TabPanel value={currentTabIndex} index={2}>
         <NetworkInfoPanel height={props.height - TOOLBAR_HEIGHT - 1} />
       </TabPanel>
-      <Menu
-        open={contextMenu !== null}
-        onClose={handleContextMenuClose}
-        anchorReference="anchorPosition"
-        anchorPosition={
-          contextMenu !== null ? contextMenu.anchorPosition : undefined
+      <TableContextMenu
+        contextMenu={contextMenu}
+        handleContextMenuClose={handleContextMenuClose}
+        isContextCellVirtual={isContextCellVirtual}
+        isSelectionEmpty={
+          selection.rows.length === 0 && selection.current === undefined
         }
-        MenuListProps={{
-          'aria-labelledby': 'table-browser-context-menu',
-        }}
-      >
-        <Tooltip
-          title={isContextCellVirtual ? 'Cannot apply to virtual columns' : ''}
-          placement="right"
-        >
-          <span>
-            <MenuItem
-              disabled={isContextCellVirtual}
-              onClick={() => {
-                if (contextMenu === null) return
-                const [columnIndex, rowIndex] = contextMenu.cell
-                const rowData = rows?.[rowIndex]
-                const column = allColumns?.[columnIndex]
-                const columnKey = column.id
-                const cellValue = (rowData as any)?.[columnKey]
-                const cellEdits: CellEdit[] = []
-                const prevColumnValues: CellEdit[] = []
-                Array.from(currentTable.rows.entries()).map(([k, v]) => {
-                  cellEdits.push({
-                    row: k,
-                    column: columnKey,
-                    value: cellValue,
-                  })
-                  prevColumnValues.push({
-                    row: k,
-                    column: columnKey,
-                    value: (v as any)?.[columnKey] as ValueType,
-                  })
-                })
-                postEdit(
-                  UndoCommandType.APPLY_VALUE_TO_COLUMN,
-                  'Apply value to column',
-                  [
-                    props.currentNetworkId,
-                    currentTable === nodeTable ? 'node' : 'edge',
-                    prevColumnValues,
-                  ],
-                  [
-                    props.currentNetworkId,
-                    currentTable === nodeTable ? 'node' : 'edge',
-                    cellEdits,
-                  ],
-                )
-                applyValueToElemenets(
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  columnKey,
-                  cellValue,
-                  undefined,
-                )
-                setNetworkModified(networkId, true)
-                handleContextMenuClose()
-              }}
-            >
-              Apply to entire column
-            </MenuItem>
-          </span>
-        </Tooltip>
-
-        <Tooltip
-          title={isContextCellVirtual ? 'Cannot apply to virtual columns' : ''}
-          placement="right"
-        >
-          <span>
-            <MenuItem
-              disabled={isContextCellVirtual}
-              onClick={() => {
-                if (contextMenu === null) return
-                const [columnIndex, rowIndex] = contextMenu.cell
-                const rowData = rows?.[rowIndex]
-                const column = allColumns?.[columnIndex]
-                const columnKey = column.id
-                const cellValue = (rowData as any)?.[columnKey]
-                const cellEdits: CellEdit[] = []
-                const prevColumnValues: CellEdit[] = []
-                rows.forEach((r) => {
-                  const rowId = r.id
-                  cellEdits.push({
-                    row: rowId,
-                    column: columnKey,
-                    value: cellValue,
-                  })
-                  prevColumnValues.push({
-                    row: rowId,
-                    column: columnKey,
-                    value: (r as any)?.[columnKey] as ValueType,
-                  })
-                })
-                postEdit(
-                  UndoCommandType.APPLY_VALUE_TO_SELECTED,
-                  'Apply value to selected elements',
-                  [
-                    props.currentNetworkId,
-                    currentTable === nodeTable ? 'node' : 'edge',
-                    prevColumnValues,
-                  ],
-                  [
-                    props.currentNetworkId,
-                    currentTable === nodeTable ? 'node' : 'edge',
-                    cellEdits,
-                  ],
-                )
-                applyValueToElemenets(
-                  props.currentNetworkId,
-                  currentTable === nodeTable ? 'node' : 'edge',
-                  columnKey,
-                  cellValue,
-                  rows.map((r) => r.id),
-                )
-                setNetworkModified(networkId, true)
-                handleContextMenuClose()
-              }}
-            >
-              Apply to selected {currentTable === nodeTable ? 'nodes' : 'edges'}
-            </MenuItem>
-          </span>
-        </Tooltip>
-
-        <Divider />
-
-        <MenuItem
-          onClick={() => {
-            if (contextMenu === null) return
-            const [columnIndex, rowIndex] = contextMenu.cell
-            const rowData = rows?.[rowIndex]
-            const column = allColumns?.[columnIndex]
-            const columnKey = column.id
-            const cellValue = (rowData as any)?.[columnKey]
-            navigator.clipboard.writeText(String(cellValue ?? ''))
-            handleContextMenuClose()
-          }}
-        >
-          <ListItemIcon>
-            <ContentCopy fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Copy</ListItemText>
-        </MenuItem>
-
-        <MenuItem
-          onClick={() => {
-            const activeRef =
-              currentTable === nodeTable ? nodeDataEditorRef : edgeDataEditorRef
-            // emit paste assumes the grid has focus or the browser permits it.
-            // Note: Users may need to Ctrl+V instead if browser blocks programmatic paste.
-            activeRef.current?.emit('paste').catch(() => {
-              console.warn(
-                'Programmatic paste blocked by browser. Please use Ctrl+V.',
-              )
-            })
-            handleContextMenuClose()
-          }}
-        >
-          <ListItemIcon>
-            <ContentPaste fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Paste</ListItemText>
-        </MenuItem>
-
-        <Divider />
-
-        <MenuItem
-          disabled={selection.current === undefined}
-          onClick={() => {
-            const activeRef =
-              currentTable === nodeTable ? nodeDataEditorRef : edgeDataEditorRef
-            activeRef.current?.emit('copy')
-            handleContextMenuClose()
-          }}
-        >
-          <ListItemIcon>
-            <ContentCopy fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Copy Selected</ListItemText>
-        </MenuItem>
-
-        <MenuItem
-          onClick={() => {
-            if (contextMenu === null) return
-            const [, rowIndex] = contextMenu.cell
-            const elementId = getElementId(rows?.[rowIndex])
-            if (elementId !== '') {
-              navigator.clipboard.writeText(elementId)
-            }
-            handleContextMenuClose()
-          }}
-        >
-          <ListItemIcon>
-            <ContentCopy fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>
-            {`Copy ${currentTable === nodeTable ? 'Node' : 'Edge'} ID`}
-          </ListItemText>
-        </MenuItem>
-
-        <Divider />
-
-        <MenuItem
-          onClick={() => {
-            if (contextMenu === null) return
-            const [, rowIndex] = contextMenu.cell
-            const rowData = rows?.[rowIndex]
-            if (rowData?.id != null) {
-              if (currentTable === nodeTable) {
-                exclusiveSelect(props.currentNetworkId, [rowData.id], [])
-              } else {
-                exclusiveSelect(props.currentNetworkId, [], [rowData.id])
-              }
-            }
-            handleContextMenuClose()
-          }}
-        >
-          {`Select This ${currentTable === nodeTable ? 'Node' : 'Edge'} in Viewport`}
-        </MenuItem>
-
-        <MenuItem
-          disabled={
-            selection.rows.length === 0 && selection.current === undefined
-          }
-          onClick={() => {
-            const rowsToSelect = new Set(selection.rows.toArray())
-
-            if (selection.current) {
-              const ranges =
-                selection.current.rangeStack.length > 0
-                  ? selection.current.rangeStack
-                  : [selection.current.range]
-
-              ranges.forEach((range) => {
-                for (let r = range.y; r < range.y + range.height; r++) {
-                  rowsToSelect.add(r)
-                }
-              })
-            }
-
-            const rowIds = Array.from(rowsToSelect)
-              .map((r) => rows?.[r]?.id)
-              .filter((id) => id !== undefined)
-            if (currentTable === nodeTable) {
-              exclusiveSelect(props.currentNetworkId, rowIds as string[], [])
-            } else {
-              exclusiveSelect(props.currentNetworkId, [], rowIds as string[])
-            }
-            setSelection({
-              ...selection,
-              rows: CompactSelection.empty(),
-            })
-            handleContextMenuClose()
-          }}
-        >
-          <ListItemIcon>
-            <CheckBoxOutlinedIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>
-            {`Select ${currentTable === nodeTable ? 'nodes' : 'edges'} from selection`}
-          </ListItemText>
-        </MenuItem>
-      </Menu>
+        currentTableIsNodeTable={currentTable === nodeTable}
+        activeEditorRef={currentTable === nodeTable ? nodeDataEditorRef : edgeDataEditorRef}
+        rows={rows}
+        allColumns={allColumns}
+        currentTable={currentTable}
+        nodeTable={nodeTable}
+        currentNetworkId={props.currentNetworkId}
+        postEdit={postEdit}
+        applyValueToElements={applyValueToElemenets}
+        setNetworkModified={(id, mod) => setNetworkModified(id, mod)}
+        exclusiveSelect={exclusiveSelect}
+        selection={selection}
+        setSelection={setSelection}
+      />
       {listEditor !== null ? (
         <ListValueEditorDialog
           key={`${listEditor.cxId}:${listEditor.columnKey}`}

--- a/src/features/TableBrowser/TableColumnForm.spec.tsx
+++ b/src/features/TableBrowser/TableColumnForm.spec.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ValueTypeName } from '../../models/TableModel/ValueTypeName'
+import { CreateTableColumnForm } from './TableColumnForm'
+
+describe('CreateTableColumnForm', () => {
+  it('resets its state when reopened instead of when submitted', () => {
+    const onSubmit = vi.fn()
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <CreateTableColumnForm open={true} onSubmit={onSubmit} onClose={onClose} />
+    )
+
+    // Initially the form should be empty
+    expect((screen.getByTestId('create-table-column-name-input').querySelector('input') as HTMLInputElement).value).toBe('')
+
+    // Type a column name
+    fireEvent.change(screen.getByTestId('create-table-column-name-input').querySelector('input') as HTMLInputElement, {
+      target: { value: 'newColumn' },
+    })
+    expect((screen.getByTestId('create-table-column-name-input').querySelector('input') as HTMLInputElement).value).toBe('newColumn')
+
+    // Submit the form
+    fireEvent.click(screen.getByTestId('create-table-column-confirm-button'))
+    
+    // Check that onSubmit was called
+    expect(onSubmit).toHaveBeenCalledWith('newColumn', ValueTypeName.String, '')
+
+    // The state should NOT be reset immediately (so if validation failed, the user's input remains)
+    expect((screen.getByTestId('create-table-column-name-input').querySelector('input') as HTMLInputElement).value).toBe('newColumn')
+
+    // Close the dialog and reopen it
+    rerender(<CreateTableColumnForm open={false} onSubmit={onSubmit} onClose={onClose} />)
+    rerender(<CreateTableColumnForm open={true} onSubmit={onSubmit} onClose={onClose} />)
+
+    // The state should now be reset because the dialog was reopened
+    expect((screen.getByTestId('create-table-column-name-input').querySelector('input') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/src/features/TableBrowser/TableColumnForm.tsx
+++ b/src/features/TableBrowser/TableColumnForm.tsx
@@ -267,6 +267,15 @@ export function CreateTableColumnForm(
   const [defaultValue, setDefaultValue] = React.useState('')
   // Opens the shared list editor for a list-typed default value (CW-563).
   const [listEditorOpen, setListEditorOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    if (props.open) {
+      setColumnName('')
+      setDefaultValue('')
+      setValueTypeName(ValueTypeName.String)
+    }
+  }, [props.open])
+
   const disabled = columnName === ''
 
   const submitButton = disabled ? (
@@ -284,9 +293,6 @@ export function CreateTableColumnForm(
       disabled={columnName === ''}
       onClick={() => {
         props.onSubmit(columnName, valueTypeName, defaultValue)
-        setColumnName('')
-        setDefaultValue('')
-        setValueTypeName(ValueTypeName.String)
       }}
     >
       Confirm

--- a/src/features/TableBrowser/TableColumnForm.tsx
+++ b/src/features/TableBrowser/TableColumnForm.tsx
@@ -281,7 +281,7 @@ export function CreateTableColumnForm(
   const submitButton = disabled ? (
     <Tooltip title="Column name must not be empty">
       <Box>
-        <Button variant="contained" disabled>
+        <Button data-testid="create-table-column-confirm-button" variant="contained" disabled>
           Confirm
         </Button>
       </Box>

--- a/src/features/TableBrowser/components/TabPanel.tsx
+++ b/src/features/TableBrowser/components/TabPanel.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Box } from '@mui/material'
+
+export interface TabPanelProps {
+  children?: React.ReactNode
+  index: number
+  value: number
+}
+
+export function TabPanel(props: TabPanelProps): React.ReactElement {
+  const { children, value, index, ...other } = props
+
+  return (
+    <Box
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      sx={{ flexGrow: 1 }}
+      {...other}
+    >
+      {value === index && <>{children}</>}
+    </Box>
+  )
+}

--- a/src/features/TableBrowser/components/TableBrowserTabs.tsx
+++ b/src/features/TableBrowser/components/TableBrowserTabs.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import { Tab, Tabs, Tooltip } from '@mui/material'
 
+export enum TableBrowserTab {
+  NODES = 0,
+  EDGES = 1,
+  NETWORK = 2,
+}
+
 export interface TableBrowserTabsProps {
   currentTabIndex: number
   handleChange: (event: React.SyntheticEvent, newValue: number) => void

--- a/src/features/TableBrowser/components/TableBrowserTabs.tsx
+++ b/src/features/TableBrowser/components/TableBrowserTabs.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Tab, Tabs, Tooltip } from '@mui/material'
+
+export interface TableBrowserTabsProps {
+  currentTabIndex: number
+  handleChange: (event: React.SyntheticEvent, newValue: number) => void
+  selectedNodesCount: number
+  selectedEdgesCount: number
+  tabsHeight: number
+}
+
+export const TableBrowserTabs: React.FC<TableBrowserTabsProps> = ({
+  currentTabIndex,
+  handleChange,
+  selectedNodesCount,
+  selectedEdgesCount,
+  tabsHeight,
+}) => {
+  return (
+    <Tabs
+      data-testid="table-browser-tabs"
+      value={currentTabIndex}
+      onChange={handleChange}
+      aria-label="tabs"
+      sx={{
+        height: tabsHeight,
+        minHeight: tabsHeight,
+        '& button': {
+          minHeight: tabsHeight,
+          height: tabsHeight,
+          width: 200,
+        },
+      }}
+    >
+      <Tab
+        data-testid="table-browser-nodes-tab"
+        label={
+          <Tooltip
+            title={
+              selectedNodesCount > 0
+                ? `The table is showing ${selectedNodesCount} selected nodes. Deselect all nodes in the network view to show the complete list of nodes.`
+                : 'The table is showing all nodes in the network. Select one or more nodes in the network to filter this table.'
+            }
+          >
+            <>
+              Nodes
+              {selectedNodesCount > 0 ? ` (${selectedNodesCount})` : ''}
+            </>
+          </Tooltip>
+        }
+      />
+      <Tab
+        data-testid="table-browser-edges-tab"
+        label={
+          <Tooltip
+            title={
+              selectedEdgesCount > 0
+                ? `The table is showing ${selectedEdgesCount} selected edges. Deselect all edges in the network view to show the complete list of edges.`
+                : 'The table is showing all edges in the network. Select one or more edges in the network to filter this table.'
+            }
+          >
+            <>
+              Edges
+              {selectedEdgesCount > 0 ? ` (${selectedEdgesCount})` : ''}
+            </>
+          </Tooltip>
+        }
+      />
+      <Tab data-testid="table-browser-network-tab" label="Network" />
+    </Tabs>
+  )
+}

--- a/src/features/TableBrowser/components/TableContextMenu.tsx
+++ b/src/features/TableBrowser/components/TableContextMenu.tsx
@@ -1,0 +1,253 @@
+import {
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from '@mui/material'
+import React from 'react'
+
+import {
+  CheckBoxOutlined as CheckBoxOutlinedIcon,
+  ContentCopy,
+  ContentPaste,
+} from '@mui/icons-material'
+
+import { DataEditorRef, GridSelection } from '@glideapps/glide-data-grid'
+import { IdType } from '../../../models/IdType'
+import { Table } from '../../../models/TableModel'
+import { TableColumn } from '../TableBrowser'
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { getElementId } from '../idColumn'
+import { handleApplyToEntireColumn, handleApplyToSelected, handleSelectFromSelection } from '../utils/contextMenuActions'
+
+export interface TableContextMenuProps {
+  contextMenu: {
+    cell: readonly [number, number]
+    anchorPosition: { top: number; left: number }
+  } | null
+  handleContextMenuClose: () => void
+  isContextCellVirtual: boolean
+  isSelectionEmpty: boolean
+  currentTableIsNodeTable: boolean
+  
+  // Dependencies for internal actions
+  activeEditorRef: React.RefObject<DataEditorRef | null>
+  rows: any[]
+  allColumns: TableColumn[]
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  currentNetworkId: IdType
+  postEdit: (type: UndoCommandType, name: string, oldVal: any, newVal: any) => void
+  applyValueToElements: (networkId: IdType, tableType: 'node' | 'edge', columnKey: string, value: any, elementIds?: string[]) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+  exclusiveSelect: (networkId: IdType, nodeIds: IdType[], edgeIds: IdType[]) => void
+  selection: GridSelection
+  setSelection: (selection: GridSelection) => void
+}
+
+export const TableContextMenu: React.FC<TableContextMenuProps> = ({
+  contextMenu,
+  handleContextMenuClose,
+  isContextCellVirtual,
+  isSelectionEmpty,
+  currentTableIsNodeTable,
+  activeEditorRef,
+  rows,
+  allColumns,
+  currentTable,
+  nodeTable,
+  currentNetworkId,
+  postEdit,
+  applyValueToElements,
+  setNetworkModified,
+  exclusiveSelect,
+  selection,
+  setSelection,
+}) => {
+  const elementTypeName = currentTableIsNodeTable ? 'Node' : 'Edge'
+  const pluralElementTypeName = currentTableIsNodeTable ? 'nodes' : 'edges'
+
+  const onApplyToEntireColumn = React.useCallback(() => {
+    if (contextMenu === null) return
+    handleApplyToEntireColumn({
+      contextMenuCell: contextMenu.cell,
+      rows,
+      allColumns,
+      currentTable,
+      nodeTable,
+      currentNetworkId,
+      postEdit,
+      applyValueToElements,
+      setNetworkModified: (id: string, mod: boolean) => setNetworkModified(id, mod),
+      handleContextMenuClose,
+    })
+  }, [contextMenu, rows, allColumns, currentTable, nodeTable, currentNetworkId, postEdit, applyValueToElements, setNetworkModified, handleContextMenuClose])
+
+  const onApplyToSelected = React.useCallback(() => {
+    if (contextMenu === null) return
+    handleApplyToSelected({
+      contextMenuCell: contextMenu.cell,
+      rows,
+      allColumns,
+      currentTable,
+      nodeTable,
+      currentNetworkId,
+      postEdit,
+      applyValueToElements,
+      setNetworkModified: (id: string, mod: boolean) => setNetworkModified(id, mod),
+      handleContextMenuClose,
+    })
+  }, [contextMenu, rows, allColumns, currentTable, nodeTable, currentNetworkId, postEdit, applyValueToElements, setNetworkModified, handleContextMenuClose])
+
+  const onCopyValue = React.useCallback(() => {
+    if (contextMenu === null) return
+    const [columnIndex, rowIndex] = contextMenu.cell
+    const rowData = rows?.[rowIndex]
+    const column = allColumns?.[columnIndex]
+    const columnKey = column.id
+    const cellValue = (rowData as any)?.[columnKey]
+    navigator.clipboard.writeText(String(cellValue ?? ''))
+    handleContextMenuClose()
+  }, [contextMenu, rows, allColumns, handleContextMenuClose])
+
+  const onPaste = React.useCallback(() => {
+    activeEditorRef.current?.emit('paste').catch(() => {
+      console.warn('Programmatic paste blocked by browser. Please use Ctrl+V.')
+    })
+    handleContextMenuClose()
+  }, [activeEditorRef, handleContextMenuClose])
+
+  const onCopySelected = React.useCallback(() => {
+    activeEditorRef.current?.emit('copy')
+    handleContextMenuClose()
+  }, [activeEditorRef, handleContextMenuClose])
+
+  const onCopyId = React.useCallback(() => {
+    if (contextMenu === null) return
+    const [, rowIndex] = contextMenu.cell
+    const elementId = getElementId(rows?.[rowIndex])
+    if (elementId !== '') {
+      navigator.clipboard.writeText(elementId)
+    }
+    handleContextMenuClose()
+  }, [contextMenu, rows, handleContextMenuClose])
+
+  const onSelectInViewport = React.useCallback(() => {
+    if (contextMenu === null) return
+    const [, rowIndex] = contextMenu.cell
+    const rowData = rows?.[rowIndex]
+    if (rowData?.id != null) {
+      if (currentTableIsNodeTable) {
+        exclusiveSelect(currentNetworkId, [rowData.id], [])
+      } else {
+        exclusiveSelect(currentNetworkId, [], [rowData.id])
+      }
+    }
+    handleContextMenuClose()
+  }, [contextMenu, rows, currentTableIsNodeTable, currentNetworkId, exclusiveSelect, handleContextMenuClose])
+
+  const onSelectFromSelection = React.useCallback(() => {
+    handleSelectFromSelection({
+      selection,
+      rows,
+      currentTable,
+      nodeTable,
+      currentNetworkId,
+      exclusiveSelect,
+      setSelection,
+      handleContextMenuClose,
+    })
+  }, [selection, rows, currentTable, nodeTable, currentNetworkId, exclusiveSelect, setSelection, handleContextMenuClose])
+
+  return (
+    <Menu
+      open={contextMenu !== null}
+      onClose={handleContextMenuClose}
+      anchorReference="anchorPosition"
+      anchorPosition={
+        contextMenu !== null ? contextMenu.anchorPosition : undefined
+      }
+      MenuListProps={{
+        'aria-labelledby': 'table-browser-context-menu',
+      }}
+    >
+      <Tooltip
+        title={isContextCellVirtual ? 'Cannot apply to virtual columns' : ''}
+        placement="right"
+      >
+        <span>
+          <MenuItem
+            disabled={isContextCellVirtual}
+            onClick={onApplyToEntireColumn}
+          >
+            Apply to entire column
+          </MenuItem>
+        </span>
+      </Tooltip>
+
+      <Tooltip
+        title={isContextCellVirtual ? 'Cannot apply to virtual columns' : ''}
+        placement="right"
+      >
+        <span>
+          <MenuItem
+            disabled={isContextCellVirtual}
+            onClick={onApplyToSelected}
+          >
+            Apply to selected {pluralElementTypeName}
+          </MenuItem>
+        </span>
+      </Tooltip>
+
+      <Divider />
+
+      <MenuItem onClick={onCopyValue}>
+        <ListItemIcon>
+          <ContentCopy fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Copy</ListItemText>
+      </MenuItem>
+
+      <MenuItem onClick={onPaste}>
+        <ListItemIcon>
+          <ContentPaste fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Paste</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      <MenuItem disabled={isSelectionEmpty} onClick={onCopySelected}>
+        <ListItemIcon>
+          <ContentCopy fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Copy Selected</ListItemText>
+      </MenuItem>
+
+      <MenuItem onClick={onCopyId}>
+        <ListItemIcon>
+          <ContentCopy fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Copy {elementTypeName} ID</ListItemText>
+      </MenuItem>
+
+      <Divider />
+
+      <MenuItem onClick={onSelectInViewport}>
+        Select This {elementTypeName} in Viewport
+      </MenuItem>
+
+      <MenuItem
+        disabled={isSelectionEmpty}
+        onClick={onSelectFromSelection}
+      >
+        <ListItemIcon>
+          <CheckBoxOutlinedIcon fontSize="small" />
+        </ListItemIcon>
+        <ListItemText>Select {pluralElementTypeName} from selection</ListItemText>
+      </MenuItem>
+    </Menu>
+  )
+}

--- a/src/features/TableBrowser/components/TableContextMenu.tsx
+++ b/src/features/TableBrowser/components/TableContextMenu.tsx
@@ -163,6 +163,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
 
   return (
     <Menu
+      data-testid="table-browser-context-menu"
       open={contextMenu !== null}
       onClose={handleContextMenuClose}
       anchorReference="anchorPosition"
@@ -179,6 +180,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
       >
         <span>
           <MenuItem
+            data-testid="context-menu-apply-to-column"
             disabled={isContextCellVirtual}
             onClick={onApplyToEntireColumn}
           >
@@ -193,6 +195,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
       >
         <span>
           <MenuItem
+            data-testid="context-menu-apply-to-selected"
             disabled={isContextCellVirtual}
             onClick={onApplyToSelected}
           >
@@ -203,14 +206,14 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
 
       <Divider />
 
-      <MenuItem onClick={onCopyValue}>
+      <MenuItem data-testid="context-menu-copy" onClick={onCopyValue}>
         <ListItemIcon>
           <ContentCopy fontSize="small" />
         </ListItemIcon>
         <ListItemText>Copy</ListItemText>
       </MenuItem>
 
-      <MenuItem onClick={onPaste}>
+      <MenuItem data-testid="context-menu-paste" onClick={onPaste}>
         <ListItemIcon>
           <ContentPaste fontSize="small" />
         </ListItemIcon>
@@ -219,14 +222,14 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
 
       <Divider />
 
-      <MenuItem disabled={isSelectionEmpty} onClick={onCopySelected}>
+      <MenuItem data-testid="context-menu-copy-selected" disabled={isSelectionEmpty} onClick={onCopySelected}>
         <ListItemIcon>
           <ContentCopy fontSize="small" />
         </ListItemIcon>
         <ListItemText>Copy Selected</ListItemText>
       </MenuItem>
 
-      <MenuItem onClick={onCopyId}>
+      <MenuItem data-testid="context-menu-copy-id" onClick={onCopyId}>
         <ListItemIcon>
           <ContentCopy fontSize="small" />
         </ListItemIcon>
@@ -235,11 +238,12 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
 
       <Divider />
 
-      <MenuItem onClick={onSelectInViewport}>
+      <MenuItem data-testid="context-menu-select-viewport" onClick={onSelectInViewport}>
         Select This {elementTypeName} in Viewport
       </MenuItem>
 
       <MenuItem
+        data-testid="context-menu-select-from-selection"
         disabled={isSelectionEmpty}
         onClick={onSelectFromSelection}
       >

--- a/src/features/TableBrowser/components/TableGrid.tsx
+++ b/src/features/TableBrowser/components/TableGrid.tsx
@@ -1,0 +1,100 @@
+import DataEditor, {
+  CellClickedEventArgs,
+  DataEditorRef,
+  GridColumn,
+  GridSelection,
+  Item,
+  Theme,
+} from '@glideapps/glide-data-grid'
+import React from 'react'
+
+export interface TableGridProps {
+  testId: string
+  editorRef: React.RefObject<DataEditorRef>
+  selection: GridSelection
+  onGridSelectionChange: (selection: GridSelection) => void
+  minId: number
+  maxId: number
+  onCellContextMenu: (
+    cell: readonly [number, number],
+    event: CellClickedEventArgs,
+  ) => void
+  onCellActivated: (cell: Item) => void
+  onPaste: (
+    target: readonly [number, number],
+    values: readonly (readonly string[])[],
+  ) => boolean
+  onColumnMoved: (startIndex: number, endIndex: number) => void
+  onItemHovered: (args: Item) => void
+  onColumnResizeEnd: (
+    column: GridColumn,
+    newSize: number,
+    colIndex: number,
+  ) => void
+  width: number
+  height: number
+  getCellContent: (cell: readonly [number, number]) => any
+  onCellEdited: (cell: readonly [number, number], newValue: any) => void
+  columns: any[]
+  theme: Partial<Theme>
+  headerIcons: any
+  drawHeader: any
+}
+
+export const TableGrid: React.FC<TableGridProps> = ({
+  testId,
+  editorRef,
+  selection,
+  onGridSelectionChange,
+  minId,
+  maxId,
+  onCellContextMenu,
+  onCellActivated,
+  onPaste,
+  onColumnMoved,
+  onItemHovered,
+  onColumnResizeEnd,
+  width,
+  height,
+  getCellContent,
+  onCellEdited,
+  columns,
+  theme,
+  headerIcons,
+  drawHeader,
+}) => {
+  return (
+    <DataEditor
+      data-testid={testId}
+      ref={editorRef}
+      gridSelection={selection}
+      onGridSelectionChange={onGridSelectionChange}
+      rowSelectionBlending="mixed"
+      rangeSelectionBlending="mixed"
+      columnSelectionBlending="mixed"
+      rangeSelect="rect"
+      rowSelect={'multi'}
+      rowMarkers={'checkbox'}
+      rowMarkerWidth={35}
+      rowMarkerStartIndex={minId}
+      onCellContextMenu={onCellContextMenu}
+      onCellActivated={onCellActivated}
+      onPaste={onPaste}
+      getCellsForSelection={true}
+      onColumnMoved={onColumnMoved}
+      onItemHovered={(e) => onItemHovered(e.location)}
+      overscrollX={10}
+      overscrollY={10}
+      onColumnResizeEnd={onColumnResizeEnd}
+      width={width}
+      height={height}
+      getCellContent={getCellContent}
+      onCellEdited={onCellEdited}
+      columns={columns}
+      rows={maxId - minId + 1}
+      theme={theme}
+      headerIcons={headerIcons}
+      drawHeader={drawHeader}
+    />
+  )
+}

--- a/src/features/TableBrowser/components/TableGrid.tsx
+++ b/src/features/TableBrowser/components/TableGrid.tsx
@@ -64,37 +64,38 @@ export const TableGrid: React.FC<TableGridProps> = ({
   drawHeader,
 }) => {
   return (
-    <DataEditor
-      data-testid={testId}
-      ref={editorRef}
-      gridSelection={selection}
-      onGridSelectionChange={onGridSelectionChange}
-      rowSelectionBlending="mixed"
-      rangeSelectionBlending="mixed"
-      columnSelectionBlending="mixed"
-      rangeSelect="rect"
-      rowSelect={'multi'}
-      rowMarkers={'checkbox'}
-      rowMarkerWidth={35}
-      rowMarkerStartIndex={minId}
-      onCellContextMenu={onCellContextMenu}
-      onCellActivated={onCellActivated}
-      onPaste={onPaste}
-      getCellsForSelection={true}
-      onColumnMoved={onColumnMoved}
-      onItemHovered={(e) => onItemHovered(e.location)}
-      overscrollX={10}
-      overscrollY={10}
-      onColumnResizeEnd={onColumnResizeEnd}
-      width={width}
-      height={height}
-      getCellContent={getCellContent}
-      onCellEdited={onCellEdited}
-      columns={columns}
-      rows={maxId - minId + 1}
-      theme={theme}
-      headerIcons={headerIcons}
-      drawHeader={drawHeader}
-    />
+    <div data-testid={testId} style={{ width: width, height: height }}>
+      <DataEditor
+        ref={editorRef}
+        gridSelection={selection}
+        onGridSelectionChange={onGridSelectionChange}
+        rowSelectionBlending="mixed"
+        rangeSelectionBlending="mixed"
+        columnSelectionBlending="mixed"
+        rangeSelect="rect"
+        rowSelect={'multi'}
+        rowMarkers={'checkbox'}
+        rowMarkerWidth={35}
+        rowMarkerStartIndex={minId}
+        onCellContextMenu={onCellContextMenu}
+        onCellActivated={onCellActivated}
+        onPaste={onPaste}
+        getCellsForSelection={true}
+        onColumnMoved={onColumnMoved}
+        onItemHovered={(e) => onItemHovered(e.location)}
+        overscrollX={10}
+        overscrollY={10}
+        onColumnResizeEnd={onColumnResizeEnd}
+        width={width}
+        height={height}
+        getCellContent={getCellContent}
+        onCellEdited={onCellEdited}
+        columns={columns}
+        rows={maxId - minId + 1}
+        theme={theme}
+        headerIcons={headerIcons}
+        drawHeader={drawHeader}
+      />
+    </div>
   )
 }

--- a/src/features/TableBrowser/components/TableToolbar.tsx
+++ b/src/features/TableBrowser/components/TableToolbar.tsx
@@ -1,0 +1,505 @@
+import { Box, Button, Tooltip } from '@mui/material'
+import React from 'react'
+import { CompactSelection, GridSelection } from '@glideapps/glide-data-grid'
+
+import { IdType } from '../../../models/IdType'
+import { Table, ValueType, ValueTypeName } from '../../../models/TableModel'
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { TableDisplayConfiguration } from '../../../models/VisualStyleModel/VisualStyleOptions'
+import { CellEdit } from '../../../models/StoreModel/TableStoreModel'
+import { deserializeValue, serializedStringIsValid } from '../../../models/TableModel/impl/valueTypeImpl'
+import { useJoinTableToNetworkStore } from '../../TableDataLoader/store/joinTableToNetworkStore'
+import { VisualProperty } from '../../../models/VisualStyleModel'
+
+import { CreateTableColumnForm, DeleteTableColumnForm, EditTableColumnForm } from '../TableColumnForm'
+
+// --- Helper Components ---
+const ButtonTooltip = ({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactElement
+}) => (
+  <Tooltip
+    title={title}
+    placement="top"
+    PopperProps={{
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, -16],
+          },
+        },
+      ],
+    }}
+  >
+    {children}
+  </Tooltip>
+)
+
+const ToolbarIconButton = ({
+  title,
+  disabled = false,
+  onClick,
+  children,
+}: {
+  title: string
+  disabled?: boolean
+  onClick: () => void
+  children: React.ReactElement
+}) => (
+  <ButtonTooltip title={title}>
+    <span>
+      <Button
+        disabled={disabled}
+        onClick={onClick}
+        sx={{
+          minWidth: 48,
+          maxWidth: 48,
+          height: 48,
+          p: 0,
+          color: (theme) => theme.palette.text.primary,
+        }}
+      >
+        {children}
+      </Button>
+    </span>
+  </ButtonTooltip>
+)
+
+const ToolbarTextButton = ({
+  onClick,
+  children,
+}: {
+  onClick: () => void
+  children: React.ReactNode
+}) => (
+  <Button
+    variant="outlined"
+    size="small"
+    onClick={onClick}
+    sx={{
+      textTransform: 'none',
+      color: (theme) => theme.palette.text.primary,
+      borderColor: (theme) => theme.palette.text.secondary,
+      borderRadius: 4,
+    }}
+  >
+    {children}
+  </Button>
+)
+
+export interface TableToolbarProps {
+  currentNetworkId: IdType
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  edgeTable: Table | undefined
+  tables: Record<string, any>
+  selection: GridSelection
+  setSelection: (selection: GridSelection) => void
+  rows: any[] | undefined
+  allColumns: any[] | undefined
+  tableDisplayConfiguration: TableDisplayConfiguration | undefined
+  createUpdatedTableDisplayConfiguration: (config: any) => TableDisplayConfiguration
+  setTableDisplayConfiguration: (networkId: IdType, config: TableDisplayConfiguration) => void
+  setNetworkModified: (networkId: IdType, modified: boolean) => void
+  postEdit: (type: UndoCommandType, desc: string, undo: any[], redo: any[]) => void
+  addColumn: (networkId: IdType, tableType: 'node'|'edge', colName: string, dataType: ValueTypeName, defValue: any) => void
+  deleteColumn: (networkId: IdType, tableType: 'node'|'edge', colName: string) => void
+  setColumnName: (networkId: IdType, tableType: 'node'|'edge', oldName: string, newName: string) => void
+  applyValueToElements: (networkId: IdType, tableType: 'node'|'edge', colKey: string, val: any, elements?: string[]) => void
+  exclusiveSelect: (networkId: IdType, nodeIds: string[], edgeIds: string[]) => void
+  visualPropertiesDependentOnSelectedColumn: VisualProperty<any>[]
+  setMapping: (networkId: IdType, vpName: any, mapping: any) => void
+  setSort: (sort: any) => void
+  duplicateColumn: (networkId: IdType, tableType: 'node'|'edge', colName: string) => void
+  columns: any[]
+}
+
+export const TableToolbar: React.FC<TableToolbarProps> = ({
+  currentNetworkId,
+  currentTable,
+  nodeTable,
+  edgeTable,
+  tables,
+  selection,
+  setSelection,
+  rows,
+  allColumns,
+  tableDisplayConfiguration,
+  createUpdatedTableDisplayConfiguration,
+  setTableDisplayConfiguration,
+  setNetworkModified,
+  postEdit,
+  addColumn,
+  deleteColumn,
+  setColumnName,
+  applyValueToElements,
+  exclusiveSelect,
+  visualPropertiesDependentOnSelectedColumn,
+  setMapping,
+  setSort,
+  duplicateColumn,
+  columns,
+}) => {
+  const showTableJoinForm = useJoinTableToNetworkStore((state: any) => state.setShow)
+
+  // Modals state
+  const [showCreateColumnForm, setShowCreateColumnForm] = React.useState(false)
+  const [createColumnFormError, setCreateColumnFormError] = React.useState<string | undefined>(undefined)
+  const [showEditColumnForm, setShowEditColumnForm] = React.useState(false)
+  const [columnFormError, setColumnFormError] = React.useState<string | undefined>(undefined)
+  const [showDeleteColumnForm, setShowDeleteColumnForm] = React.useState(false)
+  const [deleteColumnFormError, setDeleteColumnFormError] = React.useState<string | undefined>(undefined)
+
+  // Derived state
+  const selectedColumnIndex = selection.columns.first()
+  const selectedColumn = selectedColumnIndex !== undefined && allColumns != null ? allColumns[selectedColumnIndex] : null
+
+  const selectedCell = selection.current?.cell ?? null
+  const isSelectedCellVirtual =
+    selectedCell != null &&
+    allColumns?.[selectedCell[0]] &&
+    (allColumns[selectedCell[0]] as any).isVirtual
+
+  const selectedColumnToolbar =
+    selectedColumnIndex !== undefined &&
+    selectedColumn != null &&
+    !(selectedColumn as any).isVirtual ? (
+      <>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            ml: 2,
+            backgroundColor: 'transparent',
+          }}
+        >
+          <ToolbarTextButton onClick={() => {
+            if (selectedColumn != null) {
+              const columnKey = selectedColumn.id
+              const columnType = selectedColumn.type
+              setSort({ column: columnKey, direction: 'asc', valueType: columnType })
+              const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({ sortColumn: columnKey, sortDirection: 'ascending' })
+              setTableDisplayConfiguration(currentNetworkId, newTableDisplayConfiguration)
+              setNetworkModified(currentNetworkId, true)
+            }
+          }}>
+            Sort Asc
+          </ToolbarTextButton>
+          <ToolbarTextButton onClick={() => {
+            if (selectedColumn != null) {
+              const columnKey = selectedColumn.id
+              const columnType = selectedColumn.type
+              setSort({ column: columnKey, direction: 'desc', valueType: columnType })
+              const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({ sortColumn: columnKey, sortDirection: 'descending' })
+              setTableDisplayConfiguration(currentNetworkId, newTableDisplayConfiguration)
+              setNetworkModified(currentNetworkId, true)
+            }
+          }}>
+            Sort Desc
+          </ToolbarTextButton>
+          <ToolbarTextButton onClick={() => {
+            if (selectedColumn !== null && !(selectedColumn as any)?.isVirtual) {
+              const columnKey = selectedColumn.id
+              duplicateColumn(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', columnKey)
+              setNetworkModified(currentNetworkId, true)
+              setSelection({ ...selection, columns: CompactSelection.fromSingleSelection(selectedColumn.index + 1) })
+
+              const defaultConfig = {
+                columnConfiguration: (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map((col: any) => ({
+                  attributeName: col.name,
+                  visible: true,
+                  columnWidth: undefined,
+                })) ?? [],
+                sortColumn: undefined,
+                sortDirection: undefined,
+              }
+              const currentConfig = currentTable === nodeTable
+                ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
+                : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
+              const duplicatedCol = currentConfig.columnConfiguration.find((col: any) => col.attributeName === columnKey)
+              const allColumnNames = columns.map((c: any) => c.id)
+              const originalIndex = allColumnNames.indexOf(columnKey)
+              const newColumnName = allColumnNames[originalIndex + 1]
+              if (duplicatedCol && newColumnName) {
+                const newColConfig = [
+                  ...currentConfig.columnConfiguration.slice(0, originalIndex + 1),
+                  { ...duplicatedCol, attributeName: newColumnName },
+                  ...currentConfig.columnConfiguration.slice(originalIndex + 1),
+                ]
+                const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({ columnConfiguration: newColConfig })
+                setTableDisplayConfiguration(currentNetworkId, newTableDisplayConfiguration)
+                setNetworkModified(currentNetworkId, true)
+              }
+            }
+          }}>
+            Duplicate
+          </ToolbarTextButton>
+          <ToolbarTextButton onClick={() => setShowEditColumnForm(true)}>
+            Edit Column Name
+          </ToolbarTextButton>
+          <ToolbarTextButton onClick={() => setShowDeleteColumnForm(true)}>
+            Delete Column
+          </ToolbarTextButton>
+        </Box>
+        <EditTableColumnForm
+          error={columnFormError}
+          dependentVisualProperties={visualPropertiesDependentOnSelectedColumn}
+          open={showEditColumnForm}
+          column={selectedColumn}
+          onClose={() => {
+            setShowEditColumnForm(false)
+            setColumnFormError(undefined)
+          }}
+          onSubmit={(newColumnName: string, mappingUpdateType?: 'delete' | 'rename') => {
+            if (currentTable?.columns?.find((c: any) => c.name === newColumnName)) {
+              setColumnFormError(`${newColumnName} already exists. Please enter a new unique column name`)
+            } else {
+              postEdit(
+                UndoCommandType.RENAME_COLUMN,
+                `Rename column '${selectedColumn.title}' to '${newColumnName}'`,
+                [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', newColumnName, selectedColumn.id],
+                [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', selectedColumn.id, newColumnName],
+              )
+              setColumnName(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', selectedColumn.id, newColumnName)
+              setNetworkModified(currentNetworkId, true)
+
+              const defaultConfig = {
+                columnConfiguration: (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map((col: any) => ({
+                  attributeName: col.name,
+                  visible: true,
+                  columnWidth: undefined,
+                })) ?? [],
+                sortColumn: undefined,
+                sortDirection: undefined,
+              }
+              const currentConfig = currentTable === nodeTable
+                  ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
+                  : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
+              const newColumnConfig = currentConfig.columnConfiguration.map((col: any) =>
+                col.attributeName === selectedColumn.id ? { ...col, attributeName: newColumnName } : col,
+              )
+              const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({ columnConfiguration: newColumnConfig })
+              setTableDisplayConfiguration(currentNetworkId, newTableDisplayConfiguration)
+              setNetworkModified(currentNetworkId, true)
+
+              if (mappingUpdateType === 'rename') {
+                visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
+                  if (vp.mapping != null) {
+                    setMapping(currentNetworkId, vp.name, { ...vp.mapping, attribute: newColumnName })
+                  }
+                })
+              } else if (mappingUpdateType === 'delete') {
+                visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
+                  setMapping(currentNetworkId, vp.name, undefined)
+                })
+              }
+              setColumnFormError(undefined)
+              setShowEditColumnForm(false)
+            }
+          }}
+        />
+        <DeleteTableColumnForm
+          error={deleteColumnFormError}
+          dependentVisualProperties={visualPropertiesDependentOnSelectedColumn}
+          open={showDeleteColumnForm}
+          column={selectedColumn}
+          onClose={() => {
+            setShowDeleteColumnForm(false)
+            setDeleteColumnFormError(undefined)
+          }}
+          onSubmit={(mappingUpdateType?: 'delete') => {
+            postEdit(
+              UndoCommandType.DELETE_COLUMN,
+              `Delete ${currentTable === nodeTable ? 'node' : 'edge'} column ${selectedColumn.title}`,
+              [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', currentTable, selectedColumn],
+              [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', currentTable, selectedColumn],
+            )
+            deleteColumn(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', selectedColumn.id)
+            setNetworkModified(currentNetworkId, true)
+
+            const defaultConfig = {
+              columnConfiguration: (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map((col: any) => ({
+                attributeName: col.name,
+                visible: true,
+                columnWidth: undefined,
+              })) ?? [],
+              sortColumn: undefined,
+              sortDirection: undefined,
+            }
+            const currentConfig = currentTable === nodeTable
+                ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
+                : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
+            const newColumnConfig = currentConfig.columnConfiguration.filter((col: any) => col.attributeName !== selectedColumn.id)
+            const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({ columnConfiguration: newColumnConfig })
+            setTableDisplayConfiguration(currentNetworkId, newTableDisplayConfiguration)
+            setNetworkModified(currentNetworkId, true)
+
+            if (mappingUpdateType === 'delete') {
+              visualPropertiesDependentOnSelectedColumn.forEach((vp) => {
+                setMapping(currentNetworkId, vp.name, undefined)
+              })
+            }
+            setShowDeleteColumnForm(false)
+            setDeleteColumnFormError(undefined)
+            setSelection({ columns: CompactSelection.empty(), rows: CompactSelection.empty() })
+          }}
+        />
+      </>
+    ) : null
+
+  const selectedCellToolbar =
+    selectedCell != null && !isSelectedCellVirtual ? (
+      <Box sx={{ display: 'flex', gap: 1, ml: 2, backgroundColor: 'transparent', minWidth: '540px' }}>
+        <ToolbarTextButton
+          onClick={() => {
+            const [columnIndex, rowIndex] = selectedCell
+            const rowData = rows?.[rowIndex]
+            const column = allColumns?.[columnIndex]
+            if (rowData == null || column == null) return
+            const columnKey = column.id
+            const cellValue = (rowData as any)?.[columnKey]
+            const cellEdits: CellEdit[] = []
+            const prevColumnValues: CellEdit[] = []
+            Array.from(currentTable?.rows.entries() || []).map(([k, v]) => {
+              cellEdits.push({ row: k, column: columnKey, value: cellValue })
+              prevColumnValues.push({ row: k, column: columnKey, value: (v as any)?.[columnKey] as ValueType })
+            })
+            postEdit(
+              UndoCommandType.APPLY_VALUE_TO_COLUMN,
+              'Apply value to column',
+              [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', prevColumnValues],
+              [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', cellEdits],
+            )
+            applyValueToElements(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', columnKey, cellValue)
+            setNetworkModified(currentNetworkId, true)
+          }}
+        >
+          Apply Value to Column
+        </ToolbarTextButton>
+        <ToolbarTextButton
+          onClick={() => {
+            const [columnIndex, rowIndex] = selectedCell
+            const rowData = rows?.[rowIndex]
+            const column = allColumns?.[columnIndex]
+            if (rowData == null || column == null) return
+            const columnKey = column.id
+            const cellValue = (rowData as any)?.[columnKey]
+            const cellEdits: CellEdit[] = []
+            const prevColumnValues: CellEdit[] = []
+
+            rows?.forEach((r) => {
+              const rowId = r.id
+              cellEdits.push({ row: rowId, column: columnKey, value: cellValue })
+              prevColumnValues.push({ row: rowId, column: columnKey, value: (r as any)?.[columnKey] as ValueType })
+            })
+
+            postEdit(
+              UndoCommandType.APPLY_VALUE_TO_SELECTED,
+              'Apply value to selected elements',
+              [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', prevColumnValues],
+              [currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', cellEdits],
+            )
+            applyValueToElements(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', columnKey, cellValue, rows?.map((r) => r.id))
+            setNetworkModified(currentNetworkId, true)
+          }}
+        >
+          {`Apply Value to Selected ${currentTable === nodeTable ? 'Nodes' : 'Edges'}`}
+        </ToolbarTextButton>
+      </Box>
+    ) : null
+
+  const selectedRowToolbar =
+    selection.rows.length > 0 ? (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 2, backgroundColor: 'transparent' }}>
+        <ToolbarTextButton
+          onClick={() => {
+            const rowsToSelect = selection.rows.toArray()
+            const rowIds = rowsToSelect.map((r) => rows?.[r].id).filter((id) => id !== undefined)
+            if (currentTable === nodeTable) {
+              exclusiveSelect(currentNetworkId, rowIds, [])
+            } else {
+              exclusiveSelect(currentNetworkId, [], rowIds)
+            }
+            setSelection({ ...selection, rows: CompactSelection.empty() })
+          }}
+        >
+          {`Select ${currentTable === nodeTable ? 'Nodes' : 'Edges'}`}
+        </ToolbarTextButton>
+      </Box>
+    ) : null
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, ml: 1, backgroundColor: 'transparent' }}>
+      <ToolbarIconButton
+        title="Insert new column"
+        disabled={tables[currentNetworkId] === undefined}
+        onClick={() => setShowCreateColumnForm(true)}
+      >
+        <span className="icon">&#8209;</span>
+      </ToolbarIconButton>
+      <ToolbarIconButton
+        title="Import table from file..."
+        disabled={tables[currentNetworkId] === undefined}
+        onClick={() => showTableJoinForm(true)}
+      >
+        <span className="icon">&#44;</span>
+      </ToolbarIconButton>
+      <CreateTableColumnForm
+        error={createColumnFormError}
+        open={showCreateColumnForm}
+        onClose={() => {
+          setShowCreateColumnForm(false)
+          setCreateColumnFormError(undefined)
+        }}
+        onSubmit={(columnName: string, dataType: ValueTypeName, value: string) => {
+          const columnNameSet = new Set(columns?.map((c: any) => c.name))
+          const columnNameAlreadyExists = columnNameSet.has(columnName)
+          const valueIsValid = serializedStringIsValid(dataType, value)
+          if (columnNameAlreadyExists) {
+            setCreateColumnFormError(`${columnName} already exists. Please enter a new unique column name`)
+          } else {
+            if (!valueIsValid) {
+              setCreateColumnFormError(`Default value ${value} is not a valid ${dataType}. Please enter a valid ${dataType}`)
+            } else {
+              const valueType = deserializeValue(dataType, value)
+              addColumn(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', columnName, dataType, valueType)
+              setNetworkModified(currentNetworkId, true)
+
+              const defaultConfig = {
+                columnConfiguration: (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map((col: any) => ({
+                  attributeName: col.name,
+                  visible: true,
+                  columnWidth: undefined,
+                })) ?? [],
+                sortColumn: undefined,
+                sortDirection: undefined,
+              }
+              const currentConfig = currentTable === nodeTable
+                  ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
+                  : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
+              const newColumnConfig = [
+                { attributeName: columnName, visible: true, columnWidth: undefined },
+                ...currentConfig.columnConfiguration,
+              ]
+              const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({ columnConfiguration: newColumnConfig })
+              setTableDisplayConfiguration(currentNetworkId, newTableDisplayConfiguration)
+              setNetworkModified(currentNetworkId, true)
+
+              setCreateColumnFormError(undefined)
+              setSelection({ ...selection, columns: CompactSelection.fromSingleSelection(0) })
+              setShowCreateColumnForm(false)
+            }
+          }
+        }}
+      />
+      {selectedColumnToolbar}
+      {selectedCellToolbar}
+      {selectedRowToolbar}
+    </Box>
+  )
+}

--- a/src/features/TableBrowser/components/TableToolbar.tsx
+++ b/src/features/TableBrowser/components/TableToolbar.tsx
@@ -43,16 +43,19 @@ const ToolbarIconButton = ({
   title,
   disabled = false,
   onClick,
+  testId,
   children,
 }: {
   title: string
   disabled?: boolean
   onClick: () => void
+  testId?: string
   children: React.ReactElement
 }) => (
   <ButtonTooltip title={title}>
     <span>
       <Button
+        data-testid={testId}
         disabled={disabled}
         onClick={onClick}
         sx={{
@@ -71,12 +74,15 @@ const ToolbarIconButton = ({
 
 const ToolbarTextButton = ({
   onClick,
+  testId,
   children,
 }: {
   onClick: () => void
+  testId?: string
   children: React.ReactNode
 }) => (
   <Button
+    data-testid={testId}
     variant="outlined"
     size="small"
     onClick={onClick}
@@ -178,7 +184,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
             backgroundColor: 'transparent',
           }}
         >
-          <ToolbarTextButton onClick={() => {
+          <ToolbarTextButton testId="table-toolbar-sort-asc-button" onClick={() => {
             if (selectedColumn != null) {
               const columnKey = selectedColumn.id
               const columnType = selectedColumn.type
@@ -190,7 +196,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
           }}>
             Sort Asc
           </ToolbarTextButton>
-          <ToolbarTextButton onClick={() => {
+          <ToolbarTextButton testId="table-toolbar-sort-desc-button" onClick={() => {
             if (selectedColumn != null) {
               const columnKey = selectedColumn.id
               const columnType = selectedColumn.type
@@ -202,7 +208,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
           }}>
             Sort Desc
           </ToolbarTextButton>
-          <ToolbarTextButton onClick={() => {
+          <ToolbarTextButton testId="table-toolbar-duplicate-column-button" onClick={() => {
             if (selectedColumn !== null && !(selectedColumn as any)?.isVirtual) {
               const columnKey = selectedColumn.id
               duplicateColumn(currentNetworkId, currentTable === nodeTable ? 'node' : 'edge', columnKey)
@@ -239,10 +245,10 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
           }}>
             Duplicate
           </ToolbarTextButton>
-          <ToolbarTextButton onClick={() => setShowEditColumnForm(true)}>
+          <ToolbarTextButton testId="table-toolbar-edit-column-button" onClick={() => setShowEditColumnForm(true)}>
             Edit Column Name
           </ToolbarTextButton>
-          <ToolbarTextButton onClick={() => setShowDeleteColumnForm(true)}>
+          <ToolbarTextButton testId="table-toolbar-delete-column-button" onClick={() => setShowDeleteColumnForm(true)}>
             Delete Column
           </ToolbarTextButton>
         </Box>
@@ -356,6 +362,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
     selectedCell != null && !isSelectedCellVirtual ? (
       <Box sx={{ display: 'flex', gap: 1, ml: 2, backgroundColor: 'transparent', minWidth: '540px' }}>
         <ToolbarTextButton
+          testId="table-toolbar-apply-value-to-column-button"
           onClick={() => {
             const [columnIndex, rowIndex] = selectedCell
             const rowData = rows?.[rowIndex]
@@ -382,6 +389,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
           Apply Value to Column
         </ToolbarTextButton>
         <ToolbarTextButton
+          testId="table-toolbar-apply-value-to-selected-button"
           onClick={() => {
             const [columnIndex, rowIndex] = selectedCell
             const rowData = rows?.[rowIndex]
@@ -417,6 +425,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
     selection.rows.length > 0 ? (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 2, backgroundColor: 'transparent' }}>
         <ToolbarTextButton
+          testId="table-toolbar-select-elements-button"
           onClick={() => {
             const rowsToSelect = selection.rows.toArray()
             const rowIds = rowsToSelect.map((r) => rows?.[r].id).filter((id) => id !== undefined)
@@ -436,6 +445,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, ml: 1, backgroundColor: 'transparent' }}>
       <ToolbarIconButton
+        testId="insert-column-button"
         title="Insert new column"
         disabled={tables[currentNetworkId] === undefined}
         onClick={() => setShowCreateColumnForm(true)}
@@ -443,6 +453,7 @@ export const TableToolbar: React.FC<TableToolbarProps> = ({
         <span className="icon">&#8209;</span>
       </ToolbarIconButton>
       <ToolbarIconButton
+        testId="import-table-button"
         title="Import table from file..."
         disabled={tables[currentNetworkId] === undefined}
         onClick={() => showTableJoinForm(true)}

--- a/src/features/TableBrowser/hooks/useDataEditorTheme.test.ts
+++ b/src/features/TableBrowser/hooks/useDataEditorTheme.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useDataEditorTheme } from './useDataEditorTheme'
+import * as muiStyles from '@mui/material/styles'
+
+vi.mock('@mui/material/styles', () => ({
+  useTheme: vi.fn(),
+}))
+
+describe('useDataEditorTheme', () => {
+  it('maps mui theme to data editor theme', () => {
+    const mockTheme = {
+      palette: {
+        background: { default: '#111', paper: '#222' },
+        action: { hover: '#333', focus: '#444', selected: '#555' },
+        text: { primary: '#666', secondary: '#777', disabled: '#888' },
+        primary: { main: '#999', contrastText: '#aaa' },
+        divider: '#bbb',
+      }
+    }
+    vi.mocked(muiStyles.useTheme).mockReturnValue(mockTheme as any)
+
+    const { result } = renderHook(() => useDataEditorTheme())
+
+    expect(result.current.bgHeader).toBe('#111')
+    expect(result.current.bgCell).toBe('#222')
+    expect(result.current.accentColor).toBe('#999')
+  })
+})

--- a/src/features/TableBrowser/hooks/useDataEditorTheme.ts
+++ b/src/features/TableBrowser/hooks/useDataEditorTheme.ts
@@ -1,0 +1,26 @@
+import React from 'react'
+import { useTheme } from '@mui/material/styles'
+
+export const useDataEditorTheme = () => {
+  const theme = useTheme()
+  return React.useMemo(() => {
+    return {
+      bgHeader: theme.palette.background.default,
+      bgHeaderHovered: theme.palette.action.hover,
+      bgHeaderHasFocus: theme.palette.action.focus,
+      textHeader: theme.palette.text.primary,
+      textHeaderSelected: theme.palette.primary.contrastText,
+      bgIconHeader: theme.palette.text.disabled,
+      fgIconHeader: theme.palette.background.default,
+      bgCell: theme.palette.background.paper,
+      bgCellMedium: theme.palette.background.paper,
+      bgCellLight: theme.palette.background.paper,
+      accentColor: theme.palette.primary.main,
+      accentLight: theme.palette.action.selected,
+      textDark: theme.palette.text.secondary,
+      textMedium: theme.palette.text.disabled,
+      textLight: theme.palette.text.disabled,
+      borderColor: theme.palette.divider,
+    }
+  }, [theme])
+}

--- a/src/features/TableBrowser/hooks/useIsContextCellVirtual.test.ts
+++ b/src/features/TableBrowser/hooks/useIsContextCellVirtual.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useIsContextCellVirtual } from './useIsContextCellVirtual'
+
+describe('useIsContextCellVirtual', () => {
+  it('returns false if contextMenu is null', () => {
+    const { result } = renderHook(() => useIsContextCellVirtual(null, []))
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false if contextMenu cell column is out of bounds', () => {
+    const contextMenu = { cell: [0, 0] as [number, number] }
+    const { result } = renderHook(() => useIsContextCellVirtual(contextMenu, []))
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false if column is not virtual', () => {
+    const contextMenu = { cell: [0, 0] as [number, number] }
+    const allColumns = [{ isVirtual: false }]
+    const { result } = renderHook(() => useIsContextCellVirtual(contextMenu, allColumns))
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true if column is virtual', () => {
+    const contextMenu = { cell: [0, 0] as [number, number] }
+    const allColumns = [{ isVirtual: true }]
+    const { result } = renderHook(() => useIsContextCellVirtual(contextMenu, allColumns))
+    expect(result.current).toBe(true)
+  })
+})

--- a/src/features/TableBrowser/hooks/useIsContextCellVirtual.ts
+++ b/src/features/TableBrowser/hooks/useIsContextCellVirtual.ts
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Item } from '@glideapps/glide-data-grid'
+
+export const useIsContextCellVirtual = (
+  contextMenu: { cell: Item } | null,
+  allColumns: any[],
+) => {
+  return React.useMemo(() => {
+    return (
+      contextMenu !== null &&
+      allColumns[contextMenu.cell[0]] != null &&
+      (allColumns[contextMenu.cell[0]] as any).isVirtual === true
+    )
+  }, [contextMenu, allColumns])
+}

--- a/src/features/TableBrowser/hooks/useListEditor.ts
+++ b/src/features/TableBrowser/hooks/useListEditor.ts
@@ -1,0 +1,101 @@
+import React from 'react'
+import { Item } from '@glideapps/glide-data-grid'
+import { IdType } from '../../../models/IdType'
+import { ValueType, ValueTypeName, Table } from '../../../models/TableModel'
+import { isListType } from '../../../models/TableModel/impl/valueTypeImpl'
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { TableColumn } from '../TableBrowser'
+
+export interface ListEditorState {
+  cxId: IdType
+  columnKey: string
+  columnName: string
+  type: ValueTypeName
+  value: ValueType | null
+}
+
+export interface UseListEditorProps {
+  allColumns: TableColumn[]
+  rows: any[]
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  currentNetworkId: IdType
+  networkId: IdType
+  postEdit: (type: UndoCommandType, name: string, oldVal: any, newVal: any) => void
+  setCellValue: (networkId: IdType, tableType: 'node' | 'edge', elementId: string, attributeName: string, value: any) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+}
+
+export const useListEditor = ({
+  allColumns,
+  rows,
+  currentTable,
+  nodeTable,
+  currentNetworkId,
+  networkId,
+  postEdit,
+  setCellValue,
+  setNetworkModified,
+}: UseListEditorProps) => {
+  const [listEditor, setListEditor] = React.useState<ListEditorState | null>(null)
+
+  const onCellActivated = React.useCallback(
+    (cell: Item): void => {
+      const [columnIndex, rowIndex] = cell
+      const column = allColumns?.[columnIndex]
+      const rowData = rows?.[rowIndex]
+      if (column == null || rowData == null || (column as any).isVirtual) return
+      if (!isListType(column.type)) return
+      const cxId = rowData.id
+      if (cxId == null) return
+      setListEditor({
+        cxId,
+        columnKey: column.id,
+        columnName: column.id,
+        type: column.type,
+        value: (rowData as any)?.[column.id] ?? null,
+      })
+    },
+    [allColumns, rows],
+  )
+
+  const handleListEditorSave = React.useCallback(
+    (newValue: ValueType): void => {
+      if (listEditor == null) return
+      const { cxId, columnKey } = listEditor
+      const elementType = currentTable === nodeTable ? 'node' : 'edge'
+      postEdit(
+        UndoCommandType.SET_CELL_VALUE,
+        'Set cell value',
+        [currentNetworkId, elementType, cxId, columnKey, listEditor.value],
+        [currentNetworkId, elementType, cxId, columnKey, newValue],
+      )
+      setCellValue(
+        currentNetworkId,
+        elementType,
+        `${cxId}`,
+        columnKey,
+        newValue,
+      )
+      setNetworkModified(networkId, true)
+      setListEditor(null)
+    },
+    [
+      listEditor,
+      currentTable,
+      nodeTable,
+      postEdit,
+      currentNetworkId,
+      setCellValue,
+      setNetworkModified,
+      networkId,
+    ],
+  )
+
+  return {
+    listEditor,
+    setListEditor,
+    onCellActivated,
+    handleListEditorSave,
+  }
+}

--- a/src/features/TableBrowser/hooks/useTableData.test.ts
+++ b/src/features/TableBrowser/hooks/useTableData.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { ValueTypeName } from '../../../models/TableModel'
 import { useTableData } from './useTableData'
 import { ID_COLUMN_ID } from '../idColumn'
+import { TableBrowserTab } from '../components/TableBrowserTabs'
 
 describe('useTableData', () => {
   const mockNodeTable = {
@@ -29,7 +30,7 @@ describe('useTableData', () => {
 
   it('initializes with node table columns and rows when currentTabIndex is 0', () => {
     const { result } = renderHook(() => useTableData({
-      currentTabIndex: 0,
+      currentTabIndex: TableBrowserTab.NODES,
       nodeTable: mockNodeTable as any,
       edgeTable: mockEdgeTable as any,
       network: undefined,
@@ -48,7 +49,7 @@ describe('useTableData', () => {
 
   it('filters rows based on selectedElements', () => {
     const { result } = renderHook(() => useTableData({
-      currentTabIndex: 0,
+      currentTabIndex: TableBrowserTab.NODES,
       nodeTable: mockNodeTable as any,
       edgeTable: mockEdgeTable as any,
       network: undefined,
@@ -73,7 +74,7 @@ describe('useTableData', () => {
     }
 
     const { result } = renderHook(() => useTableData({
-      currentTabIndex: 0,
+      currentTabIndex: TableBrowserTab.NODES,
       nodeTable: mockNodeTable as any,
       edgeTable: mockEdgeTable as any,
       network: undefined,
@@ -85,8 +86,23 @@ describe('useTableData', () => {
     expect(result.current.sort.column).toBe('score')
     expect(result.current.sort.direction).toBe('desc')
     
-    // Rows should be sorted descending by score (node2 then node1)
     expect(result.current.rows[0].id).toBe('node2')
     expect(result.current.rows[1].id).toBe('node1')
+  })
+
+  it('does not include edge virtual columns when both tables are undefined and currentTabIndex is 0', () => {
+    const { result } = renderHook(() => useTableData({
+      currentTabIndex: 0,
+      nodeTable: undefined,
+      edgeTable: undefined,
+      network: undefined,
+      tableDisplayConfiguration: undefined,
+      selectedNodes: [],
+      selectedEdges: [],
+    }))
+
+    const columnIds = result.current.allColumns.map(c => c.id)
+    expect(columnIds).not.toContain('__sourceNodeName')
+    expect(columnIds).not.toContain('__targetNodeName')
   })
 })

--- a/src/features/TableBrowser/hooks/useTableData.test.ts
+++ b/src/features/TableBrowser/hooks/useTableData.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ValueTypeName } from '../../../models/TableModel'
+import { useTableData } from './useTableData'
+import { ID_COLUMN_ID } from '../idColumn'
+
+describe('useTableData', () => {
+  const mockNodeTable = {
+    id: 'nodes',
+    rows: new Map([
+      ['node1', { name: 'Node 1', score: 10 }],
+      ['node2', { name: 'Node 2', score: 20 }],
+    ]),
+    columns: [
+      { name: 'name', type: ValueTypeName.String },
+      { name: 'score', type: ValueTypeName.Double },
+    ],
+  }
+
+  const mockEdgeTable = {
+    id: 'edges',
+    rows: new Map([
+      ['edge1', { interaction: 'pp' }],
+    ]),
+    columns: [
+      { name: 'interaction', type: ValueTypeName.String },
+    ],
+  }
+
+  it('initializes with node table columns and rows when currentTabIndex is 0', () => {
+    const { result } = renderHook(() => useTableData({
+      currentTabIndex: 0,
+      nodeTable: mockNodeTable as any,
+      edgeTable: mockEdgeTable as any,
+      network: undefined,
+      tableDisplayConfiguration: undefined,
+      selectedNodes: [],
+      selectedEdges: [],
+    }))
+
+    expect(result.current.currentTable).toBe(mockNodeTable)
+    expect(result.current.allColumns.length).toBeGreaterThan(0)
+    expect(result.current.allColumns[0].id).toBe(ID_COLUMN_ID)
+    
+    // Rows should be the full node table
+    expect(result.current.rows.length).toBe(2)
+  })
+
+  it('filters rows based on selectedElements', () => {
+    const { result } = renderHook(() => useTableData({
+      currentTabIndex: 0,
+      nodeTable: mockNodeTable as any,
+      edgeTable: mockEdgeTable as any,
+      network: undefined,
+      tableDisplayConfiguration: undefined,
+      selectedNodes: ['node1'],
+      selectedEdges: [],
+    }))
+
+    // Should only return the selected node
+    expect(result.current.rows.length).toBe(1)
+    expect(result.current.rows[0].id).toBe('node1')
+  })
+
+  it('initializes sort state from tableDisplayConfiguration', () => {
+    const mockDisplayConfig = {
+      nodeTable: {
+        sortColumn: 'score',
+        sortDirection: 'descending' as const,
+        columnConfiguration: [],
+      },
+      edgeTable: undefined,
+    }
+
+    const { result } = renderHook(() => useTableData({
+      currentTabIndex: 0,
+      nodeTable: mockNodeTable as any,
+      edgeTable: mockEdgeTable as any,
+      network: undefined,
+      tableDisplayConfiguration: mockDisplayConfig as any,
+      selectedNodes: [],
+      selectedEdges: [],
+    }))
+
+    expect(result.current.sort.column).toBe('score')
+    expect(result.current.sort.direction).toBe('desc')
+    
+    // Rows should be sorted descending by score (node2 then node1)
+    expect(result.current.rows[0].id).toBe('node2')
+    expect(result.current.rows[1].id).toBe('node1')
+  })
+})

--- a/src/features/TableBrowser/hooks/useTableData.ts
+++ b/src/features/TableBrowser/hooks/useTableData.ts
@@ -8,6 +8,7 @@ import { getElementId, ID_COLUMN_ID, ID_COLUMN_TITLE } from '../idColumn'
 import { SortType } from '../../../models/TableModel/impl/valueTypeImpl'
 import { getHeaderIconForType } from '../utils/tableRenderers'
 import { getBadgeWidth } from '../../../models/TableModel/impl/valueTypeNameIcons'
+import { TableBrowserTab } from '../components/TableBrowserTabs'
 
 export interface UseTableDataProps {
   currentTabIndex: number
@@ -28,8 +29,8 @@ export const useTableData = ({
   selectedNodes,
   selectedEdges,
 }: UseTableDataProps) => {
-  const currentTable = currentTabIndex === 0 ? nodeTable : edgeTable
-  const selectedElements = currentTabIndex === 0 ? selectedNodes : selectedEdges
+  const currentTable = currentTabIndex === TableBrowserTab.NODES ? nodeTable : edgeTable
+  const selectedElements = currentTabIndex === TableBrowserTab.NODES ? selectedNodes : selectedEdges
 
   const isNodeTable = currentTable === nodeTable
   const currentTableConfig = isNodeTable
@@ -120,7 +121,7 @@ export const useTableData = ({
   }, [nodeTable])
 
   const virtualColumns = React.useMemo(() => {
-    if (currentTabIndex !== 1) { // 1 is Edge Table tab
+    if (currentTabIndex !== TableBrowserTab.EDGES) {
       return []
     }
 
@@ -177,7 +178,7 @@ export const useTableData = ({
 
   const allColumns = React.useMemo(
     () =>
-      currentTabIndex === 1
+      currentTabIndex === TableBrowserTab.EDGES
         ? [idColumn, ...virtualColumns, ...columns]
         : [idColumn, ...columns],
     [currentTabIndex, idColumn, virtualColumns, columns],

--- a/src/features/TableBrowser/hooks/useTableData.ts
+++ b/src/features/TableBrowser/hooks/useTableData.ts
@@ -120,7 +120,7 @@ export const useTableData = ({
   }, [nodeTable])
 
   const virtualColumns = React.useMemo(() => {
-    if (currentTable !== edgeTable) {
+    if (currentTabIndex !== 1) { // 1 is Edge Table tab
       return []
     }
 
@@ -158,7 +158,7 @@ export const useTableData = ({
         },
       },
     ]
-  }, [currentTable, edgeTable, nodeNameMap, network])
+  }, [currentTabIndex, nodeNameMap, network])
 
   const idColumn = React.useMemo(
     () => ({
@@ -177,10 +177,10 @@ export const useTableData = ({
 
   const allColumns = React.useMemo(
     () =>
-      currentTable === edgeTable
+      currentTabIndex === 1
         ? [idColumn, ...virtualColumns, ...columns]
         : [idColumn, ...columns],
-    [currentTable, edgeTable, idColumn, virtualColumns, columns],
+    [currentTabIndex, idColumn, virtualColumns, columns],
   )
 
   const rowsWithIds = React.useMemo(() => {

--- a/src/features/TableBrowser/hooks/useTableData.ts
+++ b/src/features/TableBrowser/hooks/useTableData.ts
@@ -1,0 +1,304 @@
+import React from 'react'
+import { GridColumnIcon } from '@glideapps/glide-data-grid'
+import { orderBy } from 'lodash'
+import { IdType } from '../../../models/IdType'
+import { Table, ValueType, ValueTypeName } from '../../../models/TableModel'
+import { Network } from '../../../models/NetworkModel'
+import { TableDisplayConfiguration, ColumnConfiguration } from '../../../models/VisualStyleModel/VisualStyleOptions'
+import { getElementId, ID_COLUMN_ID, ID_COLUMN_TITLE } from '../idColumn'
+import { SortType } from '../../../models/TableModel/impl/valueTypeImpl'
+import { getHeaderIconForType } from '../utils/tableRenderers'
+import { getBadgeWidth } from '../../../models/TableModel/impl/valueTypeNameIcons'
+
+export interface UseTableDataProps {
+  currentTabIndex: number
+  nodeTable: Table | undefined
+  edgeTable: Table | undefined
+  network: Network | undefined
+  tableDisplayConfiguration: TableDisplayConfiguration | undefined
+  selectedNodes: string[]
+  selectedEdges: string[]
+}
+
+export const useTableData = ({
+  currentTabIndex,
+  nodeTable,
+  edgeTable,
+  network,
+  tableDisplayConfiguration,
+  selectedNodes,
+  selectedEdges,
+}: UseTableDataProps) => {
+  const currentTable = currentTabIndex === 0 ? nodeTable : edgeTable
+  const selectedElements = currentTabIndex === 0 ? selectedNodes : selectedEdges
+
+  const isNodeTable = currentTable === nodeTable
+  const currentTableConfig = isNodeTable
+    ? tableDisplayConfiguration?.nodeTable
+    : tableDisplayConfiguration?.edgeTable
+
+  const [sort, setSort] = React.useState<SortType>({
+    column: undefined,
+    direction: undefined,
+    valueType: undefined,
+  })
+
+  // Initialize sort state from tableDisplayConfiguration
+  React.useEffect(() => {
+    if (currentTableConfig?.sortColumn && currentTableConfig?.sortDirection) {
+      const sortColumn = currentTable?.columns?.find(
+        (c) => c.name === currentTableConfig.sortColumn,
+      )
+
+      setSort({
+        column: currentTableConfig.sortColumn,
+        direction: currentTableConfig.sortDirection === 'ascending' ? 'asc' : 'desc',
+        valueType: sortColumn?.type ?? ValueTypeName.String,
+      })
+    }
+  }, [tableDisplayConfiguration, currentTabIndex, currentTable, currentTableConfig])
+
+  // Get configuration columns or fallback to table columns
+  const modelColumns = React.useMemo(() => {
+    if (currentTableConfig && currentTableConfig.columnConfiguration) {
+      return currentTableConfig.columnConfiguration.filter((col) => col.visible)
+    }
+    return (
+      currentTable?.columns?.map((col) => ({
+        attributeName: col.name,
+        visible: true,
+        columnWidth: undefined,
+      })) ?? []
+    )
+  }, [currentTableConfig, currentTable])
+
+  const columns = React.useMemo(
+    () =>
+      modelColumns.map((col, index) => {
+        const columnType = currentTable?.columns?.find(
+          (c) => c?.name === col?.attributeName,
+        )?.type
+
+        const attributeName = col?.attributeName ?? ''
+        const resolvedType = columnType ?? ValueTypeName.String
+
+        const badgeWidth = getBadgeWidth(resolvedType)
+        const charWidth = 8
+        const padding = 48
+        const calculatedWidth = Math.max(100, attributeName.length * charWidth + badgeWidth + padding)
+
+        const baseColumn = {
+          id: attributeName,
+          title: attributeName,
+          icon: getHeaderIconForType(resolvedType),
+          themeOverride: { headerIconSize: badgeWidth },
+          type: resolvedType,
+          index,
+        }
+
+        return col?.columnWidth !== undefined
+          ? { ...baseColumn, width: col.columnWidth }
+          : { ...baseColumn, width: calculatedWidth }
+      }),
+    [modelColumns, currentTable],
+  )
+
+  const virtualColumns = React.useMemo(() => {
+    if (currentTable !== edgeTable) {
+      return []
+    }
+
+    const nodeNameMap = new Map<string, string>()
+    if (nodeTable) {
+      nodeTable.rows.forEach((nodeData, nodeId) => {
+        const nodeName =
+          (nodeData.name as string) ||
+          (nodeData.label as string) ||
+          (nodeData.nodeLabel as string) ||
+          (nodeData.displayName as string) ||
+          (nodeData.title as string) ||
+          nodeId.toString()
+        nodeNameMap.set(nodeId.toString(), nodeName)
+      })
+    }
+
+    return [
+      {
+        id: '__sourceNodeName',
+        title: 'Source Node',
+        icon: GridColumnIcon.ProtectedColumnOverlay,
+        style: 'highlight' as const,
+        type: ValueTypeName.String,
+        index: 0,
+        width: 150,
+        isVirtual: true,
+        getValue: (edgeData: any) => {
+          const edgeId = edgeData?.id?.toString()
+          const edge = network?.edges?.find((e: any) => e.id?.toString() === edgeId)
+          const sourceId = edge?.s?.toString()
+          return sourceId ? nodeNameMap.get(sourceId) || `Node ${sourceId}` : ''
+        },
+      },
+      {
+        id: '__targetNodeName',
+        title: 'Target Node',
+        icon: GridColumnIcon.ProtectedColumnOverlay,
+        style: 'highlight' as const,
+        type: ValueTypeName.String,
+        index: 1,
+        width: 150,
+        isVirtual: true,
+        getValue: (edgeData: any) => {
+          const edgeId = edgeData?.id?.toString()
+          const edge = network?.edges?.find((e: any) => e.id?.toString() === edgeId)
+          const targetId = edge?.t?.toString()
+          return targetId ? nodeNameMap.get(targetId) || `Node ${targetId}` : ''
+        },
+      },
+    ]
+  }, [currentTable, edgeTable, nodeTable, network])
+
+  const idColumn = React.useMemo(
+    () => ({
+      id: ID_COLUMN_ID,
+      title: ID_COLUMN_TITLE,
+      icon: GridColumnIcon.ProtectedColumnOverlay,
+      style: 'highlight' as const,
+      type: ValueTypeName.String,
+      index: 0,
+      width: 120,
+      isVirtual: true,
+      getValue: (dataRow: any) => getElementId(dataRow),
+    }),
+    [],
+  )
+
+  const allColumns = React.useMemo(
+    () =>
+      currentTable === edgeTable
+        ? [idColumn, ...virtualColumns, ...columns]
+        : [idColumn, ...columns],
+    [currentTable, edgeTable, idColumn, virtualColumns, columns],
+  )
+
+  const rows = React.useMemo(() => {
+    const selectedElementsSet = new Set(selectedElements)
+    const rowsWithIds = Array.from((currentTable?.rows ?? new Map()).entries()).map(
+      ([key, value]) => ({ ...value, id: key }),
+    )
+    let result =
+      selectedElements?.length > 0
+        ? rowsWithIds.filter((r) => selectedElementsSet.has(r.id))
+        : rowsWithIds
+
+    if (sort.column != null && sort.direction != null && sort.valueType != null) {
+      if (sort.column === '__sourceNodeName' || sort.column === '__targetNodeName') {
+        const nodeNameMap = new Map<string, string>()
+        if (nodeTable) {
+          nodeTable.rows.forEach((nodeData, nodeId) => {
+            const nodeName =
+              (nodeData.name as string) ||
+              (nodeData.label as string) ||
+              (nodeData.nodeLabel as string) ||
+              (nodeData.displayName as string) ||
+              (nodeData.title as string) ||
+              nodeId.toString()
+            nodeNameMap.set(nodeId.toString(), nodeName)
+          })
+        }
+
+        result = orderBy(
+          result,
+          (o) => {
+            if (sort.column === '__sourceNodeName') {
+              const sourceId = (o as any).s?.toString()
+              return sourceId ? nodeNameMap.get(sourceId) || `Node ${sourceId}` : ''
+            } else if (sort.column === '__targetNodeName') {
+              const targetId = (o as any).t?.toString()
+              return targetId ? nodeNameMap.get(targetId) || `Node ${targetId}` : ''
+            }
+            return ''
+          },
+          sort.direction,
+        )
+      } else if (sort.column === ID_COLUMN_ID) {
+        result = orderBy(result, (o) => getElementId(o), sort.direction)
+      } else {
+        result = orderBy(
+          result,
+          (o) => (o as Record<string, ValueType>)[sort.column as string] as ValueType,
+          sort.direction,
+        )
+      }
+    }
+
+    return result
+  }, [selectedElements, currentTable, sort, nodeTable])
+
+
+  const createUpdatedTableDisplayConfiguration = React.useCallback(
+    (updates: {
+      columnConfiguration?: ColumnConfiguration[]
+      sortColumn?: string
+      sortDirection?: 'ascending' | 'descending'
+    }) => {
+      const isNodeTable = currentTable === nodeTable
+      // Temporary fix: create default config from table columns if tableDisplayConfiguration is missing
+      const defaultNodeConfig = {
+        columnConfiguration:
+          nodeTable?.columns?.map((col) => ({
+            attributeName: col.name,
+            visible: true,
+            columnWidth: undefined,
+          })) ?? [],
+        sortColumn: undefined,
+        sortDirection: undefined,
+      }
+      const defaultEdgeConfig = {
+        columnConfiguration:
+          edgeTable?.columns?.map((col) => ({
+            attributeName: col.name,
+            visible: true,
+            columnWidth: undefined,
+          })) ?? [],
+        sortColumn: undefined,
+        sortDirection: undefined,
+      }
+      const currentConfig = isNodeTable
+        ? (tableDisplayConfiguration?.nodeTable ?? defaultNodeConfig)
+        : (tableDisplayConfiguration?.edgeTable ?? defaultEdgeConfig)
+      const otherConfig = isNodeTable
+        ? (tableDisplayConfiguration?.edgeTable ?? defaultEdgeConfig)
+        : (tableDisplayConfiguration?.nodeTable ?? defaultNodeConfig)
+
+      const updatedConfig = {
+        ...currentConfig,
+        ...updates,
+      }
+
+      return isNodeTable
+        ? {
+            nodeTable: updatedConfig as any,
+            edgeTable: otherConfig as any,
+          }
+        : {
+            nodeTable: otherConfig as any,
+            edgeTable: updatedConfig as any,
+          }
+    },
+    [tableDisplayConfiguration, currentTable, nodeTable, edgeTable],
+  )
+
+  return {
+    currentTable,
+    createUpdatedTableDisplayConfiguration,
+    sort,
+    setSort,
+    allColumns,
+    columns,
+    idColumn,
+    virtualColumns,
+    rows,
+    selectedElements,
+  }
+}

--- a/src/features/TableBrowser/hooks/useTableData.ts
+++ b/src/features/TableBrowser/hooks/useTableData.ts
@@ -1,7 +1,6 @@
 import React from 'react'
 import { GridColumnIcon } from '@glideapps/glide-data-grid'
 import { orderBy } from 'lodash'
-import { IdType } from '../../../models/IdType'
 import { Table, ValueType, ValueTypeName } from '../../../models/TableModel'
 import { Network } from '../../../models/NetworkModel'
 import { TableDisplayConfiguration, ColumnConfiguration } from '../../../models/VisualStyleModel/VisualStyleOptions'
@@ -103,12 +102,8 @@ export const useTableData = ({
     [modelColumns, currentTable],
   )
 
-  const virtualColumns = React.useMemo(() => {
-    if (currentTable !== edgeTable) {
-      return []
-    }
-
-    const nodeNameMap = new Map<string, string>()
+  const nodeNameMap = React.useMemo(() => {
+    const map = new Map<string, string>()
     if (nodeTable) {
       nodeTable.rows.forEach((nodeData, nodeId) => {
         const nodeName =
@@ -118,8 +113,15 @@ export const useTableData = ({
           (nodeData.displayName as string) ||
           (nodeData.title as string) ||
           nodeId.toString()
-        nodeNameMap.set(nodeId.toString(), nodeName)
+        map.set(nodeId.toString(), nodeName)
       })
+    }
+    return map
+  }, [nodeTable])
+
+  const virtualColumns = React.useMemo(() => {
+    if (currentTable !== edgeTable) {
+      return []
     }
 
     return [
@@ -156,7 +158,7 @@ export const useTableData = ({
         },
       },
     ]
-  }, [currentTable, edgeTable, nodeTable, network])
+  }, [currentTable, edgeTable, nodeNameMap, network])
 
   const idColumn = React.useMemo(
     () => ({
@@ -181,11 +183,14 @@ export const useTableData = ({
     [currentTable, edgeTable, idColumn, virtualColumns, columns],
   )
 
-  const rows = React.useMemo(() => {
-    const selectedElementsSet = new Set(selectedElements)
-    const rowsWithIds = Array.from((currentTable?.rows ?? new Map()).entries()).map(
+  const rowsWithIds = React.useMemo(() => {
+    return Array.from((currentTable?.rows ?? new Map()).entries()).map(
       ([key, value]) => ({ ...value, id: key }),
     )
+  }, [currentTable])
+
+  const rows = React.useMemo(() => {
+    const selectedElementsSet = new Set(selectedElements)
     let result =
       selectedElements?.length > 0
         ? rowsWithIds.filter((r) => selectedElementsSet.has(r.id))
@@ -193,20 +198,6 @@ export const useTableData = ({
 
     if (sort.column != null && sort.direction != null && sort.valueType != null) {
       if (sort.column === '__sourceNodeName' || sort.column === '__targetNodeName') {
-        const nodeNameMap = new Map<string, string>()
-        if (nodeTable) {
-          nodeTable.rows.forEach((nodeData, nodeId) => {
-            const nodeName =
-              (nodeData.name as string) ||
-              (nodeData.label as string) ||
-              (nodeData.nodeLabel as string) ||
-              (nodeData.displayName as string) ||
-              (nodeData.title as string) ||
-              nodeId.toString()
-            nodeNameMap.set(nodeId.toString(), nodeName)
-          })
-        }
-
         result = orderBy(
           result,
           (o) => {
@@ -233,7 +224,7 @@ export const useTableData = ({
     }
 
     return result
-  }, [selectedElements, currentTable, sort, nodeTable])
+  }, [selectedElements, rowsWithIds, sort, nodeNameMap])
 
 
   const createUpdatedTableDisplayConfiguration = React.useCallback(

--- a/src/features/TableBrowser/hooks/useTableMinMaxIds.test.ts
+++ b/src/features/TableBrowser/hooks/useTableMinMaxIds.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react'
+import { expect, test, describe } from 'vitest'
+import { useTableMinMaxIds } from './useTableMinMaxIds'
+import { Table } from '../../../models/TableModel'
+
+describe('useTableMinMaxIds', () => {
+  test('returns undefined for empty tables', () => {
+    const { result } = renderHook(() => useTableMinMaxIds(undefined, undefined))
+    expect(result.current.minNodeId).toBeUndefined()
+    expect(result.current.maxNodeId).toBeUndefined()
+    expect(result.current.minEdgeId).toBeUndefined()
+    expect(result.current.maxEdgeId).toBeUndefined()
+  })
+
+  test('calculates correct min/max for node table', () => {
+    const nodeTable: Table = {
+      id: 'nodes',
+      columns: [],
+      rows: new Map([
+        ['5', {}],
+        ['2', {}],
+        ['10', {}],
+      ]),
+    }
+    const { result } = renderHook(() => useTableMinMaxIds(nodeTable, undefined))
+    expect(result.current.minNodeId).toBe(2)
+    expect(result.current.maxNodeId).toBe(10)
+    expect(result.current.minEdgeId).toBeUndefined()
+    expect(result.current.maxEdgeId).toBeUndefined()
+  })
+
+  test('calculates correct min/max for edge table', () => {
+    const edgeTable: Table = {
+      id: 'edges',
+      columns: [],
+      rows: new Map([
+        ['e100', {}],
+        ['e50', {}],
+        ['e200', {}],
+      ]),
+    }
+    const { result } = renderHook(() => useTableMinMaxIds(undefined, edgeTable))
+    expect(result.current.minNodeId).toBeUndefined()
+    expect(result.current.maxNodeId).toBeUndefined()
+    expect(result.current.minEdgeId).toBe(50)
+    expect(result.current.maxEdgeId).toBe(200)
+  })
+})

--- a/src/features/TableBrowser/hooks/useTableMinMaxIds.ts
+++ b/src/features/TableBrowser/hooks/useTableMinMaxIds.ts
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Table } from '../../../models/TableModel'
+
+export const useTableMinMaxIds = (nodeTable?: Table, edgeTable?: Table) => {
+  return React.useMemo(() => {
+    let minN = Infinity
+    let maxN = -Infinity
+    if (nodeTable?.rows) {
+      for (const key of nodeTable.rows.keys()) {
+        const num = +key
+        if (num < minN) minN = num
+        if (num > maxN) maxN = num
+      }
+    }
+
+    let minE = Infinity
+    let maxE = -Infinity
+    if (edgeTable?.rows) {
+      for (const key of edgeTable.rows.keys()) {
+        const num = +key.slice(1) // Assuming edge ids start with 'e'
+        if (num < minE) minE = num
+        if (num > maxE) maxE = num
+      }
+    }
+
+    return {
+      minNodeId: minN === Infinity ? undefined : minN,
+      maxNodeId: maxN === -Infinity ? undefined : maxN,
+      minEdgeId: minE === Infinity ? undefined : minE,
+      maxEdgeId: maxE === -Infinity ? undefined : maxE,
+    }
+  }, [nodeTable?.rows, edgeTable?.rows])
+}

--- a/src/features/TableBrowser/hooks/useTableScrollToTop.test.ts
+++ b/src/features/TableBrowser/hooks/useTableScrollToTop.test.ts
@@ -1,0 +1,32 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useTableScrollToTop } from './useTableScrollToTop'
+
+describe('useTableScrollToTop', () => {
+  it('calls scrollTo on refs when selectedElements changes', () => {
+    const nodeScrollTo = vi.fn()
+    const edgeScrollTo = vi.fn()
+    const nodeRef = { current: { scrollTo: nodeScrollTo } } as any
+    const edgeRef = { current: { scrollTo: edgeScrollTo } } as any
+
+    const emptyArray: string[] = []
+
+    const { rerender } = renderHook(
+      ({ selected }) => useTableScrollToTop(nodeRef, edgeRef, selected),
+      { initialProps: { selected: emptyArray } }
+    )
+
+    // Initially called on mount
+    expect(nodeScrollTo).toHaveBeenCalledTimes(1)
+    expect(edgeScrollTo).toHaveBeenCalledTimes(1)
+
+    // Re-rendering with same props should not trigger again
+    rerender({ selected: emptyArray })
+    expect(nodeScrollTo).toHaveBeenCalledTimes(1)
+
+    // Re-rendering with new selection should trigger
+    rerender({ selected: ['node1'] })
+    expect(nodeScrollTo).toHaveBeenCalledTimes(2)
+    expect(edgeScrollTo).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/features/TableBrowser/hooks/useTableScrollToTop.ts
+++ b/src/features/TableBrowser/hooks/useTableScrollToTop.ts
@@ -1,0 +1,21 @@
+import React from 'react'
+import { DataEditorRef } from '@glideapps/glide-data-grid'
+
+export const useTableScrollToTop = (
+  nodeDataEditorRef: React.RefObject<DataEditorRef>,
+  edgeDataEditorRef: React.RefObject<DataEditorRef>,
+  selectedElements: string[],
+) => {
+  React.useEffect(() => {
+    // scroll to the first result anytime someone changes the filtered rows
+    // e.g. when the user selects nodes in the network view, scroll to the top of the list in the table
+    nodeDataEditorRef.current?.scrollTo(0, 0, 'both', 0, 0, {
+      vAlign: 'start',
+      hAlign: 'start',
+    })
+    edgeDataEditorRef.current?.scrollTo(0, 0, 'both', 0, 0, {
+      vAlign: 'start',
+      hAlign: 'start',
+    })
+  }, [selectedElements, nodeDataEditorRef, edgeDataEditorRef])
+}

--- a/src/features/TableBrowser/hooks/useTableSelection.test.ts
+++ b/src/features/TableBrowser/hooks/useTableSelection.test.ts
@@ -1,0 +1,44 @@
+import { act, renderHook } from '@testing-library/react'
+import { CompactSelection } from '@glideapps/glide-data-grid'
+import { describe, expect, it } from 'vitest'
+
+import { useTableSelection } from './useTableSelection'
+
+describe('useTableSelection', () => {
+  it('initializes with empty selections for nodes and edges', () => {
+    const { result } = renderHook(() => useTableSelection({ currentTabIndex: 0 }))
+    expect(result.current.nodeSelection.rows.length).toBe(0)
+    expect(result.current.edgeSelection.rows.length).toBe(0)
+    expect(result.current.selection).toBe(result.current.nodeSelection)
+  })
+
+  it('updates node selection when currentTabIndex is 0', () => {
+    const { result } = renderHook(() => useTableSelection({ currentTabIndex: 0 }))
+    
+    act(() => {
+      result.current.onGridSelectionChange({
+        columns: CompactSelection.empty(),
+        rows: CompactSelection.fromSingleSelection(5),
+      })
+    })
+
+    expect(result.current.nodeSelection.rows.toArray()).toEqual([5])
+    expect(result.current.edgeSelection.rows.length).toBe(0)
+    expect(result.current.selection.rows.toArray()).toEqual([5])
+  })
+
+  it('updates edge selection when currentTabIndex is 1', () => {
+    const { result } = renderHook(() => useTableSelection({ currentTabIndex: 1 }))
+    
+    act(() => {
+      result.current.onGridSelectionChange({
+        columns: CompactSelection.empty(),
+        rows: CompactSelection.fromSingleSelection(10),
+      })
+    })
+
+    expect(result.current.edgeSelection.rows.toArray()).toEqual([10])
+    expect(result.current.nodeSelection.rows.length).toBe(0)
+    expect(result.current.selection.rows.toArray()).toEqual([10])
+  })
+})

--- a/src/features/TableBrowser/hooks/useTableSelection.ts
+++ b/src/features/TableBrowser/hooks/useTableSelection.ts
@@ -1,0 +1,44 @@
+import React from 'react'
+import { CompactSelection, GridSelection } from '@glideapps/glide-data-grid'
+
+export interface UseTableSelectionProps {
+  currentTabIndex: number
+}
+
+export interface UseTableSelectionResult {
+  selection: GridSelection
+  nodeSelection: GridSelection
+  edgeSelection: GridSelection
+  setSelection: (newSelection: GridSelection) => void
+  onGridSelectionChange: (newSelection: GridSelection) => void
+}
+
+export const useTableSelection = ({ currentTabIndex }: UseTableSelectionProps): UseTableSelectionResult => {
+  const [nodeSelection, setNodeSelection] = React.useState<GridSelection>({
+    columns: CompactSelection.empty(),
+    rows: CompactSelection.empty(),
+  })
+  
+  const [edgeSelection, setEdgeSelection] = React.useState<GridSelection>({
+    columns: CompactSelection.empty(),
+    rows: CompactSelection.empty(),
+  })
+
+  const selection = currentTabIndex === 0 ? nodeSelection : edgeSelection
+  const updateSelection = currentTabIndex === 0 ? setNodeSelection : setEdgeSelection
+
+  const onGridSelectionChange = React.useCallback(
+    (newSelection: GridSelection) => {
+      updateSelection(newSelection)
+    },
+    [updateSelection],
+  )
+
+  return {
+    selection,
+    nodeSelection,
+    edgeSelection,
+    setSelection: updateSelection,
+    onGridSelectionChange,
+  }
+}

--- a/src/features/TableBrowser/utils/cellContentHandler.test.ts
+++ b/src/features/TableBrowser/utils/cellContentHandler.test.ts
@@ -1,0 +1,92 @@
+import { GridCellKind, Item } from '@glideapps/glide-data-grid'
+import { describe, expect, it } from 'vitest'
+
+import { ValueTypeName } from '../../../models/TableModel'
+import { getCellKind, handleGetCellContent } from './cellContentHandler'
+
+describe('cellContentHandler', () => {
+  describe('getCellKind', () => {
+    it('maps value types to correct grid cell kinds', () => {
+      expect(getCellKind(ValueTypeName.String)).toBe(GridCellKind.Text)
+      expect(getCellKind(ValueTypeName.Boolean)).toBe(GridCellKind.Boolean)
+      expect(getCellKind(ValueTypeName.Integer)).toBe(GridCellKind.Number)
+      expect(getCellKind(ValueTypeName.Double)).toBe(GridCellKind.Number)
+      expect(getCellKind(ValueTypeName.ListString)).toBe(GridCellKind.Text)
+      expect(getCellKind('unknown_type' as ValueTypeName)).toBe(
+        GridCellKind.Text,
+      )
+    })
+  })
+
+  describe('handleGetCellContent', () => {
+    const mockRows = [
+      { id: 'node-1', name: 'Node 1', score: 10.5, active: true },
+    ]
+
+    it('returns empty text cell if column or row is undefined', () => {
+      const result = handleGetCellContent({
+        cell: [0, 1] as Item, // Row index 1 does not exist
+        rows: mockRows,
+        allColumns: [{ id: 'name', type: ValueTypeName.String }],
+      })
+      expect(result.kind).toBe(GridCellKind.Text)
+      expect((result as any).displayData).toBe('')
+    })
+
+    it('handles virtual columns correctly', () => {
+      const mockVirtualColumn = {
+        id: '__id',
+        isVirtual: true,
+        getValue: (row: any) => row.id,
+      }
+      
+      const result = handleGetCellContent({
+        cell: [0, 0] as Item,
+        rows: mockRows,
+        allColumns: [mockVirtualColumn],
+      })
+      
+      expect(result.kind).toBe(GridCellKind.Text)
+      expect((result as any).displayData).toBe('node-1')
+      expect((result as any).readonly).toBe(true)
+      expect((result as any).allowOverlay).toBe(false)
+    })
+
+    it('formats numbers correctly', () => {
+      const result = handleGetCellContent({
+        cell: [0, 0] as Item,
+        rows: mockRows,
+        allColumns: [{ id: 'score', type: ValueTypeName.Double }],
+      })
+      
+      expect(result.kind).toBe(GridCellKind.Number)
+      expect((result as any).displayData).toBe('10.5')
+      expect((result as any).data).toBe(10.5)
+      expect((result as any).readonly).toBe(false)
+    })
+
+    it('formats booleans correctly without displayData', () => {
+      const result = handleGetCellContent({
+        cell: [0, 0] as Item,
+        rows: mockRows,
+        allColumns: [{ id: 'active', type: ValueTypeName.Boolean }],
+      })
+      
+      expect(result.kind).toBe(GridCellKind.Boolean)
+      expect((result as any).data).toBe(true)
+      expect((result as any).readonly).toBe(false)
+    })
+
+    it('detects URIs and returns Uri kind', () => {
+      const mockUriRow = [{ id: 'node-2', link: 'https://cytoscape.org' }]
+      const result = handleGetCellContent({
+        cell: [0, 0] as Item,
+        rows: mockUriRow,
+        allColumns: [{ id: 'link', type: ValueTypeName.String }],
+      })
+      
+      expect(result.kind).toBe(GridCellKind.Uri)
+      expect((result as any).data).toBe('https://cytoscape.org')
+    })
+  })
+})

--- a/src/features/TableBrowser/utils/cellContentHandler.ts
+++ b/src/features/TableBrowser/utils/cellContentHandler.ts
@@ -1,0 +1,131 @@
+import { GridCell, GridCellKind, Item } from '@glideapps/glide-data-grid'
+
+import { ValueTypeName } from '../../../models/TableModel'
+import { isListType, valueDisplay } from '../../../models/TableModel/impl/valueTypeImpl'
+import { isValidUrl } from '../../../utils/urlUtil'
+
+export const getCellKind = (type: ValueTypeName): GridCellKind => {
+  const valueTypeName2CellTypeMap: Record<ValueTypeName, GridCellKind> = {
+    [ValueTypeName.String]: GridCellKind.Text,
+    [ValueTypeName.Long]: GridCellKind.Number,
+    [ValueTypeName.Integer]: GridCellKind.Number,
+    [ValueTypeName.Double]: GridCellKind.Number,
+    [ValueTypeName.Boolean]: GridCellKind.Boolean,
+    [ValueTypeName.ListString]: GridCellKind.Text,
+    [ValueTypeName.ListLong]: GridCellKind.Text,
+    [ValueTypeName.ListInteger]: GridCellKind.Text,
+    [ValueTypeName.ListDouble]: GridCellKind.Text,
+    [ValueTypeName.ListBoolean]: GridCellKind.Text,
+  }
+  return valueTypeName2CellTypeMap[type] ?? GridCellKind.Text
+}
+
+export interface HandleGetCellContentArgs {
+  cell: Item
+  rows: any[] | undefined
+  allColumns: any[] | undefined
+}
+
+export const handleGetCellContent = ({
+  cell,
+  rows,
+  allColumns,
+}: HandleGetCellContentArgs): GridCell => {
+  const [columnIndex, rowIndex] = cell
+  const dataRow = rows?.[rowIndex]
+  const column = allColumns?.[columnIndex]
+  const columnKey = column?.id
+
+  // Handle virtual columns
+  if ((column as any)?.isVirtual) {
+    const virtualColumn = column as any
+    const cellValue = virtualColumn.getValue(dataRow)
+    return {
+      cursor: 'not-allowed',
+      themeOverride: {
+        bgCell: '#D9D9D9',
+      },
+      allowOverlay: false, // Virtual columns are read-only
+      readonly: true,
+      kind: GridCellKind.Text,
+      displayData: String(cellValue),
+      data: String(cellValue),
+    }
+  }
+
+  if (dataRow == null || column == null) {
+    return {
+      allowOverlay: true,
+      readonly: false,
+      kind: GridCellKind.Text,
+      displayData: '',
+      data: '',
+    }
+  }
+
+  // Handle regular columns
+  const cellValue = (dataRow as any)?.[columnKey]
+  if (cellValue == null) {
+    return {
+      allowOverlay: true,
+      readonly: false,
+      kind: GridCellKind.Text,
+      displayData: '',
+      data: '',
+    }
+  }
+
+  const cellType = getCellKind(column.type)
+  const processedCellValue = valueDisplay(cellValue, column.type)
+
+  // List-typed cells (CW-563) are not edited inline: typing into a text
+  // overlay collapsed multi-item lists into a single element. They are
+  // shown read-only here and edited through the dedicated list editor
+  // dialog, opened via onCellActivated.
+  if (isListType(column.type)) {
+    return {
+      kind: GridCellKind.Text,
+      allowOverlay: false,
+      readonly: true,
+      displayData: String(processedCellValue),
+      data: String(processedCellValue),
+    }
+  }
+
+  // These cells generally prevent users from inputting mismatched data types
+  // e.g. a user can't but a boolean in a number, a string in a number, etc.
+  // The exception is that users can still input floats into integer columns
+  // Extra validation for this logic is done in onCellEdited
+  if (cellType === GridCellKind.Boolean) {
+    return {
+      allowOverlay: false,
+      kind: cellType,
+      readonly: false,
+      data: processedCellValue as boolean,
+    }
+  } else if (cellType === GridCellKind.Number) {
+    return {
+      allowOverlay: true,
+      kind: cellType,
+      readonly: false,
+      displayData: String(processedCellValue),
+      data: processedCellValue as number,
+    }
+  } else {
+    if (isValidUrl(String(processedCellValue))) {
+      return {
+        kind: GridCellKind.Uri,
+        allowOverlay: true,
+        readonly: false,
+        data: processedCellValue as string,
+      }
+    }
+    return {
+      kind: GridCellKind.Text,
+      allowOverlay: true,
+      displayData: String(processedCellValue),
+      readonly: false,
+      data: processedCellValue as string,
+    }
+  }
+}

--- a/src/features/TableBrowser/utils/cellEditHandler.test.ts
+++ b/src/features/TableBrowser/utils/cellEditHandler.test.ts
@@ -1,0 +1,120 @@
+import { Item } from '@glideapps/glide-data-grid'
+import { describe, expect, it, vi } from 'vitest'
+
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { ValueTypeName } from '../../../models/TableModel'
+import { handleCellEdit } from './cellEditHandler'
+
+describe('handleCellEdit', () => {
+  const mockPostEdit = vi.fn()
+  const mockSetCellValue = vi.fn()
+  const mockSetNetworkModified = vi.fn()
+  const mockNodeTable = { id: 'nodeTable', rows: new Map(), columns: [] }
+  const mockEdgeTable = { id: 'edgeTable', rows: new Map(), columns: [] }
+
+  const baseArgs = {
+    currentTable: mockNodeTable,
+    nodeTable: mockNodeTable,
+    currentNetworkId: 'test-network-1',
+    postEdit: mockPostEdit,
+    setCellValue: mockSetCellValue,
+    setNetworkModified: mockSetNetworkModified,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('updates cell value for standard string column', () => {
+    const rows = [{ id: 'node-1', name: 'Node 1' }]
+    const allColumns = [{ id: 'name', type: ValueTypeName.String }]
+    
+    handleCellEdit({
+      ...baseArgs,
+      cell: [0, 0] as Item,
+      newValue: { data: 'Updated Node 1' } as any,
+      rows,
+      allColumns,
+    })
+
+    expect(mockPostEdit).toHaveBeenCalledWith(
+      UndoCommandType.SET_CELL_VALUE,
+      'Set cell value',
+      ['test-network-1', 'node', 'node-1', 'name', 'Node 1'],
+      ['test-network-1', 'node', 'node-1', 'name', 'Updated Node 1'],
+    )
+    expect(mockSetCellValue).toHaveBeenCalledWith(
+      'test-network-1',
+      'node',
+      'node-1',
+      'name',
+      'Updated Node 1',
+    )
+    expect(mockSetNetworkModified).toHaveBeenCalledWith('test-network-1', true)
+  })
+
+  it('correctly associates column index with the right column using allColumns, ignoring shifted indexes', () => {
+    // This specifically tests the fix for #626 where allColumns has virtual columns at the start
+    const rows = [{ id: 'node-1', selected: false, name: 'Node 1' }]
+    const allColumns = [
+      { id: '__id', type: ValueTypeName.String, isVirtual: true },
+      { id: 'selected', type: ValueTypeName.Boolean },
+      { id: 'name', type: ValueTypeName.String },
+    ]
+    
+    // User edits the 'selected' column which is index 1 in allColumns
+    handleCellEdit({
+      ...baseArgs,
+      cell: [1, 0] as Item,
+      newValue: { data: true } as any,
+      rows,
+      allColumns,
+    })
+
+    expect(mockSetCellValue).toHaveBeenCalledWith(
+      'test-network-1',
+      'node',
+      'node-1',
+      'selected', // the correct column key was used, not 'name'
+      true,
+    )
+  })
+
+  it('blocks updating integer column with float value', () => {
+    const rows = [{ id: 'node-1', score: 10 }]
+    const allColumns = [{ id: 'score', type: ValueTypeName.Integer }]
+    
+    handleCellEdit({
+      ...baseArgs,
+      cell: [0, 0] as Item,
+      newValue: { data: 15.5 } as any,
+      rows,
+      allColumns,
+    })
+
+    // It should ignore the value completely
+    expect(mockPostEdit).not.toHaveBeenCalled()
+    expect(mockSetCellValue).not.toHaveBeenCalled()
+  })
+
+  it('deserializes list types before setting value', () => {
+    const rows = [{ id: 'node-1', aliases: [] }]
+    const allColumns = [{ id: 'aliases', type: ValueTypeName.ListString }]
+    
+    handleCellEdit({
+      ...baseArgs,
+      cell: [0, 0] as Item,
+      newValue: { data: 'alias1, alias2' } as any,
+      rows,
+      allColumns,
+    })
+
+    expect(mockSetCellValue).toHaveBeenCalledWith(
+      'test-network-1',
+      'node',
+      'node-1',
+      'aliases',
+      ['alias1', 'alias2'], // Parsed array
+    )
+  })
+})

--- a/src/features/TableBrowser/utils/cellEditHandler.test.ts
+++ b/src/features/TableBrowser/utils/cellEditHandler.test.ts
@@ -1,5 +1,5 @@
 import { Item } from '@glideapps/glide-data-grid'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
 import { ValueTypeName } from '../../../models/TableModel'
@@ -10,7 +10,6 @@ describe('handleCellEdit', () => {
   const mockSetCellValue = vi.fn()
   const mockSetNetworkModified = vi.fn()
   const mockNodeTable = { id: 'nodeTable', rows: new Map(), columns: [] }
-  const mockEdgeTable = { id: 'edgeTable', rows: new Map(), columns: [] }
 
   const baseArgs = {
     currentTable: mockNodeTable,

--- a/src/features/TableBrowser/utils/cellEditHandler.ts
+++ b/src/features/TableBrowser/utils/cellEditHandler.ts
@@ -1,0 +1,123 @@
+import { EditableGridCell, Item } from '@glideapps/glide-data-grid'
+import { IdType } from '../../../models/IdType'
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { Table, ValueType, ValueTypeName } from '../../../models/TableModel'
+import {
+  deserializeValueList,
+  isListType,
+  serializedStringIsValid,
+} from '../../../models/TableModel/impl/valueTypeImpl'
+
+export interface HandleCellEditArgs {
+  cell: Item
+  newValue: EditableGridCell
+  rows: any[] | undefined
+  allColumns: any[] | undefined
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  currentNetworkId: IdType
+  postEdit: (
+    type: UndoCommandType,
+    description: string,
+    undoArgs: any[],
+    redoArgs: any[],
+  ) => void
+  setCellValue: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    cxId: string,
+    columnKey: string,
+    value: ValueType,
+  ) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+}
+
+export const handleCellEdit = ({
+  cell,
+  newValue,
+  rows,
+  allColumns,
+  currentTable,
+  nodeTable,
+  currentNetworkId,
+  postEdit,
+  setCellValue,
+  setNetworkModified,
+}: HandleCellEditArgs): void => {
+  const [columnIndex, rowIndex] = cell
+  const rowData = rows?.[rowIndex]
+  const cxId = rowData?.id
+  const column = allColumns?.[columnIndex]
+  const columnKey = column?.id
+  let data = newValue.data
+
+  if (rowData == null || cxId == null || column == null || data == null) return
+
+  const prevCellValue = (rowData as any)?.[columnKey]
+  const elementType = currentTable === nodeTable ? 'node' : 'edge'
+
+  if (isListType(column.type)) {
+    if (serializedStringIsValid(column.type, data as string)) {
+      data = deserializeValueList(column.type, data as string)
+      postEdit(
+        UndoCommandType.SET_CELL_VALUE,
+        'Set cell value',
+        [currentNetworkId, elementType, cxId, columnKey, prevCellValue],
+        [currentNetworkId, elementType, cxId, columnKey, data as ValueType],
+      )
+      setCellValue(
+        currentNetworkId,
+        elementType,
+        `${cxId}`,
+        columnKey,
+        data as ValueType,
+      )
+      setNetworkModified(currentNetworkId, true)
+    }
+  } else {
+    if (
+      column.type !== ValueTypeName.Integer &&
+      column.type !== ValueTypeName.Long
+    ) {
+      postEdit(
+        UndoCommandType.SET_CELL_VALUE,
+        'Set cell value',
+        [currentNetworkId, elementType, cxId, columnKey, prevCellValue],
+        [currentNetworkId, elementType, cxId, columnKey, data as ValueType],
+      )
+      setCellValue(
+        currentNetworkId,
+        elementType,
+        `${cxId}`,
+        columnKey,
+        data as ValueType,
+      )
+      setNetworkModified(currentNetworkId, true)
+    } else {
+      if (Number.isInteger(data)) {
+        postEdit(
+          UndoCommandType.SET_CELL_VALUE,
+          'Set cell value',
+          [currentNetworkId, elementType, cxId, columnKey, prevCellValue],
+          [
+            currentNetworkId,
+            elementType,
+            cxId,
+            columnKey,
+            parseFloat(data as string),
+          ],
+        )
+        setCellValue(
+          currentNetworkId,
+          elementType,
+          `${cxId}`,
+          columnKey,
+          parseFloat(data as string),
+        )
+        setNetworkModified(currentNetworkId, true)
+      } else {
+        // the user is trying to assign a double value to a integer column.  Ignore this value.
+      }
+    }
+  }
+}

--- a/src/features/TableBrowser/utils/columnHandlers.test.ts
+++ b/src/features/TableBrowser/utils/columnHandlers.test.ts
@@ -1,0 +1,151 @@
+import { GridColumn } from '@glideapps/glide-data-grid'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleColumnMove, handleColumnResize } from './columnHandlers'
+
+describe('columnHandlers', () => {
+  const mockMoveColumn = vi.fn()
+  const mockSetColumnWidth = vi.fn()
+  const mockCreateUpdatedTableDisplayConfiguration = vi.fn()
+  const mockSetTableDisplayConfiguration = vi.fn()
+  const mockSetNetworkModified = vi.fn()
+
+  const mockNodeTable = { id: 'nodeTable', rows: new Map(), columns: [] }
+  const networkId = 'test-network-1'
+
+  const baseArgs = {
+    networkId,
+    currentTable: mockNodeTable as any,
+    nodeTable: mockNodeTable as any,
+    edgeTable: undefined,
+    tableDisplayConfiguration: {
+      nodeTable: { columnConfiguration: [], sortColumn: undefined, sortDirection: undefined },
+      edgeTable: { columnConfiguration: [], sortColumn: undefined, sortDirection: undefined },
+    } as any,
+    createUpdatedTableDisplayConfiguration: mockCreateUpdatedTableDisplayConfiguration,
+    setTableDisplayConfiguration: mockSetTableDisplayConfiguration,
+    setNetworkModified: mockSetNetworkModified,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateUpdatedTableDisplayConfiguration.mockReturnValue('new-config')
+  })
+
+  describe('handleColumnMove', () => {
+    it('moves a column and updates configuration', () => {
+      const allColumns = [
+        { id: 'col1', title: 'Col 1' },
+        { id: 'col2', title: 'Col 2' },
+        { id: 'col3', title: 'Col 3' },
+      ]
+
+      handleColumnMove({
+        ...baseArgs,
+        startIndex: 0,
+        endIndex: 2,
+        allColumns,
+        tableDisplayConfiguration: {
+          nodeTable: {
+            columnConfiguration: [
+              { attributeName: 'col1', visible: true, columnWidth: 100 },
+              { attributeName: 'col2', visible: true, columnWidth: 100 },
+              { attributeName: 'col3', visible: true, columnWidth: 100 },
+            ],
+            sortColumn: undefined,
+            sortDirection: undefined,
+          },
+        } as any,
+        moveColumn: mockMoveColumn,
+      })
+
+      // The moveColumn store action should be called
+      expect(mockMoveColumn).toHaveBeenCalledWith(networkId, 'node', 0, 2)
+      
+      // Configuration should be updated with new order
+      expect(mockCreateUpdatedTableDisplayConfiguration).toHaveBeenCalledWith({
+        columnConfiguration: [
+          { attributeName: 'col2', visible: true, columnWidth: 100 },
+          { attributeName: 'col3', visible: true, columnWidth: 100 },
+          { attributeName: 'col1', visible: true, columnWidth: 100 },
+        ],
+      })
+      expect(mockSetTableDisplayConfiguration).toHaveBeenCalledWith(networkId, 'new-config')
+      expect(mockSetNetworkModified).toHaveBeenCalledWith(networkId, true)
+    })
+
+    it('prevents moving virtual columns', () => {
+      const allColumns = [
+        { id: '__id', isVirtual: true },
+        { id: 'col1' },
+      ]
+
+      handleColumnMove({
+        ...baseArgs,
+        startIndex: 0,
+        endIndex: 1,
+        allColumns,
+        moveColumn: mockMoveColumn,
+      })
+
+      expect(mockMoveColumn).not.toHaveBeenCalled()
+      expect(mockSetTableDisplayConfiguration).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleColumnResize', () => {
+    it('resizes a column and updates configuration', () => {
+      const allColumns = [
+        { id: 'col1' },
+        { id: 'col2' },
+      ]
+
+      handleColumnResize({
+        ...baseArgs,
+        column: { id: 'col1' } as GridColumn,
+        newSize: 200,
+        colIndex: 0,
+        allColumns,
+        tableDisplayConfiguration: {
+          nodeTable: {
+            columnConfiguration: [
+              { attributeName: 'col1', visible: true, columnWidth: 100 },
+              { attributeName: 'col2', visible: true, columnWidth: 100 },
+            ],
+            sortColumn: undefined,
+            sortDirection: undefined,
+          },
+        } as any,
+        setColumnWidth: mockSetColumnWidth,
+      })
+
+      expect(mockSetColumnWidth).toHaveBeenCalledWith(networkId, 'node', 'col1', 200)
+
+      expect(mockCreateUpdatedTableDisplayConfiguration).toHaveBeenCalledWith({
+        columnConfiguration: [
+          { attributeName: 'col1', visible: true, columnWidth: 200 },
+          { attributeName: 'col2', visible: true, columnWidth: 100 },
+        ],
+      })
+      expect(mockSetTableDisplayConfiguration).toHaveBeenCalledWith(networkId, 'new-config')
+    })
+
+    it('prevents resizing virtual columns', () => {
+      const allColumns = [
+        { id: '__id', isVirtual: true },
+      ]
+
+      handleColumnResize({
+        ...baseArgs,
+        column: { id: '__id' } as GridColumn,
+        newSize: 200,
+        colIndex: 0,
+        allColumns,
+        setColumnWidth: mockSetColumnWidth,
+      })
+
+      expect(mockSetColumnWidth).not.toHaveBeenCalled()
+      expect(mockSetTableDisplayConfiguration).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/TableBrowser/utils/columnHandlers.ts
+++ b/src/features/TableBrowser/utils/columnHandlers.ts
@@ -1,0 +1,188 @@
+import { GridColumn } from '@glideapps/glide-data-grid'
+import { IdType } from '../../../models/IdType'
+import { Table } from '../../../models/TableModel'
+import {
+  TableDisplayConfiguration,
+} from '../../../models/VisualStyleModel/VisualStyleOptions'
+
+export interface HandleColumnMoveArgs {
+  startIndex: number
+  endIndex: number
+  allColumns: any[]
+  networkId: IdType
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  edgeTable: Table | undefined
+  tableDisplayConfiguration: TableDisplayConfiguration | undefined
+  moveColumn: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    startIndex: number,
+    endIndex: number,
+  ) => void
+  createUpdatedTableDisplayConfiguration: (
+    partialConfig: any,
+  ) => TableDisplayConfiguration
+  setTableDisplayConfiguration: (
+    networkId: IdType,
+    config: TableDisplayConfiguration,
+  ) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+}
+
+export const handleColumnMove = ({
+  startIndex,
+  endIndex,
+  allColumns,
+  networkId,
+  currentTable,
+  nodeTable,
+  edgeTable,
+  tableDisplayConfiguration,
+  moveColumn,
+  createUpdatedTableDisplayConfiguration,
+  setTableDisplayConfiguration,
+  setNetworkModified,
+}: HandleColumnMoveArgs): void => {
+  // Don't allow moving virtual columns
+  const startColumn = allColumns[startIndex]
+  const endColumn = allColumns[endIndex]
+  if ((startColumn as any)?.isVirtual || (endColumn as any)?.isVirtual) {
+    return
+  }
+
+  // offset the virtual column indices
+  const realColumns = allColumns.filter((col) => !(col as any).isVirtual)
+  const startColId = allColumns[startIndex]?.id
+  const endColId = allColumns[endIndex]?.id
+  const realStartIndex = realColumns.findIndex((col) => col.id === startColId)
+  const realEndIndex = realColumns.findIndex((col) => col.id === endColId)
+  if (realStartIndex === -1 || realEndIndex === -1) return
+
+  moveColumn(
+    networkId,
+    currentTable === nodeTable ? 'node' : 'edge',
+    realStartIndex,
+    realEndIndex,
+  )
+
+  // Create updated column configuration with moved column
+  // Temporary fix: fallback to table columns if tableDisplayConfiguration is missing
+  const defaultConfig: any = {
+    columnConfiguration:
+      (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map(
+        (col) => ({
+          attributeName: col.name,
+          visible: true,
+          columnWidth: undefined,
+        }),
+      ) ?? [],
+    sortColumn: undefined,
+    sortDirection: undefined,
+  }
+  const currentConfig =
+    currentTable === nodeTable
+      ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
+      : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
+  
+  const nextColumnConfig = [...currentConfig.columnConfiguration]
+  const [movedColumn] = nextColumnConfig.splice(realStartIndex, 1)
+  nextColumnConfig.splice(realEndIndex, 0, movedColumn)
+
+  const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({
+    columnConfiguration: nextColumnConfig,
+  })
+  
+  setTableDisplayConfiguration(networkId, newTableDisplayConfiguration)
+  setNetworkModified(networkId, true)
+}
+
+export interface HandleColumnResizeArgs {
+  column: GridColumn
+  newSize: number
+  colIndex: number
+  allColumns: any[]
+  networkId: IdType
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  edgeTable: Table | undefined
+  tableDisplayConfiguration: TableDisplayConfiguration | undefined
+  setColumnWidth: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    columnId: string,
+    width: number,
+  ) => void
+  createUpdatedTableDisplayConfiguration: (
+    partialConfig: any,
+  ) => TableDisplayConfiguration
+  setTableDisplayConfiguration: (
+    networkId: IdType,
+    config: TableDisplayConfiguration,
+  ) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+}
+
+export const handleColumnResize = ({
+  column,
+  newSize,
+  colIndex,
+  allColumns,
+  networkId,
+  currentTable,
+  nodeTable,
+  edgeTable,
+  tableDisplayConfiguration,
+  setColumnWidth,
+  createUpdatedTableDisplayConfiguration,
+  setTableDisplayConfiguration,
+  setNetworkModified,
+}: HandleColumnResizeArgs): void => {
+  if (column?.id === undefined) {
+    return
+  }
+
+  // Don't allow resizing virtual columns
+  const columnData = allColumns[colIndex]
+  if ((columnData as any)?.isVirtual) {
+    return
+  }
+
+  setColumnWidth(
+    networkId,
+    currentTable === nodeTable ? 'node' : 'edge',
+    column.id,
+    newSize,
+  )
+
+  // Update the width in the tableDisplayConfiguration
+  const defaultConfig: any = {
+    columnConfiguration:
+      (currentTable === nodeTable ? nodeTable : edgeTable)?.columns?.map(
+        (col) => ({
+          attributeName: col.name,
+          visible: true,
+          columnWidth: undefined,
+        }),
+      ) ?? [],
+    sortColumn: undefined,
+    sortDirection: undefined,
+  }
+  const currentConfig =
+    currentTable === nodeTable
+      ? (tableDisplayConfiguration?.nodeTable ?? defaultConfig)
+      : (tableDisplayConfiguration?.edgeTable ?? defaultConfig)
+      
+  const nextColumnConfig = currentConfig.columnConfiguration.map((col: any) =>
+    col.attributeName === column.id
+      ? { ...col, columnWidth: newSize }
+      : col,
+  )
+
+  const newTableDisplayConfiguration = createUpdatedTableDisplayConfiguration({
+    columnConfiguration: nextColumnConfig,
+  })
+  
+  setTableDisplayConfiguration(networkId, newTableDisplayConfiguration)
+  setNetworkModified(networkId, true)
+}

--- a/src/features/TableBrowser/utils/contextMenuActions.test.ts
+++ b/src/features/TableBrowser/utils/contextMenuActions.test.ts
@@ -1,0 +1,149 @@
+import { CompactSelection } from '@glideapps/glide-data-grid'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { ValueTypeName } from '../../../models/TableModel'
+import {
+  handleApplyToEntireColumn,
+  handleApplyToSelected,
+  handleSelectFromSelection,
+} from './contextMenuActions'
+
+describe('contextMenuActions', () => {
+  const mockPostEdit = vi.fn()
+  const mockApplyValueToElements = vi.fn()
+  const mockSetNetworkModified = vi.fn()
+  const mockHandleContextMenuClose = vi.fn()
+  const mockExclusiveSelect = vi.fn()
+  const mockSetSelection = vi.fn()
+
+  const mockNodeTableRows = new Map()
+  mockNodeTableRows.set('node-1', { id: 'node-1', name: 'Node 1', score: 10 })
+  mockNodeTableRows.set('node-2', { id: 'node-2', name: 'Node 2', score: 20 })
+
+  const mockNodeTable = { id: 'nodeTable', rows: mockNodeTableRows, columns: [] }
+  const networkId = 'test-network-1'
+
+  const allColumns = [
+    { id: 'name', type: ValueTypeName.String },
+    { id: 'score', type: ValueTypeName.Integer },
+  ]
+  
+  const rows = Array.from(mockNodeTableRows.values())
+
+  const baseArgs = {
+    rows,
+    allColumns,
+    currentTable: mockNodeTable as any,
+    nodeTable: mockNodeTable as any,
+    currentNetworkId: networkId,
+    postEdit: mockPostEdit,
+    applyValueToElements: mockApplyValueToElements,
+    setNetworkModified: mockSetNetworkModified,
+    handleContextMenuClose: mockHandleContextMenuClose,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('handleApplyToEntireColumn', () => {
+    it('applies the cell value to the entire column', () => {
+      handleApplyToEntireColumn({
+        ...baseArgs,
+        contextMenuCell: [0, 0], // 'name' column, first row ('Node 1')
+      })
+
+      const expectedEdits = [
+        { row: 'node-1', column: 'name', value: 'Node 1' },
+        { row: 'node-2', column: 'name', value: 'Node 1' }, // Overwritten with 'Node 1'
+      ]
+
+      expect(mockPostEdit).toHaveBeenCalledWith(
+        UndoCommandType.APPLY_VALUE_TO_COLUMN,
+        'Apply value to column',
+        expect.any(Array),
+        [networkId, 'node', expectedEdits],
+      )
+
+      expect(mockApplyValueToElements).toHaveBeenCalledWith(
+        networkId,
+        'node',
+        'name',
+        'Node 1',
+        undefined, // Undefined means all elements
+      )
+      
+      expect(mockSetNetworkModified).toHaveBeenCalledWith(networkId, true)
+      expect(mockHandleContextMenuClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleApplyToSelected', () => {
+    it('applies the cell value only to selected rows', () => {
+      // The context menu only gets passed the subset of rows that are selected or visible
+      const selectedRowsSubset = [
+        { id: 'node-2', name: 'Node 2', score: 20 },
+      ]
+
+      handleApplyToSelected({
+        ...baseArgs,
+        rows: selectedRowsSubset,
+        contextMenuCell: [1, 0], // 'score' column, first selected row ('node-2', score 20)
+      })
+
+      const expectedEdits = [
+        { row: 'node-2', column: 'score', value: 20 },
+      ]
+
+      expect(mockPostEdit).toHaveBeenCalledWith(
+        UndoCommandType.APPLY_VALUE_TO_SELECTED,
+        'Apply value to selected elements',
+        expect.any(Array),
+        [networkId, 'node', expectedEdits],
+      )
+
+      expect(mockApplyValueToElements).toHaveBeenCalledWith(
+        networkId,
+        'node',
+        'score',
+        20,
+        ['node-2'], // Only applied to these IDs
+      )
+      
+      expect(mockHandleContextMenuClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('handleSelectFromSelection', () => {
+    it('selects the elements in the workspace and clears the grid selection', () => {
+      const mockSelection = {
+        rows: CompactSelection.fromSingleSelection(1),
+        columns: CompactSelection.empty(),
+        current: undefined, // no current cell selection
+      } as any
+
+      handleSelectFromSelection({
+        selection: mockSelection,
+        rows,
+        currentTable: mockNodeTable as any,
+        nodeTable: mockNodeTable as any,
+        currentNetworkId: networkId,
+        exclusiveSelect: mockExclusiveSelect,
+        setSelection: mockSetSelection,
+        handleContextMenuClose: mockHandleContextMenuClose,
+      })
+
+      // Select node-2 which is at index 1
+      expect(mockExclusiveSelect).toHaveBeenCalledWith(networkId, ['node-2'], [])
+      
+      expect(mockSetSelection).toHaveBeenCalledWith({
+        rows: expect.any(Object),
+        columns: mockSelection.columns,
+        current: undefined,
+      })
+      
+      expect(mockHandleContextMenuClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/TableBrowser/utils/contextMenuActions.ts
+++ b/src/features/TableBrowser/utils/contextMenuActions.ts
@@ -1,0 +1,208 @@
+import { CompactSelection, GridSelection } from '@glideapps/glide-data-grid'
+import { IdType } from '../../../models/IdType'
+import { CellEdit } from '../../../models/StoreModel/TableStoreModel'
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { Table, ValueType } from '../../../models/TableModel'
+
+export interface ContextMenuActionArgs {
+  contextMenuCell: readonly [number, number]
+  rows: any[] | undefined
+  allColumns: any[] | undefined
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  currentNetworkId: IdType
+  postEdit: (
+    type: UndoCommandType,
+    description: string,
+    undoArgs: any[],
+    redoArgs: any[],
+  ) => void
+  applyValueToElements: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    columnKey: string,
+    value: any,
+    elementIds: string[] | undefined,
+  ) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+  handleContextMenuClose: () => void
+}
+
+export const handleApplyToEntireColumn = ({
+  contextMenuCell,
+  rows,
+  allColumns,
+  currentTable,
+  nodeTable,
+  currentNetworkId,
+  postEdit,
+  applyValueToElements,
+  setNetworkModified,
+  handleContextMenuClose,
+}: ContextMenuActionArgs): void => {
+  if (currentTable == null) return
+
+  const [columnIndex, rowIndex] = contextMenuCell
+  const rowData = rows?.[rowIndex]
+  const column = allColumns?.[columnIndex]
+  if (rowData == null || column == null) return
+
+  const columnKey = column.id
+  const cellValue = (rowData as any)?.[columnKey]
+  
+  const cellEdits: CellEdit[] = []
+  const prevColumnValues: CellEdit[] = []
+  
+  Array.from(currentTable.rows.entries()).forEach(([k, v]) => {
+    cellEdits.push({
+      row: k,
+      column: columnKey,
+      value: cellValue,
+    })
+    prevColumnValues.push({
+      row: k,
+      column: columnKey,
+      value: (v as any)?.[columnKey] as ValueType,
+    })
+  })
+
+  const elementType = currentTable === nodeTable ? 'node' : 'edge'
+
+  postEdit(
+    UndoCommandType.APPLY_VALUE_TO_COLUMN,
+    'Apply value to column',
+    [currentNetworkId, elementType, prevColumnValues],
+    [currentNetworkId, elementType, cellEdits],
+  )
+  
+  applyValueToElements(
+    currentNetworkId,
+    elementType,
+    columnKey,
+    cellValue,
+    undefined,
+  )
+  
+  setNetworkModified(currentNetworkId, true)
+  handleContextMenuClose()
+}
+
+export const handleApplyToSelected = ({
+  contextMenuCell,
+  rows,
+  allColumns,
+  currentTable,
+  nodeTable,
+  currentNetworkId,
+  postEdit,
+  applyValueToElements,
+  setNetworkModified,
+  handleContextMenuClose,
+}: ContextMenuActionArgs): void => {
+  if (rows == null) return
+
+  const [columnIndex, rowIndex] = contextMenuCell
+  const rowData = rows?.[rowIndex]
+  const column = allColumns?.[columnIndex]
+  if (rowData == null || column == null) return
+
+  const columnKey = column.id
+  const cellValue = (rowData as any)?.[columnKey]
+  
+  const cellEdits: CellEdit[] = []
+  const prevColumnValues: CellEdit[] = []
+  
+  rows.forEach((r) => {
+    const rowId = r.id
+    cellEdits.push({
+      row: rowId,
+      column: columnKey,
+      value: cellValue,
+    })
+    prevColumnValues.push({
+      row: rowId,
+      column: columnKey,
+      value: (r as any)?.[columnKey] as ValueType,
+    })
+  })
+
+  const elementType = currentTable === nodeTable ? 'node' : 'edge'
+
+  postEdit(
+    UndoCommandType.APPLY_VALUE_TO_SELECTED,
+    'Apply value to selected elements',
+    [currentNetworkId, elementType, prevColumnValues],
+    [currentNetworkId, elementType, cellEdits],
+  )
+  
+  applyValueToElements(
+    currentNetworkId,
+    elementType,
+    columnKey,
+    cellValue,
+    rows.map((r) => r.id),
+  )
+  
+  setNetworkModified(currentNetworkId, true)
+  handleContextMenuClose()
+}
+
+export interface HandleSelectFromSelectionArgs {
+  selection: GridSelection
+  rows: any[] | undefined
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  currentNetworkId: IdType
+  exclusiveSelect: (
+    networkId: IdType,
+    nodeIds: string[],
+    edgeIds: string[],
+  ) => void
+  setSelection: (selection: GridSelection) => void
+  handleContextMenuClose: () => void
+}
+
+export const handleSelectFromSelection = ({
+  selection,
+  rows,
+  currentTable,
+  nodeTable,
+  currentNetworkId,
+  exclusiveSelect,
+  setSelection,
+  handleContextMenuClose,
+}: HandleSelectFromSelectionArgs): void => {
+  // Use the underlying Set of rows from CompactSelection
+  // The actual property is usually _items or similar, but the TableBrowser uses .toArray()
+  const rowsToSelect = new Set(selection.rows.toArray())
+
+  if (selection.current) {
+    const ranges =
+      selection.current.rangeStack.length > 0
+        ? selection.current.rangeStack
+        : [selection.current.range]
+
+    ranges.forEach((range) => {
+      for (let r = range.y; r < range.y + range.height; r++) {
+        rowsToSelect.add(r)
+      }
+    })
+  }
+
+  const rowIds = Array.from(rowsToSelect)
+    .map((r) => rows?.[r]?.id)
+    .filter((id) => id !== undefined)
+    
+  if (currentTable === nodeTable) {
+    exclusiveSelect(currentNetworkId, rowIds as string[], [])
+  } else {
+    exclusiveSelect(currentNetworkId, [], rowIds as string[])
+  }
+  
+  setSelection({
+    ...selection,
+    rows: CompactSelection.empty(),
+  })
+  
+  handleContextMenuClose()
+}

--- a/src/features/TableBrowser/utils/pasteHandler.test.ts
+++ b/src/features/TableBrowser/utils/pasteHandler.test.ts
@@ -1,0 +1,123 @@
+import { Item } from '@glideapps/glide-data-grid'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { ValueTypeName } from '../../../models/TableModel'
+import { handlePaste } from './pasteHandler'
+
+describe('pasteHandler', () => {
+  const mockPostEdit = vi.fn()
+  const mockSetValues = vi.fn()
+  const mockSetNetworkModified = vi.fn()
+  
+  const mockNodeTable = { id: 'nodeTable', rows: new Map(), columns: [] }
+
+  const baseArgs = {
+    currentTable: mockNodeTable,
+    nodeTable: mockNodeTable,
+    currentNetworkId: 'test-network-1',
+    postEdit: mockPostEdit,
+    setValues: mockSetValues,
+    setNetworkModified: mockSetNetworkModified,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('pastes values across multiple rows and columns', () => {
+    const rows = [
+      { id: 'node-1', name: 'Node 1', score: 1 },
+      { id: 'node-2', name: 'Node 2', score: 2 },
+    ]
+    const allColumns = [
+      { id: 'name', type: ValueTypeName.String },
+      { id: 'score', type: ValueTypeName.Integer },
+    ]
+
+    handlePaste({
+      ...baseArgs,
+      target: [0, 0] as Item,
+      values: [
+        ['Pasted Name 1', '10'],
+        ['Pasted Name 2', '20'],
+      ],
+      rows,
+      allColumns,
+    })
+
+    const expectedCellEdits = [
+      { row: 'node-1', column: 'name', value: 'Pasted Name 1' },
+      { row: 'node-1', column: 'score', value: 10 },
+      { row: 'node-2', column: 'name', value: 'Pasted Name 2' },
+      { row: 'node-2', column: 'score', value: 20 },
+    ]
+
+    expect(mockSetValues).toHaveBeenCalledWith(
+      'test-network-1',
+      'node',
+      expectedCellEdits,
+    )
+    expect(mockPostEdit).toHaveBeenCalledWith(
+      UndoCommandType.APPLY_VALUE_TO_SELECTED,
+      'Paste cell values',
+      expect.any(Array),
+      ['test-network-1', 'node', expectedCellEdits],
+    )
+    expect(mockSetNetworkModified).toHaveBeenCalledWith('test-network-1', true)
+  })
+
+  it('skips virtual columns when pasting', () => {
+    const rows = [{ id: 'node-1', name: 'Node 1' }]
+    const allColumns = [
+      { id: '__id', type: ValueTypeName.String, isVirtual: true },
+      { id: 'name', type: ValueTypeName.String },
+    ]
+
+    handlePaste({
+      ...baseArgs,
+      target: [0, 0] as Item, // Attempt to paste starting at the virtual column
+      values: [['ignored virtual paste', 'Valid Name']],
+      rows,
+      allColumns,
+    })
+
+    // Only the second column ('name') should be updated
+    const expectedCellEdits = [
+      { row: 'node-1', column: 'name', value: 'Valid Name' },
+    ]
+
+    expect(mockSetValues).toHaveBeenCalledWith(
+      'test-network-1',
+      'node',
+      expectedCellEdits,
+    )
+  })
+
+  it('skips invalid data types during paste without failing completely', () => {
+    const rows = [{ id: 'node-1', score: 10, name: 'Node 1' }]
+    const allColumns = [
+      { id: 'score', type: ValueTypeName.Integer },
+      { id: 'name', type: ValueTypeName.String },
+    ]
+
+    handlePaste({
+      ...baseArgs,
+      target: [0, 0] as Item,
+      values: [['invalid-score-string', 'Valid Name']],
+      rows,
+      allColumns,
+    })
+
+    // Only the valid string paste should succeed
+    const expectedCellEdits = [
+      { row: 'node-1', column: 'name', value: 'Valid Name' },
+    ]
+
+    expect(mockSetValues).toHaveBeenCalledWith(
+      'test-network-1',
+      'node',
+      expectedCellEdits,
+    )
+  })
+})

--- a/src/features/TableBrowser/utils/pasteHandler.ts
+++ b/src/features/TableBrowser/utils/pasteHandler.ts
@@ -1,0 +1,91 @@
+import { Item } from '@glideapps/glide-data-grid'
+import { IdType } from '../../../models/IdType'
+import { CellEdit } from '../../../models/StoreModel/TableStoreModel'
+import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
+import { Table, ValueType } from '../../../models/TableModel'
+import {
+  deserializeValue,
+  serializedStringIsValid,
+} from '../../../models/TableModel/impl/valueTypeImpl'
+
+export interface HandlePasteArgs {
+  target: Item
+  values: readonly (readonly string[])[]
+  rows: any[] | undefined
+  allColumns: any[] | undefined
+  currentNetworkId: IdType
+  currentTable: Table | undefined
+  nodeTable: Table | undefined
+  postEdit: (
+    type: UndoCommandType,
+    description: string,
+    undoArgs: any[],
+    redoArgs: any[],
+  ) => void
+  setValues: (
+    networkId: IdType,
+    tableType: 'node' | 'edge',
+    cellEdits: CellEdit[],
+  ) => void
+  setNetworkModified: (networkId: IdType, isModified: boolean) => void
+}
+
+export const handlePaste = ({
+  target,
+  values,
+  rows,
+  allColumns,
+  currentNetworkId,
+  currentTable,
+  nodeTable,
+  postEdit,
+  setValues,
+  setNetworkModified,
+}: HandlePasteArgs): boolean => {
+  const [startCol, startRow] = target
+  const cellEdits: CellEdit[] = []
+  const prevCellEdits: CellEdit[] = []
+
+  for (let dy = 0; dy < values.length; dy++) {
+    const rowIndex = startRow + dy
+    const rowData = rows?.[rowIndex]
+    if (rowData == null) continue
+
+    for (let dx = 0; dx < values[dy].length; dx++) {
+      const colIndex = startCol + dx
+      const column = allColumns?.[colIndex]
+      if (column == null || (column as any).isVirtual) continue
+
+      const pastedString = values[dy][dx]
+      if (!serializedStringIsValid(column.type, pastedString)) continue
+
+      const newValue = deserializeValue(column.type, pastedString)
+      const prevValue = (rowData as any)?.[column.id] as ValueType
+
+      cellEdits.push({
+        row: rowData.id,
+        column: column.id,
+        value: newValue as ValueType,
+      })
+      prevCellEdits.push({
+        row: rowData.id,
+        column: column.id,
+        value: prevValue,
+      })
+    }
+  }
+
+  if (cellEdits.length > 0) {
+    const elementType = currentTable === nodeTable ? 'node' : 'edge'
+    postEdit(
+      UndoCommandType.APPLY_VALUE_TO_SELECTED,
+      'Paste cell values',
+      [currentNetworkId, elementType, prevCellEdits],
+      [currentNetworkId, elementType, cellEdits],
+    )
+    setValues(currentNetworkId, elementType, cellEdits)
+    setNetworkModified(currentNetworkId, true)
+  }
+
+  return false
+}

--- a/src/features/TableBrowser/utils/tableRenderers.test.ts
+++ b/src/features/TableBrowser/utils/tableRenderers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createHeaderIcons, handleDrawHeader } from './tableRenderers'
+import { ValueTypeName } from '../../../models/TableModel'
+
+describe('tableRenderers', () => {
+  describe('createHeaderIcons', () => {
+    it('creates icons for all ValueTypeNames', () => {
+      const icons = createHeaderIcons(false)
+      const darkIcons = createHeaderIcons(true)
+      
+      expect(icons[ValueTypeName.String]).toBeDefined()
+      expect(icons[ValueTypeName.Double]).toBeDefined()
+      expect(darkIcons[ValueTypeName.Boolean]).toBeDefined()
+      
+      // Ensure it returns a function that produces an SVG string
+      expect(typeof icons[ValueTypeName.String]()).toBe('string')
+      expect(icons[ValueTypeName.String]()).toContain('<svg')
+    })
+  })
+
+  describe('handleDrawHeader', () => {
+    it('returns false and does not override fillText for missing type', () => {
+      const ctx = { fillText: vi.fn() } as any
+      const column = { title: 'Missing Type' } as any
+      
+      const result = handleDrawHeader({ ctx, column, theme: {} as any, rect: {} as any, hoverAmount: 0, isHovered: false, hasSelectedCell: false, spriteManager: {} as any, menuBounds: {} as any } as any)
+      
+      expect(result).toBe(false)
+      expect(ctx.fillText.name).not.toBe('') // original function untouched
+    })
+
+    it('overrides fillText and returns false for valid type', () => {
+      const originalFillText = vi.fn()
+      const ctx = { fillText: originalFillText } as any
+      const column = { title: 'Score', type: ValueTypeName.Double } as any
+      
+      const result = handleDrawHeader({ ctx, column, theme: {} as any, rect: {} as any, hoverAmount: 0, isHovered: false, hasSelectedCell: false, spriteManager: {} as any, menuBounds: {} as any } as any)
+      
+      expect(result).toBe(false)
+      expect(ctx.fillText).not.toBe(originalFillText) // function was overridden
+      
+      // Test the overridden function
+      ctx.fillText('Score', 10, 20, 100)
+      expect(originalFillText).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/TableBrowser/utils/tableRenderers.ts
+++ b/src/features/TableBrowser/utils/tableRenderers.ts
@@ -1,0 +1,43 @@
+import { DrawHeaderCallback, GridColumnIcon } from '@glideapps/glide-data-grid'
+import { ValueTypeName } from '../../../models/TableModel'
+import { getBadgeWidth, getValueTypeNameSVG } from '../../../models/TableModel/impl/valueTypeNameIcons'
+
+export const getHeaderIconForType = (type: ValueTypeName): GridColumnIcon | string => {
+  return type as string
+}
+
+export const createHeaderIcons = (isDark: boolean): Record<string, () => string> => {
+  const icons: Record<string, () => string> = {}
+  Object.values(ValueTypeName).forEach((type) => {
+    icons[type] = () => getValueTypeNameSVG(type, isDark)
+  })
+  return icons
+}
+
+export const handleDrawHeader: DrawHeaderCallback = ({ ctx, column }) => {
+  // Only apply to columns that have our custom SVG badge type
+  const colType = (column as any).type as ValueTypeName
+  if (!colType || !Object.values(ValueTypeName).includes(colType)) {
+    return false
+  }
+
+  const badgeWidth = getBadgeWidth(colType)
+  const gap = 8
+
+  // glide-data-grid advances the text by Math.ceil(headerIconSize * 1.3)
+  const defaultAdvance = Math.ceil(badgeWidth * 1.3)
+  const desiredAdvance = badgeWidth + gap
+  const shift = desiredAdvance - defaultAdvance
+
+  const originalFillText = ctx.fillText
+  ctx.fillText = function (text, x, y, maxWidth) {
+    ctx.fillText = originalFillText
+    if (text === column.title) {
+      originalFillText.call(this, text, x + shift, y, maxWidth)
+    } else {
+      originalFillText.call(this, text, x, y, maxWidth)
+    }
+  }
+
+  return false
+}

--- a/test/playwright/table-browser.spec.ts
+++ b/test/playwright/table-browser.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from './fixtures'
+import { gotoAndSeedNetwork } from './fixtures'
+
+test.describe('Table Browser', () => {
+  test.describe('1. Basic Rendering & Tabs', () => {
+    test('1.1 Initial Load without Network', async ({ page }) => {
+      // Navigate to app without seeding a network
+      await page.goto('/')
+      await expect(page.locator('[data-testid="app-shell"]')).toBeVisible()
+
+      // Table browser tabs should be visible
+      const tabs = page.locator('[data-testid="table-browser-tabs"]')
+      await expect(tabs).toBeVisible()
+
+      // The network tab should be selected by default, or nodes tab
+      await expect(page.locator('[data-testid="table-browser-nodes-tab"]')).toBeVisible()
+
+      // Import button should be disabled when no network is loaded
+      const importButton = page.locator('[data-testid="import-table-button"]')
+      await expect(importButton).toBeDisabled()
+    })
+
+    test('1.2 Tab Switching', async ({ page }) => {
+      await gotoAndSeedNetwork(page)
+
+      // By default Nodes tab is active, so node editor is visible
+      await expect(page.locator('[data-testid="table-browser-node-editor"]')).toBeVisible()
+
+      // Switch to Edges tab
+      await page.click('[data-testid="table-browser-edges-tab"]')
+      await expect(page.locator('[data-testid="table-browser-edge-editor"]')).toBeVisible()
+
+      // Switch to Network tab
+      await page.click('[data-testid="table-browser-network-tab"]')
+      // Network info panel should be visible
+      await expect(page.locator('[data-testid="network-info-panel"]').getByText('Test Network')).toBeVisible()
+    })
+  })
+
+  test.describe('3. Column Operations', () => {
+    test('3.1 Insert Column', async ({ page }) => {
+      await gotoAndSeedNetwork(page)
+      await expect(page.locator('[data-testid="table-browser-nodes-tab"]')).toBeVisible()
+
+      // Click Insert Column button
+      await page.click('[data-testid="insert-column-button"]')
+      await expect(page.locator('[data-testid="create-table-column-dialog"]')).toBeVisible()
+
+      // Fill in column name
+      await page.fill('[data-testid="create-table-column-name-input"] input', 'Test Column')
+      
+      // Default type is String, default value empty. Fill a default value
+      await page.fill('[data-testid="create-table-column-default-value-input"] input', 'test_val')
+
+      // Submit
+      await page.click('[data-testid="create-table-column-confirm-button"]')
+
+      // Dialog should close
+      await expect(page.locator('[data-testid="create-table-column-dialog"]')).not.toBeVisible()
+
+      // Verify the column was added and the default value applied using CyWebApi
+      const nodeTableResult = await page.evaluate(() => {
+        const api = (window as any).CyWebApi
+        const currentNetworkIdResult = api.workspace.getCurrentNetworkId()
+        const currentNetworkId = currentNetworkIdResult.data.networkId
+        return api.table.getTable(currentNetworkId, 'node')
+      })
+
+      expect(nodeTableResult).toEqual(expect.objectContaining({ success: true }))
+      const tableData = nodeTableResult.data
+      
+      // Expect column to exist
+      expect(tableData.columns.find((c: any) => c.name === 'Test Column')).toBeDefined()
+
+      // Expect rows to have the default value
+      expect(tableData.rows.length).toBeGreaterThan(0)
+      for (const row of tableData.rows) {
+        expect(row['Test Column']).toBe('test_val')
+      }
+    })
+  })
+
+  test.describe('6. Toolbar Operations', () => {
+    test('6.1 Import Table Dialog', async ({ page }) => {
+      await gotoAndSeedNetwork(page)
+      await expect(page.locator('[data-testid="table-browser-nodes-tab"]')).toBeVisible()
+
+      // Click Import Table button
+      await page.click('[data-testid="import-table-button"]')
+
+      // Verify the join table to network dialog appears
+      await expect(page.locator('[data-testid="join-table-upload-dropzone"]')).toBeVisible()
+
+      // Close the dialog by pressing Escape
+      await page.keyboard.press('Escape')
+      await expect(page.locator('[data-testid="join-table-upload-dropzone"]')).not.toBeVisible()
+    })
+  })
+})


### PR DESCRIPTION
refs #627 fixes #627
Fix issue related to table browser cell updating due to the introduction of virtual node/edge id columns

This pull request introduces several improvements and new components to the Table Browser feature. The main changes include the addition of reusable UI components for tab panels, table tabs, the table grid, and the table context menu, as well as new custom hooks and corresponding unit tests for handling theme mapping and context cell logic. There are also enhancements to the `CreateTableColumnForm` to improve UX around form state management and test coverage.

**New UI Components:**

* Added `TableContextMenu`, `TableGrid`, `TableBrowserTabs`, and `TabPanel` components to modularize and improve the Table Browser UI. These components provide reusable, testable building blocks for the table interface, context menu actions, and tab navigation. [[1]](diffhunk://#diff-2cd49e47f59e217430217adb9da9c9070c80e8f77125991ed989ce77e3a0cfd4R1-R257) [[2]](diffhunk://#diff-5c87cd4d4d9d6a8dba2e487d92eb26b679cc7065d5baf11bdb78ed3fc6517206R1-R101) [[3]](diffhunk://#diff-c4ec319f49a39151b1285c488e7a4562728b7e32643983aef89de1a9bf88b087R1-R78) [[4]](diffhunk://#diff-fb6361a4083153db1a1fc307a09f7cc7473706a22f59a3e5cd373161f2e9ccc0R1-R25)

**Custom Hooks and Tests:**

* Introduced `useDataEditorTheme` and `useIsContextCellVirtual` hooks, along with comprehensive unit tests, to encapsulate theme mapping and logic for determining if a context menu cell is virtual. [[1]](diffhunk://#diff-65e0efab4a0c02881741710753ee55c93497d09e0f03127e2cd58791fdcc4c4aR1-R26) [[2]](diffhunk://#diff-02654f095f2aa7c87d9ab17b9aa8f275f98cf8ece287c40e1ef126c041f7973cR1-R15) [[3]](diffhunk://#diff-cc45b73affd6d2b7d0c005cc31d61d89e5d1d8cd31477349da6d69d65335bff3R1-R29) [[4]](diffhunk://#diff-46af7399c8dc7ffd3c47d294159897e2fba2b6961b74fcbf832f22bdd222cbedR1-R30)

**Form State and Accessibility Improvements:**

* Updated `CreateTableColumnForm` so that its state is reset only when the dialog is reopened, not upon form submission. This prevents accidental loss of user input if validation fails. Added tests to verify this behavior. [[1]](diffhunk://#diff-eb3f1bcb9c4097ea67da293e56315754307241999674c7dfab19e0e2a53bb918R270-R284) [[2]](diffhunk://#diff-eb3f1bcb9c4097ea67da293e56315754307241999674c7dfab19e0e2a53bb918L287-L289) [[3]](diffhunk://#diff-4e128653381bced6720b74454ae4864f27bf7d20bc8cb38ce4a4e5dddea28aa2R1-R40)
* Added `data-testid` attributes to key buttons for improved testability, including the cancel and confirm buttons in dialogs. [[1]](diffhunk://#diff-51b456cb683a2a51305ae79169958a93b514f7288dd91a5bf82d374c69956bacL250-R250) [[2]](diffhunk://#diff-eb3f1bcb9c4097ea67da293e56315754307241999674c7dfab19e0e2a53bb918R270-R284)

These changes enhance the modularity, testability, and user experience of the Table Browser feature.