### PR TITLE
fix(FilterPanel): prevent infinite render loop on subnetwork click

### DIFF
--- a/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.spec.tsx
+++ b/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.spec.tsx
@@ -1,0 +1,95 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+import { useFilterStore } from '../../../../data/hooks/stores/FilterStore'
+import { useTableStore } from '../../../../data/hooks/stores/TableStore'
+import { useUiStateStore } from '../../../../data/hooks/stores/UiStateStore'
+import { useVisualStyleStore } from '../../../../data/hooks/stores/VisualStyleStore'
+import { useWorkspaceStore } from '../../../../data/hooks/stores/WorkspaceStore'
+import { FilterPanel } from './FilterPanel'
+import { DisplayMode } from '../../../../models/FilterModel/DisplayMode'
+import { GraphObjectType } from '../../../../models/NetworkModel'
+
+// Mock child components to isolate the test to FilterPanel's useEffect behavior
+vi.mock('./AttributeSelector', () => ({
+  AttributeSelector: () => <div data-testid="mock-attr-selector" />
+}))
+
+vi.mock('./CheckboxFilter', () => ({
+  CheckboxFilter: () => <div data-testid="mock-checkbox-filter" />
+}))
+
+describe('FilterPanel', () => {
+  beforeEach(() => {
+    // Reset stores
+    useFilterStore.setState({ filterConfigs: {}, search: {} as any })
+    useTableStore.setState({ tables: {} })
+    useUiStateStore.setState({ ui: { activeNetworkView: '' } as any })
+    useVisualStyleStore.setState({ visualStyles: {} })
+    useWorkspaceStore.setState({ workspace: { currentNetworkId: '' } as any })
+    
+    // Clear mocks
+    vi.clearAllMocks()
+  })
+
+  it('does not infinitely loop when visual mapping has not changed', () => {
+    const targetNetworkId = 'net1_sub1'
+    
+    // Setup Zustand stores with initial state to trigger the condition
+    useUiStateStore.setState({
+      ui: { activeNetworkView: targetNetworkId } as any,
+    })
+    
+    const visualMapping = {
+      type: 'discrete',
+      attribute: 'interaction',
+    } as any
+
+    useFilterStore.setState({
+      filterConfigs: {
+        [targetNetworkId]: {
+          name: targetNetworkId,
+          label: 'Test Filter',
+          attribute: 'interaction',
+          type: 'checkbox',
+          displayMode: DisplayMode.SELECT,
+          targetObjectType: GraphObjectType.EDGE,
+          visualMapping,
+        } as any,
+      },
+    })
+
+    useTableStore.setState({
+      tables: {
+        [targetNetworkId]: {
+          nodeTable: { rows: new Map(), columns: [] } as any,
+          edgeTable: { rows: new Map(), columns: [] } as any,
+        },
+      },
+    })
+
+    useVisualStyleStore.setState({
+      visualStyles: {
+        [targetNetworkId]: {
+          edgeLineColor: {
+            mapping: visualMapping
+          }
+        } as any,
+      },
+    })
+    
+    const updateSpy = vi.spyOn(useFilterStore.getState(), 'updateFilterConfig')
+
+    render(
+      <MemoryRouter>
+        <FilterPanel />
+      </MemoryRouter>
+    )
+
+    // The component should mount without calling updateFilterConfig
+    // because the visual mapping derived from the visual style is identical
+    // to the one already in the filter config.
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.spec.tsx
+++ b/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.spec.tsx
@@ -41,7 +41,12 @@ describe('FilterPanel', () => {
       ui: { activeNetworkView: targetNetworkId } as any,
     })
     
-    const visualMapping = {
+    const visualMappingForStore = {
+      type: 'discrete',
+      attribute: 'interaction',
+    } as any
+
+    const visualMappingForStyle = {
       type: 'discrete',
       attribute: 'interaction',
     } as any
@@ -55,7 +60,7 @@ describe('FilterPanel', () => {
           type: 'checkbox',
           displayMode: DisplayMode.SELECT,
           targetObjectType: GraphObjectType.EDGE,
-          visualMapping,
+          visualMapping: visualMappingForStore,
         } as any,
       },
     })
@@ -73,7 +78,7 @@ describe('FilterPanel', () => {
       visualStyles: {
         [targetNetworkId]: {
           edgeLineColor: {
-            mapping: visualMapping
+            mapping: visualMappingForStyle
           }
         } as any,
       },

--- a/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.tsx
+++ b/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.tsx
@@ -170,12 +170,6 @@ export const FilterPanel = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only URL-param init; re-runs would clobber the toggle
   }, [])
 
-  /**
-   * Add visual mapping to the filter config
-   *
-   * `selectedFilter` must NOT be a dependency: this effect writes it back via
-   * updateFilterConfig with a fresh object, so adding it would loop forever.
-   */
   useEffect(() => {
     if (selectedFilter === undefined) return
 
@@ -183,8 +177,13 @@ export const FilterPanel = () => {
 
     if (visualMapping === undefined) return
 
-    const newFilterConfig = { ...selectedFilter, visualMapping }
-    updateFilterConfig(newFilterConfig.name, newFilterConfig)
+    const currentMappingStr = JSON.stringify(selectedFilter.visualMapping)
+    const newMappingStr = JSON.stringify(visualMapping)
+    
+    if (currentMappingStr !== newMappingStr) {
+      const newFilterConfig = { ...selectedFilter, visualMapping }
+      updateFilterConfig(newFilterConfig.name, newFilterConfig)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- vs trigger only; selectedFilter is written here (loop)
   }, [vs])
 
@@ -210,8 +209,14 @@ export const FilterPanel = () => {
     const visualMapping = getMapping(vs, targetAttrName)
 
     if (currentConfig !== undefined) {
-      const newConfig = { ...currentConfig, visualMapping }
-      updateFilterConfig(newConfig.name, newConfig)
+      const currentMappingStr = JSON.stringify(currentConfig.visualMapping)
+      const newMappingStr = JSON.stringify(visualMapping)
+      
+      if (currentMappingStr !== newMappingStr) {
+        const newConfig = { ...currentConfig, visualMapping }
+        updateFilterConfig(newConfig.name, newConfig)
+      }
+      
       searchParams.set(FilterUrlParams.FILTER_FOR, selectedObjectType)
       searchParams.set(FilterUrlParams.FILTER_BY, targetAttrName)
       searchParams.set(

--- a/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.tsx
+++ b/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import { isEqual } from 'lodash'
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
@@ -177,10 +178,7 @@ export const FilterPanel = () => {
 
     if (visualMapping === undefined) return
 
-    const currentMappingStr = JSON.stringify(selectedFilter.visualMapping)
-    const newMappingStr = JSON.stringify(visualMapping)
-    
-    if (currentMappingStr !== newMappingStr) {
+    if (!isEqual(selectedFilter.visualMapping, visualMapping)) {
       const newFilterConfig = { ...selectedFilter, visualMapping }
       updateFilterConfig(newFilterConfig.name, newFilterConfig)
     }
@@ -209,10 +207,7 @@ export const FilterPanel = () => {
     const visualMapping = getMapping(vs, targetAttrName)
 
     if (currentConfig !== undefined) {
-      const currentMappingStr = JSON.stringify(currentConfig.visualMapping)
-      const newMappingStr = JSON.stringify(visualMapping)
-      
-      if (currentMappingStr !== newMappingStr) {
+      if (!isEqual(currentConfig.visualMapping, visualMapping)) {
         const newConfig = { ...currentConfig, visualMapping }
         updateFilterConfig(newConfig.name, newConfig)
       }


### PR DESCRIPTION
- Added a deep equality check in FilterPanel's useEffect to prevent unconditionally calling updateFilterConfig when the visual mapping has not changed.
- Created FilterPanel.spec.tsx to verify the infinite loop condition is mitigated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary filter configuration updates when the computed visual mapping already matches the stored mapping for the active view.
  * Improved filter state synchronization stability by only updating when a mapping mismatch is detected.

* **Tests**
  * Added a new test suite to confirm that mounting the filter panel does not trigger updates when visual mappings are already in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->