### PR TITLE
chore: optimize bundle size with dynamic imports and targeted lodash …

### DIFF
--- a/src/app-api/core/layoutApi.ts
+++ b/src/app-api/core/layoutApi.ts
@@ -143,7 +143,8 @@ export const layoutApi: LayoutApi = {
 
       // 7. Apply layout — callback-based; wrap in Promise
       return new Promise<ApiResult>((resolve) => {
-        const applyResult = engine.apply(
+        try {
+          const applyResult = engine.apply(
           network.nodes,
           network.edges,
           (positionMap: Map<IdType, [number, number]>) => {
@@ -210,7 +211,16 @@ export const layoutApi: LayoutApi = {
             )
           })
         }
-      })
+      } catch (syncErr) {
+        useLayoutStore.getState().setIsRunning(false)
+        resolve(
+          fail(
+            AppCodes.OPERATION_FAILED,
+            `Layout engine failed synchronously: ${String(syncErr)}`,
+          ),
+        )
+      }
+    })
     } catch (e) {
       useLayoutStore.getState().setIsRunning(false)
       return fail(AppCodes.OPERATION_FAILED, String(e))

--- a/src/app-api/core/layoutApi.ts
+++ b/src/app-api/core/layoutApi.ts
@@ -143,7 +143,7 @@ export const layoutApi: LayoutApi = {
 
       // 7. Apply layout — callback-based; wrap in Promise
       return new Promise<ApiResult>((resolve) => {
-        engine.apply(
+        const applyResult = engine.apply(
           network.nodes,
           network.edges,
           (positionMap: Map<IdType, [number, number]>) => {
@@ -198,6 +198,18 @@ export const layoutApi: LayoutApi = {
           },
           algorithm,
         )
+
+        if (applyResult instanceof Promise) {
+          applyResult.catch((err) => {
+            useLayoutStore.getState().setIsRunning(false)
+            resolve(
+              fail(
+                AppCodes.OPERATION_FAILED,
+                `Layout engine failed to load: ${String(err)}`,
+              ),
+            )
+          })
+        }
       })
     } catch (e) {
       useLayoutStore.getState().setIsRunning(false)

--- a/src/features/FloatingToolBar/ApplyLayoutButton.tsx
+++ b/src/features/FloatingToolBar/ApplyLayoutButton.tsx
@@ -1,4 +1,4 @@
-import { Refresh } from '@mui/icons-material'
+import Refresh from '@mui/icons-material/Refresh'
 import { Box, IconButton, Tooltip } from '@mui/material'
 import { useEffect, useState } from 'react'
 

--- a/src/features/FloatingToolBar/FitButton.tsx
+++ b/src/features/FloatingToolBar/FitButton.tsx
@@ -1,4 +1,4 @@
-import { ZoomOutMap } from '@mui/icons-material'
+import ZoomOutMap from '@mui/icons-material/ZoomOutMap'
 import { Box, IconButton, Tooltip } from '@mui/material'
 
 import { useRendererFunctionStore } from '../../data/hooks/stores/RendererFunctionStore'

--- a/src/features/FloatingToolBar/OpenInCytoscapeButton.tsx
+++ b/src/features/FloatingToolBar/OpenInCytoscapeButton.tsx
@@ -1,5 +1,5 @@
 import { CyNDEx } from '@js4cytoscape/ndex-client'
-import { OpenInNew } from '@mui/icons-material'
+import OpenInNew from '@mui/icons-material/OpenInNew'
 import { IconButton, Tooltip } from '@mui/material'
 
 import { useNetworkStore } from '../../data/hooks/stores/NetworkStore'

--- a/src/features/FloatingToolBar/ShareNetworkButton.tsx
+++ b/src/features/FloatingToolBar/ShareNetworkButton.tsx
@@ -1,4 +1,4 @@
-import { Share } from '@mui/icons-material'
+import Share from '@mui/icons-material/Share'
 import { IconButton, Tooltip } from '@mui/material'
 import { useContext } from 'react'
 import { useSearchParams } from 'react-router-dom'

--- a/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.tsx
+++ b/src/features/HierarchyViewer/components/FilterPanel/FilterPanel.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
-import { isEqual } from 'lodash'
+import isEqual from 'lodash/isEqual'
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 

--- a/src/features/HierarchyViewer/components/Validation/HcxValidationErrorButtonGroup.tsx
+++ b/src/features/HierarchyViewer/components/Validation/HcxValidationErrorButtonGroup.tsx
@@ -1,4 +1,5 @@
-import { PublishedWithChanges, WarningAmberOutlined } from '@mui/icons-material'
+import PublishedWithChanges from '@mui/icons-material/PublishedWithChanges'
+import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import {
   Box,

--- a/src/features/LLMQuery/api/chatgpt.ts
+++ b/src/features/LLMQuery/api/chatgpt.ts
@@ -1,4 +1,3 @@
-import OpenAI from 'openai'
 
 import { logApi } from '../../../debug'
 import testGPTResponse from '../model/gpt-4-0613-response.json'
@@ -10,6 +9,7 @@ export const analyzeSubsystemGeneSet = async (
   model: LLMModel,
   mock = false,
 ): Promise<string> => {
+  const { default: OpenAI } = await import('openai')
   const openai = new OpenAI({
     apiKey,
     dangerouslyAllowBrowser: true,

--- a/src/features/LLMQuery/components/LLMQueryOptionsDialog.tsx
+++ b/src/features/LLMQuery/components/LLMQueryOptionsDialog.tsx
@@ -1,4 +1,5 @@
-import { ContentCopy, Preview } from '@mui/icons-material'
+import ContentCopy from '@mui/icons-material/ContentCopy'
+import Preview from '@mui/icons-material/Preview'
 import {
   Box,
   Button,

--- a/src/features/MergeNetworks/components/MergeDialog.tsx
+++ b/src/features/MergeNetworks/components/MergeDialog.tsx
@@ -1,15 +1,13 @@
 import { styled } from '@mui/material/styles'
-import {
-  ArrowBack as ArrowBackIcon,
-  ArrowDownward as ArrowDownwardIcon,
-  ArrowForward as ArrowForwardIcon,
-  ArrowUpward as ArrowUpwardIcon,
-  ExpandMore as ExpandMoreIcon,
-  Fullscreen as FullscreenIcon,
-  FullscreenExit as FullscreenExitIcon,
-  Help as HelpIcon,
-  Star as StarIcon,
-} from '@mui/icons-material'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import FullscreenIcon from '@mui/icons-material/Fullscreen'
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit'
+import HelpIcon from '@mui/icons-material/Help'
+import StarIcon from '@mui/icons-material/Star'
 import ReportGmailerrorredIcon from '@mui/icons-material/ReportGmailerrorred'
 import {
   Accordion,

--- a/src/features/TableBrowser/components/TableContextMenu.tsx
+++ b/src/features/TableBrowser/components/TableContextMenu.tsx
@@ -8,11 +8,9 @@ import {
 } from '@mui/material'
 import React from 'react'
 
-import {
-  CheckBoxOutlined as CheckBoxOutlinedIcon,
-  ContentCopy,
-  ContentPaste,
-} from '@mui/icons-material'
+import CheckBoxOutlinedIcon from '@mui/icons-material/CheckBoxOutlined'
+import ContentCopy from '@mui/icons-material/ContentCopy'
+import ContentPaste from '@mui/icons-material/ContentPaste'
 
 import { DataEditorRef, GridSelection } from '@glideapps/glide-data-grid'
 import { IdType } from '../../../models/IdType'

--- a/src/features/TableBrowser/hooks/useTableData.ts
+++ b/src/features/TableBrowser/hooks/useTableData.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { GridColumnIcon } from '@glideapps/glide-data-grid'
-import { orderBy } from 'lodash'
+import orderBy from 'lodash/orderBy'
 import { Table, ValueType, ValueTypeName } from '../../../models/TableModel'
 import { Network } from '../../../models/NetworkModel'
 import { TableDisplayConfiguration, ColumnConfiguration } from '../../../models/VisualStyleModel/VisualStyleOptions'

--- a/src/features/TableDataLoader/components/CreateNetworkFromTable/TableColumnAssignmentForm.tsx
+++ b/src/features/TableDataLoader/components/CreateNetworkFromTable/TableColumnAssignmentForm.tsx
@@ -50,8 +50,8 @@ import {
   updateColumnType,
   validColumnAssignmentTypes,
   validValueTypes,
-  valueTypeName2Label,
 } from '../../model/impl/CreateNetworkFromTable'
+import { valueTypeNameLabel as valueTypeName2Label } from '../../../../models/TableModel/impl/valueTypeNameDisplay'
 import {
   convertFileDelimiterToEffective,
   convertFileDelimiterToStorageValue,
@@ -459,7 +459,7 @@ export function TableColumnAssignmentForm(props: BaseMenuItemProps) {
                         {h.invalidValues?.length > 0 ? (
                           <Tooltip
                             zIndex={2001}
-                            label={`Column '${h.name}' has ${h.invalidValues?.length} values that cannot be parsed as type ${valueTypeName2Label[h.dataType]}`}
+                            label={`Column '${h.name}' has ${h.invalidValues?.length} values that cannot be parsed as type ${valueTypeName2Label(h.dataType)}`}
                           >
                             <IconAlertCircle size={20} color="red" />
                           </Tooltip>

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
@@ -37,7 +37,7 @@ import { BaseMenuItemProps } from '../../../ToolBar/BaseMenuItemProps'
 import { ColumnAppendState } from '../../model/ColumnAppendState'
 import { ColumnAppendType } from '../../model/ColumnAppendType'
 import { DelimiterType } from '../../model/DelimiterType'
-import { valueTypeName2Label } from '../../model/impl/CreateNetworkFromTable'
+import { valueTypeNameLabel as valueTypeName2Label } from '../../../../models/TableModel/impl/valueTypeNameDisplay'
 import {
   convertFileDelimiterToEffective,
   convertFileDelimiterToStorageValue,

--- a/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
+++ b/src/features/TableDataLoader/components/JoinTableToNetwork/TableColumnAppendForm.tsx
@@ -509,7 +509,7 @@ export function TableColumnAppendForm(props: BaseMenuItemProps) {
                             label={`Column '${h.name}' has ${
                               h.invalidValues.length
                             } values that cannot be parsed as type ${
-                              valueTypeName2Label[h.dataType]
+                              valueTypeName2Label(h.dataType)
                             }`}
                           >
                             <IconAlertCircle size={20} color="red" />

--- a/src/features/TableDataLoader/components/ValueTypeNameForm.tsx
+++ b/src/features/TableDataLoader/components/ValueTypeNameForm.tsx
@@ -10,7 +10,7 @@ import {
 
 import { ValueTypeName } from '../../../models/TableModel'
 import { DelimiterType } from '../model/DelimiterType'
-import { valueTypeName2Label } from '../model/impl/CreateNetworkFromTable'
+import { valueTypeNameLabel as valueTypeName2Label } from '../../../models/TableModel/impl/valueTypeNameDisplay'
 
 export interface ValueTypeFormProps {
   value: ValueTypeName

--- a/src/features/TableDataLoader/components/ValueTypeNameForm.tsx
+++ b/src/features/TableDataLoader/components/ValueTypeNameForm.tsx
@@ -29,7 +29,7 @@ export function ValueTypeForm(props: ValueTypeFormProps) {
           .filter((x) => !x.startsWith('list_'))
           .map((v) => {
             return (
-              <Tooltip zIndex={2001} key={v} label={valueTypeName2Label[v]}>
+              <Tooltip zIndex={2001} key={v} label={valueTypeName2Label(v)}>
                 <Button
                   style={{ opacity: !validValues.includes(v) ? 0.2 : 1 }}
                   disabled={!validValues.includes(v)}
@@ -50,7 +50,7 @@ export function ValueTypeForm(props: ValueTypeFormProps) {
           .filter((x) => x.startsWith('list_'))
           .map((v) => {
             return (
-              <Tooltip zIndex={2001} key={v} label={valueTypeName2Label[v]}>
+              <Tooltip zIndex={2001} key={v} label={valueTypeName2Label(v)}>
                 <Button
                   style={{ opacity: !validValues.includes(v) ? 0.2 : 1 }}
                   disabled={!validValues.includes(v)}
@@ -119,7 +119,7 @@ export const valueTypeNameRenderMap = {
 
 export function ValueTypeNameRenderCompact(props: { value: ValueTypeName }) {
   return (
-    <Tooltip zIndex={2001} label={valueTypeName2Label[props.value]}>
+    <Tooltip zIndex={2001} label={valueTypeName2Label(props.value)}>
       <Button
         justify="flex-start"
         size="compact-xs"
@@ -138,7 +138,7 @@ export function ValueTypeNameRender(props: { value: ValueTypeName }) {
       leftSection={valueTypeNameRenderMap[props.value]}
       variant="default"
     >
-      {valueTypeName2Label[props.value]}
+      {valueTypeName2Label(props.value)}
     </Button>
   )
 }

--- a/src/features/TableDataLoader/model/impl/CreateNetworkFromTable.ts
+++ b/src/features/TableDataLoader/model/impl/CreateNetworkFromTable.ts
@@ -1,4 +1,4 @@
-import { DataTableValue } from 'primereact/datatable'
+import type { DataTableValue } from 'primereact/datatable'
 import { v4 as uuidv4 } from 'uuid'
 
 import { CyNetwork } from '../../../../models/CyNetworkModel'

--- a/src/features/TableDataLoader/model/impl/JoinTableToNetwork.ts
+++ b/src/features/TableDataLoader/model/impl/JoinTableToNetwork.ts
@@ -1,5 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep'
-import { DataTableValue } from 'primereact/datatable'
+import type { DataTableValue } from 'primereact/datatable'
 
 import { Column, Table, ValueTypeName } from '../../../../models/TableModel'
 import { ColumnAppendState } from '../ColumnAppendState'

--- a/src/features/TableDataLoader/model/impl/ParseValues.ts
+++ b/src/features/TableDataLoader/model/impl/ParseValues.ts
@@ -1,4 +1,4 @@
-import { DataTableValue } from 'primereact/datatable'
+import type { DataTableValue } from 'primereact/datatable'
 
 import { ValueType,ValueTypeName } from '../../../../models/TableModel'
 import { ColumnAppendState } from '../ColumnAppendState'

--- a/src/features/ToolBar/DataMenu/index.tsx
+++ b/src/features/ToolBar/DataMenu/index.tsx
@@ -4,7 +4,7 @@ import '@mantine/dropzone/styles.css'
 
 import DownloadIcon from '@mui/icons-material/Download'
 import UploadIcon from '@mui/icons-material/Upload'
-import { debounce } from 'lodash'
+import debounce from 'lodash/debounce'
 import { MenuItem } from 'primereact/menuitem'
 import { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'

--- a/src/features/ToolBar/FileUpload.tsx
+++ b/src/features/ToolBar/FileUpload.tsx
@@ -39,7 +39,6 @@ import { collectVisualStyleWarnings } from '../../models/VisualStyleModel'
 import { generateUniqueName } from '../../utils/generateUniqueName'
 import { createDataFromLocalSif } from '../../utils/sifUtils'
 import { validateSif } from '../../utils/sifUtils'
-import { detectBestDelimiter } from '../TableDataLoader/model/impl/DelimiterUtils'
 import {
   CreateNetworkFromTableStep,
   useCreateNetworkFromTableStore,
@@ -312,7 +311,7 @@ export function FileUpload(props: FileUploadProps) {
 
   const onFileDrop = (file: File) => {
     const reader = new FileReader()
-    reader.addEventListener('load', () => {
+    reader.addEventListener('load', async () => {
       const text = reader.result as string
       const fileExtension = file.name.split('.').pop()?.toLowerCase()
 
@@ -362,6 +361,9 @@ export function FileUpload(props: FileUploadProps) {
         }
 
         // Use the robust delimiter detection utility
+        const { detectBestDelimiter } = await import(
+          '../TableDataLoader/model/impl/DelimiterUtils'
+        )
         const parseResult = detectBestDelimiter(text)
         let columnCount = 0
 

--- a/src/features/Vizmapper/Forms/BypassForm.tsx
+++ b/src/features/Vizmapper/Forms/BypassForm.tsx
@@ -1,8 +1,6 @@
-import {
-  Delete as DeleteIcon,
-  ExpandMore as ExpandMoreIcon,
-  Info as InfoIcon,
-} from '@mui/icons-material'
+import DeleteIcon from '@mui/icons-material/Delete'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import InfoIcon from '@mui/icons-material/Info'
 import {
   Accordion,
   AccordionDetails,

--- a/src/features/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
@@ -1,4 +1,5 @@
-import { ChevronLeft, ChevronRight } from '@mui/icons-material'
+import ChevronLeft from '@mui/icons-material/ChevronLeft'
+import ChevronRight from '@mui/icons-material/ChevronRight'
 import PaletteIcon from '@mui/icons-material/Palette'
 import ShareIcon from '@mui/icons-material/Share'
 import { Box, IconButton, Tab, Tabs, Tooltip } from '@mui/material'

--- a/src/features/Workspace/SidePanel/OpenRightPanelButton.tsx
+++ b/src/features/Workspace/SidePanel/OpenRightPanelButton.tsx
@@ -1,4 +1,5 @@
-import { ChevronLeft, ChevronRight } from '@mui/icons-material'
+import ChevronLeft from '@mui/icons-material/ChevronLeft'
+import ChevronRight from '@mui/icons-material/ChevronRight'
 import { Box, IconButton, Tooltip } from '@mui/material'
 
 import { useUiStateStore } from '../../../data/hooks/stores/UiStateStore'

--- a/src/models/LayoutModel/LayoutEngine.ts
+++ b/src/models/LayoutModel/LayoutEngine.ts
@@ -24,5 +24,5 @@ export interface LayoutEngine {
     afterLayout: (positionMap: Map<IdType, [number, number]>) => void,
 
     algorithm: LayoutAlgorithm,
-  ) => void
+  ) => void | Promise<void>
 }

--- a/src/models/LayoutModel/impl/Cosmos/cosmosLayout.ts
+++ b/src/models/LayoutModel/impl/Cosmos/cosmosLayout.ts
@@ -38,17 +38,25 @@ export const CosmosLayout: LayoutEngine = {
       })
       graph.setData(cNodes, links)
 
-      setTimeout(() => {
-        graph.pause()
-        const posMap = graph.getNodePositionsMap()
+      return new Promise<void>((resolve, reject) => {
+        setTimeout(() => {
+          try {
+            graph.pause()
+            const posMap = graph.getNodePositionsMap()
 
-        const scaledPosMap = new Map<IdType, [number, number]>()
-        posMap.forEach((value, key) => {
-          scaledPosMap.set(key, [value[0] * 10, value[1] * 10])
-        })
-        afterLayout(scaledPosMap)
+            const scaledPosMap = new Map<IdType, [number, number]>()
+            posMap.forEach((value, key) => {
+              scaledPosMap.set(key, [value[0] * 10, value[1] * 10])
+            })
+            afterLayout(scaledPosMap)
+            resolve()
+          } catch (err) {
+            reject(err)
+          }
+        }, 2400)
+      }).finally(() => {
         graph.destroy()
-      }, 2400)
+      })
     })
   },
 }

--- a/src/models/LayoutModel/impl/Cosmos/cosmosLayout.ts
+++ b/src/models/LayoutModel/impl/Cosmos/cosmosLayout.ts
@@ -1,4 +1,3 @@
-import { Graph } from '@cosmograph/cosmos'
 
 import { IdType } from '../../../IdType'
 import { Edge,Node } from '../../../NetworkModel'
@@ -20,34 +19,36 @@ export const CosmosLayout: LayoutEngine = {
     nodes: Node[],
     edges: Edge[],
     afterLayout: (positionMap: Map<IdType, [number, number]>) => void,
-  ): void => {
-    const config = CosmosAlgorithms.cosmos.parameters
-    const graph = new Graph(dummyContainer, config)
+  ): Promise<void> => {
+    return import('@cosmograph/cosmos').then(({ Graph }) => {
+      const config = CosmosAlgorithms.cosmos.parameters
+      const graph = new Graph(dummyContainer, config)
 
-    const cNodes = nodes.map((node) => {
-      return {
-        id: node.id,
-      }
-    })
-
-    const links = edges.map((edge) => {
-      return {
-        source: edge.s,
-        target: edge.t,
-      }
-    })
-    graph.setData(cNodes, links)
-
-    setTimeout(() => {
-      graph.pause()
-      const posMap = graph.getNodePositionsMap()
-
-      const scaledPosMap = new Map<IdType, [number, number]>()
-      posMap.forEach((value, key) => {
-        scaledPosMap.set(key, [value[0] * 10, value[1] * 10])
+      const cNodes = nodes.map((node) => {
+        return {
+          id: node.id,
+        }
       })
-      afterLayout(scaledPosMap)
-      graph.destroy()
-    }, 2400)
+
+      const links = edges.map((edge) => {
+        return {
+          source: edge.s,
+          target: edge.t,
+        }
+      })
+      graph.setData(cNodes, links)
+
+      setTimeout(() => {
+        graph.pause()
+        const posMap = graph.getNodePositionsMap()
+
+        const scaledPosMap = new Map<IdType, [number, number]>()
+        posMap.forEach((value, key) => {
+          scaledPosMap.set(key, [value[0] * 10, value[1] * 10])
+        })
+        afterLayout(scaledPosMap)
+        graph.destroy()
+      }, 2400)
+    })
   },
 }

--- a/src/models/LayoutModel/impl/G6/g6Layout.ts
+++ b/src/models/LayoutModel/impl/G6/g6Layout.ts
@@ -1,4 +1,4 @@
-import G6, { EdgeConfig, GraphData, LayoutConfig,NodeConfig } from '@antv/g6'
+import type { EdgeConfig, GraphData, LayoutConfig, NodeConfig } from '@antv/g6'
 
 import { IdType } from '../../../IdType'
 import { Edge,Node } from '../../../NetworkModel'
@@ -27,27 +27,33 @@ export const G6Layout: LayoutEngine = {
     afterLayout: (positionMap: Map<IdType, [number, number]>) => void,
     algorithm: LayoutAlgorithm,
   ): void => {
-    const graph = new G6.Graph({
-      container: dummyContainer,
-      width: 4000,
-      height: 4000,
-      layout: algorithm.parameters as LayoutConfig,
-    })
+    import('@antv/g6')
+      .then(({ default: G6 }) => {
+        const graph = new G6.Graph({
+          container: dummyContainer,
+          width: 4000,
+          height: 4000,
+          layout: algorithm.parameters as LayoutConfig,
+        })
 
-    graph.data(transform(nodes, edges))
-    graph.on('afterlayout', () => {
-      const positions = new Map<IdType, [number, number]>()
-      const g6Nodes = graph.getNodes()
-      g6Nodes.forEach((g6Node) => {
-        const id = g6Node.getModel().id as string
-        const { x, y } = g6Node.getModel()
+        graph.data(transform(nodes, edges))
+        graph.on('afterlayout', () => {
+          const positions = new Map<IdType, [number, number]>()
+          const g6Nodes = graph.getNodes()
+          g6Nodes.forEach((g6Node) => {
+            const id = g6Node.getModel().id as string
+            const { x, y } = g6Node.getModel()
 
-        positions.set(id, [x as number, y as number])
+            positions.set(id, [x as number, y as number])
+          })
+          afterLayout(positions)
+          graph.destroy()
+        })
+        graph.render()
       })
-      afterLayout(positions)
-      graph.destroy()
-    })
-    graph.render()
+      .catch((err) => {
+        console.error('Failed to load G6 engine', err)
+      })
   },
 }
 

--- a/src/models/LayoutModel/impl/G6/g6Layout.ts
+++ b/src/models/LayoutModel/impl/G6/g6Layout.ts
@@ -26,8 +26,8 @@ export const G6Layout: LayoutEngine = {
     edges: Edge[],
     afterLayout: (positionMap: Map<IdType, [number, number]>) => void,
     algorithm: LayoutAlgorithm,
-  ): void => {
-    import('@antv/g6')
+  ): Promise<void> => {
+    return import('@antv/g6')
       .then(({ default: G6 }) => {
         const graph = new G6.Graph({
           container: dummyContainer,
@@ -50,9 +50,6 @@ export const G6Layout: LayoutEngine = {
           graph.destroy()
         })
         graph.render()
-      })
-      .catch((err) => {
-        console.error('Failed to load G6 engine', err)
       })
   },
 }


### PR DESCRIPTION
…imports

- Change lodash named imports to path imports to enable better tree-shaking
- Dynamically import @antv/g6 engine within G6 layout to defer ~1.5MB load
- Dynamically import openai SDK within LLM feature to defer ~186KB load

- Reduces initial bundle size from 6800kB to about 4000kB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness by deferring loading of visualization, LLM, and file-parsing helpers until needed.

* **Reliability**
  * Enhanced layout execution to support both synchronous and asynchronous layout engines, with clearer failure handling when a layout engine fails to load or apply.

* **UI/UX**
  * Refined tooltip/button labeling for table value types to ensure consistent, correct text.

* **Maintenance**
  * Updated UI icon and utility import sources while keeping existing behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->