### PR TITLE
chore: bump version to 1.1.0-dev.0 and update dev config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cytoscape-web",
-  "version": "1.0.7",
+  "version": "1.1.0-dev.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -9,13 +9,17 @@
     "realm": "ndex"
   },
   "testNetworks": [
+    "2496d8c5-5c74-11ec-b3be-0ac135e8bacf",
+    "1366ba85-9acc-11ef-9702-005056ae6f73",
+    "88521140-6a12-11ef-b816-005056ae6f73",
     "a9763574-c72f-11ed-a79c-005056ae23aa",
-    "132684d4-d207-11ef-8900-005056ae6f73",
-    "a5bf5dc8-8ffb-11ef-b136-005056ae6f73"
+    "06f859c1-8051-11ef-b4e1-005056ae6f73",
+    "cfb7d52e-a2f2-11ed-9a1f-005056ae23aa"
   ],
   "defaultServices": [
     "https://cd.ndexbio.org/cy/cytocontainer/v1/updatetablesexample",
-    "https://cd.ndexbio.org/cy/cytocontainer/v1/iqueryenrichment"
+    "https://cd.ndexbio.org/cy/cytocontainer/v1/iqueryenrichment",
+    "https://cd.ndexbio.org/cy/cytocontainer/v1/gprofilerenrichment"
   ],
   "maxNetworkElementsThreshold": 26000,
   "maxEdgeCountThreshold": 20000,
@@ -26,5 +30,8 @@
   "undoStackSize": 20,
   "errorReportEndpoint": "https://dev1.ndexbio.org/report",
   "maxErrorReportSnapshotSizeMB": 10,
-  "appInstallAllowedOrigins": ["https://apps.cytoscape.org"]
+  "appInstallAllowedOrigins": [
+    "https://apps.cytoscape.org",
+    "https://apps-stage.cytoscape.org"
+  ]
 }


### PR DESCRIPTION
- package.json: 1.0.7 → 1.1.0-dev.0
- config.json: refresh testNetworks list, add gprofilerenrichment to defaultServices, allow apps-stage.cytoscape.org as an app install origin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional test networks.
  * Added an additional Cytocontainer service endpoint.
  * Enabled app installations from both production and staging app origins.

* **Chores**
  * Updated the application version to 1.1.0-dev.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->