### PR TITLE
Offer a reset button when the boot finds a newer database

### DIFF
--- a/docs/specifications/STARTUP_SPECIFICATION.md
+++ b/docs/specifications/STARTUP_SPECIFICATION.md
@@ -67,6 +67,27 @@ application:
 `database` is fatal because AppShell's first act is to read the workspace from
 IndexedDB — rendering over a dead database only relocates the failure.
 
+**The one recoverable fatal case carries a button.** A `schema-too-new` failure
+(this origin holds a database written by a newer build) is the only boot failure
+with an action the reader can take, so its error shell offers
+"Reset Workspace and Reload Cytoscape" — the same wording and the same
+`deleteDb()` primitive as the error page's button in `src/features/Error.tsx`,
+which cannot be reused directly because React never mounts on this path.
+
+Two constraints on that button:
+
+- **Arm, then confirm.** The first click swaps the label and reveals what will be
+  destroyed; only the second click runs. Clearing the database destroys the whole
+  local workspace with no undo, and the shell is too early to have the app's
+  `ConfirmationDialog` available.
+- **Never offered for `unavailable`.** A blocked IndexedDB (private browsing) is
+  not fixed by clearing data, and offering it there would send people to destroy
+  data for no reason.
+
+Recoveries are declared as data on `BootShellError.action` and dispatched by id
+through `shell/bootShellActions.ts`, so the markup module stays dependency-free
+and one delegated listener serves both renderers. See `src/boot/boot_docs/boot.md`.
+
 ### 2.3 `publish` and `route` always run
 
 `publishWorkspace` is what unblocks `waitForWorkspaceHydration()` and makes the

--- a/src/boot/bootError.ts
+++ b/src/boot/bootError.ts
@@ -62,6 +62,9 @@ export const classifyBootError = (
       classified?.message ??
       'Something went wrong while starting up. Reloading the page may help.',
     detail: classified?.detail ?? errorMessageOf(cause),
+    // No generic fallback: an action has to be declared by the classifier that
+    // knows a recovery exists. There is nothing safe to offer by default.
+    action: classified?.action,
   }
 }
 

--- a/src/boot/boot_docs/boot.md
+++ b/src/boot/boot_docs/boot.md
@@ -15,8 +15,9 @@ this document is the map of the directory and the reasoning behind its shape.
 | `bootState.ts`                                       | What the boot shell displays. Module-scope observable, not Zustand.  |
 | `bootError.ts`                                       | Maps a thrown value to actionable copy; per-phase classifiers.       |
 | `startAuthentication.ts`                             | Keycloak silent SSO. Started, never awaited.                         |
-| `openDatabasePhase.ts`                               | The DB gate and its error copy.                                      |
+| `openDatabasePhase.ts`                               | The DB gate, its error copy, and the database-reset recovery.        |
 | `shell/`                                             | The boot shell: one markup source, plain-DOM and React renderers.    |
+| `shell/bootShellActions.ts`                          | Click dispatch for error-shell recovery buttons; arm-then-confirm.   |
 | `metrics/`                                           | User Timing marks and the dev boot report.                           |
 | `steps/`                                             | The AppShell half of the boot, one file per step.                    |
 | `keycloak.ts`, `tabManager.ts`, `googleAnalytics.ts` | Integrations the boot sets up.                                       |
@@ -66,6 +67,20 @@ bootstrap. Measured on a production build at 4 Mbps: first paint ~250ms against
 `bootShellMarkup.ts`. That is why `BootShell` uses `dangerouslySetInnerHTML`:
 it makes the handoff provably identical instead of relying on two copies
 staying in step. A unit test asserts the two DOMs are byte-equal.
+
+**Error-shell buttons are declared as data, dispatched by id.** A recovery is a
+`BootShellError.action` (`id`, `label`, `confirmLabel`, `confirmMessage`); the
+handler is registered separately by id in `shell/bootShellActions.ts`. Two
+reasons it is split that way: the markup module must stay dependency-free, and
+neither renderer can hand a button an `onClick` — both write the shell as an HTML
+string — so a single delegated listener on `document` serves both and survives a
+repaint. Every action is arm-then-confirm, since the only recovery worth offering
+this early is destructive. Today there is exactly one: resetting the database
+after a `schema-too-new` open failure (`openDatabasePhase.ts`), which registers
+its handler on the failure path rather than at module scope so a healthy boot
+pays nothing. It reuses `deleteDb()` — the same primitive as the error page's
+"Reset Workspace" button, which cannot be reused directly here because it is MUI
+plus react-router and React never mounts on this path.
 
 **The app renders over the SSO check, not after it.** What keeps a logged-in
 user's startup requests from going out anonymously is not ordering but

--- a/src/boot/openDatabasePhase.test.ts
+++ b/src/boot/openDatabasePhase.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { classifyBootError } from './bootError'
+import { BootPhase } from './bootPhases'
+import { resetBootShellActionsForTesting } from './shell/bootShellActions'
+import { BOOT_SHELL_TESTID } from './shell/bootShellMarkup'
+import { showBootShell } from './shell/showBootShell'
+
+const openDatabaseForStartup = vi.fn()
+const deleteDb = vi.fn()
+
+vi.mock('../data/db/startupOpen', () => ({
+  openDatabaseForStartup: () => openDatabaseForStartup(),
+}))
+
+vi.mock('../data/db', () => ({
+  deleteDb: () => deleteDb(),
+}))
+
+// Importing the module registers the phase's error classifier as a side effect,
+// so it has to happen after the mocks above are in place.
+const { openDatabasePhase, RESET_DATABASE_ACTION_ID } = await import(
+  './openDatabasePhase'
+)
+
+const reload = vi.fn()
+
+beforeEach(() => {
+  openDatabaseForStartup.mockReset()
+  deleteDb.mockReset().mockResolvedValue(undefined)
+  reload.mockReset()
+  // jsdom's location.reload is not writable; replacing the whole descriptor is.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, reload },
+  })
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  resetBootShellActionsForTesting()
+})
+
+/** Paints the error shell the way bootstrap.tsx does on a fatal DB failure. */
+const paintErrorShell = (cause: unknown): HTMLButtonElement | null => {
+  const root = document.createElement('div')
+  root.id = 'root'
+  document.body.appendChild(root)
+
+  showBootShell({ error: classifyBootError(BootPhase.DATABASE, cause) })
+
+  return (
+    root
+      .querySelector(`[data-testid="${BOOT_SHELL_TESTID}"]`)
+      ?.querySelector('button') ?? null
+  )
+}
+
+const failWith = async (result: Record<string, unknown>): Promise<unknown> => {
+  openDatabaseForStartup.mockResolvedValue(result)
+  try {
+    await openDatabasePhase()
+  } catch (cause) {
+    return cause
+  }
+  throw new Error('openDatabasePhase resolved instead of throwing')
+}
+
+describe('openDatabasePhase database reset action', () => {
+  it('resolves quietly when the database opens', async () => {
+    openDatabaseForStartup.mockResolvedValue({ kind: 'ok' })
+
+    await expect(openDatabasePhase()).resolves.toBeUndefined()
+  })
+
+  it('offers the reset button on a schema-too-new failure', async () => {
+    const cause = await failWith({
+      kind: 'schema-too-new',
+      onDiskVersion: 12,
+      expectedVersion: 10,
+    })
+
+    const button = paintErrorShell(cause)
+    expect(button?.getAttribute('data-boot-action')).toBe(
+      RESET_DATABASE_ACTION_ID,
+    )
+    expect(button?.textContent).toBe('Reset Workspace and Reload Cytoscape')
+  })
+
+  it('states the one thing to do, and keeps the versions as the detail', async () => {
+    // Deliberately terse. There is exactly one way out of this state, so
+    // narrating how it arose (two builds on one address, a switched branch, a
+    // rollback) would only bury the instruction. The versions stay because they
+    // are the first thing anyone debugging this asks for.
+    const cause = await failWith({
+      kind: 'schema-too-new',
+      onDiskVersion: 12,
+      expectedVersion: 10,
+    })
+
+    const error = classifyBootError(BootPhase.DATABASE, cause)
+
+    expect(error.message).toBe('Reset your local workspace to continue.')
+    expect(error.detail).toBe('Stored version 12; this build expects 10.')
+  })
+
+  it('reports an unknown on-disk version without printing undefined', async () => {
+    const cause = await failWith({
+      kind: 'schema-too-new',
+      expectedVersion: 10,
+    })
+
+    const error = classifyBootError(BootPhase.DATABASE, cause)
+
+    expect(error.detail).toBe('Stored version unknown; this build expects 10.')
+  })
+
+  it('deletes the database and reloads only after the confirm click', async () => {
+    const cause = await failWith({
+      kind: 'schema-too-new',
+      onDiskVersion: 12,
+      expectedVersion: 10,
+    })
+    const button = paintErrorShell(cause)
+
+    button?.click()
+    expect(deleteDb).not.toHaveBeenCalled()
+
+    button?.click()
+    await vi.waitFor(() => {
+      expect(deleteDb).toHaveBeenCalledTimes(1)
+    })
+    // Same primitive the error page's "Reset Workspace" button reaches through
+    // WorkspaceStore.resetWorkspace().
+    await vi.waitFor(() => {
+      expect(reload).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('offers no button when IndexedDB is merely unavailable', async () => {
+    const cause = await failWith({
+      kind: 'unavailable',
+      reason: 'InvalidStateError',
+    })
+
+    // Clearing the database is not the fix for private browsing, and offering
+    // it would send people to destroy data for no reason.
+    expect(paintErrorShell(cause)).toBeNull()
+    expect(deleteDb).not.toHaveBeenCalled()
+  })
+})
+
+// Deliberately no resetBootErrorClassifiersForTesting() here: this phase
+// registers its classifier as an import-time side effect, so clearing it
+// between tests would leave every later test with the generic error and no
+// action button.

--- a/src/boot/openDatabasePhase.test.ts
+++ b/src/boot/openDatabasePhase.test.ts
@@ -27,7 +27,7 @@ const reload = vi.fn()
 
 beforeEach(() => {
   openDatabaseForStartup.mockReset()
-  deleteDb.mockReset().mockResolvedValue(undefined)
+  deleteDb.mockReset().mockResolvedValue(true)
   reload.mockReset()
   // jsdom's location.reload is not writable; replacing the whole descriptor is.
   Object.defineProperty(window, 'location', {

--- a/src/boot/openDatabasePhase.ts
+++ b/src/boot/openDatabasePhase.ts
@@ -52,11 +52,17 @@ export const RESET_DATABASE_ACTION_ID = 'reset-database'
 const registerResetAction = (): void => {
   registerBootShellAction(RESET_DATABASE_ACTION_ID, async () => {
     logDb.info('[openDatabasePhase] resetting the local database on request')
-    await deleteDb()
-    // Reload rather than continue: the boot already aborted partway through, so
-    // rerunning it from the top against the fresh database is the honest
-    // recovery.
-    window.location.reload()
+    const success = await deleteDb()
+    
+    if (success) {
+      // Reload rather than continue: the boot already aborted partway through, so
+      // rerunning it from the top against the fresh database is the honest
+      // recovery.
+      window.location.reload()
+    } else {
+      // Throw so the button re-enables and the user can try again
+      throw new Error('database deletion failed')
+    }
   })
 }
 

--- a/src/boot/openDatabasePhase.ts
+++ b/src/boot/openDatabasePhase.ts
@@ -1,9 +1,12 @@
+import { deleteDb } from '../data/db'
 import {
   openDatabaseForStartup,
   type DbOpenResult,
 } from '../data/db/startupOpen'
+import { logDb } from '../debug'
 import { registerBootErrorClassifier } from './bootError'
 import { BootPhase } from './bootPhases'
+import { registerBootShellAction } from './shell/bootShellActions'
 import type { BootShellError } from './shell/bootShellMarkup'
 
 // The DATABASE phase: open IndexedDB explicitly, and turn a failure into
@@ -24,26 +27,61 @@ class DbOpenError extends Error {
   }
 }
 
+export const RESET_DATABASE_ACTION_ID = 'reset-database'
+
+/**
+ * Wires up the recovery behind the error shell's button.
+ *
+ * This is the same recovery the error page offers ("Reset Workspace and Reload
+ * Cytoscape", src/features/Error.tsx) — deliberately the same wording, because
+ * it is the same destructive operation reached through a different door.
+ *
+ * That button cannot be reused directly: it is MUI plus react-router plus store
+ * hooks, and this failure aborts the boot before React mounts. What is shared is
+ * the primitive underneath it — deleteDb(), which the error page reaches through
+ * WorkspaceStore.resetWorkspace().
+ *
+ * Still gated behind arm-then-confirm: destroying the local workspace is
+ * unrecoverable, and this shell is too early to have the app's
+ * ConfirmationDialog available.
+ *
+ * Called on the failure path rather than at module scope: registering installs a
+ * document-level click listener, and a boot that opens the database fine should
+ * not pay for a button it will never paint.
+ */
+const registerResetAction = (): void => {
+  registerBootShellAction(RESET_DATABASE_ACTION_ID, async () => {
+    logDb.info('[openDatabasePhase] resetting the local database on request')
+    await deleteDb()
+    // Reload rather than continue: the boot already aborted partway through, so
+    // rerunning it from the top against the fresh database is the honest
+    // recovery.
+    window.location.reload()
+  })
+}
+
 const describe = (
   result: Exclude<DbOpenResult, { kind: 'ok' }>,
 ): BootShellError =>
   result.kind === 'schema-too-new'
     ? {
         title: 'This browser has a newer Cytoscape Web database',
-        message:
-          `Your browser stores a Cytoscape Web database at version ${result.onDiskVersion ?? 'unknown'}, ` +
-          `but this build expects version ${result.expectedVersion}. This happens when two ` +
-          'versions of Cytoscape Web are served from the same address — most often a local dev ' +
-          'server switched between branches, or a deployment rolled back to an earlier build.',
-        // Instructions, not a button: clearing the database destroys the whole
-        // local workspace, and a mis-click here is unrecoverable.
-        //
-        // The port tip only helps a developer, but a developer is who almost
-        // always sees this — an end user reaches it only through a rollback.
-        detail:
-          'Clear the "cyweb-db" database in DevTools > Application > IndexedDB to start fresh; ' +
-          "this permanently deletes this browser's local workspace. When running locally, " +
-          'serving the other build on a different port gives it its own database instead.',
+        // One sentence, and it is the instruction. There is exactly one way out
+        // of this state, so explaining how the state arose (two builds on one
+        // address, a switched branch, a rollback) only buries the thing to do.
+        // The button below is the answer; its confirm step spells out the cost.
+        message: 'Reset your local workspace to continue.',
+        // Not prose — the diagnostic, and the first thing anyone debugging this
+        // asks for. One short line in the detail style.
+        detail: `Stored version ${result.onDiskVersion ?? 'unknown'}; this build expects ${result.expectedVersion}.`,
+        action: {
+          id: RESET_DATABASE_ACTION_ID,
+          label: 'Reset Workspace and Reload Cytoscape',
+          confirmLabel: 'Confirm — permanently delete',
+          confirmMessage:
+            "This permanently deletes this browser's local workspace, including every network " +
+            'in it. Networks saved to NDEx are not affected.',
+        },
       }
     : {
         title: 'Cytoscape Web cannot access local storage',
@@ -64,6 +102,11 @@ registerBootErrorClassifier(BootPhase.DATABASE, (cause) =>
 export const openDatabasePhase = async (): Promise<void> => {
   const result = await openDatabaseForStartup()
   if (result.kind !== 'ok') {
+    // Before the throw, so the handler exists by the time the error shell is
+    // painted and the reader can reach the button.
+    if (result.kind === 'schema-too-new') {
+      registerResetAction()
+    }
     throw new DbOpenError(result)
   }
 }

--- a/src/boot/shell/bootShell.test.tsx
+++ b/src/boot/shell/bootShell.test.tsx
@@ -102,6 +102,22 @@ describe('BootShell / showBootShell parity', () => {
         },
       },
     ],
+    [
+      'error mode with a recovery action',
+      {
+        error: {
+          title: 'This browser has a newer database',
+          message: 'Open the newer deployment in a different browser profile.',
+          detail: 'onDisk=12 expected=11',
+          action: {
+            id: 'reset-database',
+            label: 'Reset Workspace and Reload Cytoscape',
+            confirmLabel: 'Confirm — permanently delete',
+            confirmMessage: 'This permanently deletes the local workspace.',
+          },
+        },
+      },
+    ],
   ])('renders identical DOM for %s', (_label, options) => {
     const root = mountRoot()
     showBootShell(options)
@@ -253,6 +269,71 @@ describe('bootShellInnerHtml', () => {
 
     expect(html).toContain('<svg')
     expect(html).not.toContain('<img')
+  })
+
+  it('omits the action button when the error declares no recovery', () => {
+    const root = mountRoot()
+    showBootShell({
+      error: { title: 'Storage unavailable', message: 'Private browsing?' },
+    })
+    const shell = root.querySelector(`[data-testid="${BOOT_SHELL_TESTID}"]`)
+
+    // Clearing the database is not the fix for a blocked IndexedDB, and
+    // offering it here would send people to destroy data for no reason.
+    expect(shell?.querySelector('button')).toBeNull()
+  })
+
+  it('renders the action button armed-off, with the confirm line hidden', () => {
+    const root = mountRoot()
+    showBootShell({
+      error: {
+        title: 'This browser has a newer database',
+        message: 'Two builds share this address.',
+        action: {
+          id: 'reset-database',
+          label: 'Reset Workspace and Reload Cytoscape',
+          confirmLabel: 'Confirm — permanently delete',
+          confirmMessage: 'This permanently deletes the local workspace.',
+        },
+      },
+    })
+    const shell = root.querySelector(`[data-testid="${BOOT_SHELL_TESTID}"]`)
+    const button = shell?.querySelector('button')
+
+    expect(button?.textContent).toBe('Reset Workspace and Reload Cytoscape')
+    expect(button?.getAttribute('data-boot-action')).toBe('reset-database')
+    expect(button?.classList.contains('boot-shell-error-button-armed')).toBe(
+      false,
+    )
+    // Present but hidden, so arming changes attributes only — never the markup
+    // string the React renderer diffs against.
+    const confirm = shell?.querySelector('.boot-shell-error-action-confirm')
+    expect(confirm?.hasAttribute('hidden')).toBe(true)
+  })
+
+  it('escapes quotes in action attribute values', () => {
+    // escapeHtml alone leaves quotes untouched, which would end the attribute
+    // and let the rest of the value become attributes of its own.
+    const host = document.createElement('div')
+    host.innerHTML = bootShellInnerHtml({
+      error: {
+        title: 'T',
+        message: 'M',
+        action: {
+          id: 'x" onclick="alert(1)',
+          label: 'L',
+          confirmLabel: 'C',
+          confirmMessage: 'CM',
+        },
+      },
+    })
+    const button = host.querySelector('button')
+
+    expect(button?.hasAttribute('onclick')).toBe(false)
+    // The quote stayed inside the value rather than terminating it.
+    expect(button?.getAttribute('data-boot-action')).toBe(
+      'x" onclick="alert(1)',
+    )
   })
 })
 

--- a/src/boot/shell/bootShellActions.test.ts
+++ b/src/boot/shell/bootShellActions.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  registerBootShellAction,
+  resetBootShellActionsForTesting,
+} from './bootShellActions'
+import { BOOT_SHELL_TESTID } from './bootShellMarkup'
+import { showBootShell } from './showBootShell'
+
+const ACTION_ID = 'reset-database'
+
+const paintWithAction = (): HTMLButtonElement => {
+  const root = document.createElement('div')
+  root.id = 'root'
+  document.body.appendChild(root)
+
+  showBootShell({
+    error: {
+      title: 'This browser has a newer database',
+      message: 'Two builds share this address.',
+      action: {
+        id: ACTION_ID,
+        label: 'Reset Workspace and Reload Cytoscape',
+        confirmLabel: 'Confirm — permanently delete',
+        confirmMessage: "This permanently deletes this browser's workspace.",
+      },
+    },
+  })
+
+  const button = root
+    .querySelector(`[data-testid="${BOOT_SHELL_TESTID}"]`)
+    ?.querySelector('button')
+  if (button === null || button === undefined) {
+    throw new Error('the shell painted without an action button')
+  }
+  return button
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  resetBootShellActionsForTesting()
+})
+
+describe('boot shell recovery actions', () => {
+  it('arms on the first click instead of running', () => {
+    const run = vi.fn()
+    registerBootShellAction(ACTION_ID, run)
+    const button = paintWithAction()
+
+    button.click()
+
+    // The whole point of the two-step: the action destroys the local workspace
+    // irrecoverably, and a mis-click must not be enough to trigger it.
+    expect(run).not.toHaveBeenCalled()
+    expect(button.textContent).toBe('Confirm — permanently delete')
+    expect(button.classList.contains('boot-shell-error-button-armed')).toBe(
+      true,
+    )
+    expect(
+      document
+        .querySelector('.boot-shell-error-action-confirm')
+        ?.hasAttribute('hidden'),
+    ).toBe(false)
+  })
+
+  it('runs on the second click', async () => {
+    const run = vi.fn().mockResolvedValue(undefined)
+    registerBootShellAction(ACTION_ID, run)
+    const button = paintWithAction()
+
+    button.click()
+    button.click()
+
+    expect(run).toHaveBeenCalledTimes(1)
+    // Disabled while running: these actions end in a reload, and a third click
+    // landing on a half-deleted database has nothing good to do.
+    expect(button.hasAttribute('disabled')).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(button.hasAttribute('disabled')).toBe(true)
+    })
+  })
+
+  it('re-enables the button when the action fails', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('delete blocked'))
+    registerBootShellAction(ACTION_ID, run)
+    const button = paintWithAction()
+
+    button.click()
+    button.click()
+
+    // Still armed, so the retry is a single click rather than two.
+    await vi.waitFor(() => {
+      expect(button.hasAttribute('disabled')).toBe(false)
+    })
+    expect(button.classList.contains('boot-shell-error-button-armed')).toBe(
+      true,
+    )
+  })
+
+  it('ignores clicks for an id with no registered handler', () => {
+    const button = paintWithAction()
+
+    // Arms regardless of registration, but must not throw on the run click.
+    expect(() => {
+      button.click()
+      button.click()
+    }).not.toThrow()
+  })
+
+  it('survives a repaint of the shell', () => {
+    // Delegation, not a per-button listener: the error shell is written as an
+    // HTML string, so a repaint replaces the button element entirely.
+    const run = vi.fn()
+    registerBootShellAction(ACTION_ID, run)
+    paintWithAction()
+    document.body.innerHTML = ''
+    const repainted = paintWithAction()
+
+    repainted.click()
+    repainted.click()
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/boot/shell/bootShellActions.test.ts
+++ b/src/boot/shell/bootShellActions.test.ts
@@ -99,13 +99,17 @@ describe('boot shell recovery actions', () => {
   })
 
   it('ignores clicks for an id with no registered handler', () => {
+    // Register an unrelated action to attach the document-level listener.
+    registerBootShellAction('some-other-id', vi.fn())
     const button = paintWithAction()
 
-    // Arms regardless of registration, but must not throw on the run click.
+    // The click returns before arming because no handler is registered for
+    // this button's action id.
     expect(() => {
       button.click()
       button.click()
     }).not.toThrow()
+    expect(button.classList.contains('boot-shell-error-button-armed')).toBe(false)
   })
 
   it('survives a repaint of the shell', () => {

--- a/src/boot/shell/bootShellActions.ts
+++ b/src/boot/shell/bootShellActions.ts
@@ -1,0 +1,104 @@
+import {
+  BOOT_SHELL_ACTION_ATTR,
+  BOOT_SHELL_ACTION_CONFIRM_CLASS,
+  BOOT_SHELL_ARMED_CLASS,
+  BOOT_SHELL_ARMED_LABEL_ATTR,
+} from './bootShellMarkup'
+
+// Click handling for the boot shell's recovery buttons.
+//
+// Separate from bootShellMarkup because that module is shared by both renderers
+// and must stay dependency-free; separate from the phases because a phase should
+// not have to know how the shell is painted.
+//
+// One delegated listener on `document` rather than a listener per button: the
+// error shell is written as an HTML string by whichever renderer got there
+// first — plain DOM via repaintBootShell(), or React via dangerouslySetInnerHTML
+// — so neither can hand a button an onClick, and a repaint would drop a
+// directly-attached listener. Delegation is indifferent to both.
+//
+// Deliberately dependency-free for the same reason as the markup: this is
+// reachable before the app chunks land.
+
+type BootShellActionHandler = () => void | Promise<void>
+
+const handlers = new Map<string, BootShellActionHandler>()
+let listening = false
+
+/**
+ * First click arms, second click runs.
+ *
+ * Every action offered here destroys local data irrecoverably, and the shell has
+ * no MUI ConfirmationDialog available this early, so the button is its own
+ * confirmation step.
+ */
+const arm = (button: HTMLElement): void => {
+  const armedLabel = button.getAttribute(BOOT_SHELL_ARMED_LABEL_ATTR)
+  if (armedLabel !== null) {
+    button.textContent = armedLabel
+  }
+  button.classList.add(BOOT_SHELL_ARMED_CLASS)
+  button.parentElement
+    ?.querySelector(`.${BOOT_SHELL_ACTION_CONFIRM_CLASS}`)
+    ?.removeAttribute('hidden')
+}
+
+const onClick = (event: Event): void => {
+  const target = event.target
+  if (!(target instanceof Element)) {
+    return
+  }
+
+  const button = target.closest(`[${BOOT_SHELL_ACTION_ATTR}]`)
+  if (!(button instanceof HTMLElement) || button.hasAttribute('disabled')) {
+    return
+  }
+
+  const id = button.getAttribute(BOOT_SHELL_ACTION_ATTR)
+  const run = id === null ? undefined : handlers.get(id)
+  if (run === undefined) {
+    return
+  }
+
+  if (!button.classList.contains(BOOT_SHELL_ARMED_CLASS)) {
+    arm(button)
+    return
+  }
+
+  // Disable before running: these actions end in a reload, and a second click
+  // landing on a half-deleted database has nothing good to do.
+  button.setAttribute('disabled', '')
+  void (async () => {
+    try {
+      await run()
+    } catch {
+      // The shell is already in its terminal error state and the action's own
+      // logging has run; re-enable so the reader can try again.
+      button.removeAttribute('disabled')
+    }
+  })()
+}
+
+/**
+ * Registers the handler for an action id declared by a `BootShellErrorAction`.
+ * Safe to call at module scope — the listener is installed once, lazily.
+ */
+export const registerBootShellAction = (
+  id: string,
+  run: BootShellActionHandler,
+): void => {
+  handlers.set(id, run)
+
+  if (!listening && typeof document !== 'undefined') {
+    document.addEventListener('click', onClick)
+    listening = true
+  }
+}
+
+export const resetBootShellActionsForTesting = (): void => {
+  handlers.clear()
+  if (listening && typeof document !== 'undefined') {
+    document.removeEventListener('click', onClick)
+    listening = false
+  }
+}

--- a/src/boot/shell/bootShellMarkup.ts
+++ b/src/boot/shell/bootShellMarkup.ts
@@ -512,7 +512,7 @@ const errorActionHtml = (action: BootShellErrorAction): string => `
         )}" ${BOOT_SHELL_ARMED_LABEL_ATTR}="${escapeAttr(
           action.confirmLabel,
         )}">${escapeHtml(action.label)}</button>
-        <p class="boot-shell-error-action-confirm" hidden>${escapeHtml(
+        <p class="${BOOT_SHELL_ACTION_CONFIRM_CLASS}" hidden>${escapeHtml(
           action.confirmMessage,
         )}</p>
       </div>`

--- a/src/boot/shell/bootShellMarkup.ts
+++ b/src/boot/shell/bootShellMarkup.ts
@@ -20,13 +20,39 @@
 
 export const BOOT_SHELL_TESTID = 'boot-shell'
 
+/** Carries the action id the delegated click listener dispatches on. */
+export const BOOT_SHELL_ACTION_ATTR = 'data-boot-action'
+/** Label the button swaps to once armed. */
+export const BOOT_SHELL_ARMED_LABEL_ATTR = 'data-boot-action-armed-label'
+export const BOOT_SHELL_ARMED_CLASS = 'boot-shell-error-button-armed'
+export const BOOT_SHELL_ACTION_CONFIRM_CLASS = 'boot-shell-error-action-confirm'
+
 /** `full` includes the toolbar strip; `content` sits below the real toolbar. */
 export type BootShellRegion = 'full' | 'content'
+
+/**
+ * A recovery the reader can trigger from the error shell.
+ *
+ * Deliberately data, not a callback: this module is shared by both renderers
+ * and must stay dependency-free, so it only declares the button. The handler is
+ * registered separately by id — see `registerBootShellAction`.
+ *
+ * Every action here is arm-then-confirm (the first click swaps the label to
+ * `confirmLabel` and reveals `confirmMessage`), because the only thing worth
+ * offering at this point is destructive.
+ */
+export interface BootShellErrorAction {
+  id: string
+  label: string
+  confirmLabel: string
+  confirmMessage: string
+}
 
 export interface BootShellError {
   title: string
   message: string
   detail?: string
+  action?: BootShellErrorAction
 }
 
 export interface BootShellOptions {
@@ -287,6 +313,61 @@ body {
   color: #666666;
   word-break: break-word;
 }
+.boot-shell-error-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+.boot-shell-error-action [hidden] {
+  display: none;
+}
+/*
+ * Form controls do not inherit font, so the explicit "font: inherit" is what
+ * keeps this on the shell's system-font stack rather than the UA's button font.
+ * (No backticks in this stylesheet — it is a template literal.)
+ */
+.boot-shell-error-button {
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #c62828;
+  background: none;
+  border: 1px solid #c62828;
+  border-radius: 4px;
+  padding: 6px 16px;
+  cursor: pointer;
+}
+.boot-shell-error-button:hover {
+  background-color: rgba(198, 40, 40, 0.08);
+}
+.boot-shell-error-button:focus-visible {
+  outline: 2px solid #c62828;
+  outline-offset: 2px;
+}
+/* Armed: filled, so "one more click destroys data" reads at a glance. */
+.boot-shell-error-button.boot-shell-error-button-armed {
+  color: #ffffff;
+  background-color: #c62828;
+}
+.boot-shell-error-button.boot-shell-error-button-armed:hover {
+  background-color: #a91d1d;
+}
+.boot-shell-error-button[disabled] {
+  opacity: 0.6;
+  cursor: default;
+}
+/*
+ * Two classes deep on purpose: the .boot-shell-error p rule above is more
+ * specific than a lone class selector, and would otherwise win on font-size.
+ */
+.boot-shell-error .boot-shell-error-action-confirm {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #c62828;
+  max-width: 420px;
+}
 .boot-shell-bottom {
   height: 40px;
   flex-shrink: 0;
@@ -338,6 +419,11 @@ const ERROR_ICON_SVG = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/s
 const escapeHtml = (value: string): string =>
   value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
+// Separate from escapeHtml, which is for text nodes and leaves quotes alone:
+// an unescaped quote in an attribute value would end the attribute.
+const escapeAttr = (value: string): string =>
+  escapeHtml(value).replace(/"/g, '&quot;')
+
 const repeat = (count: number, html: string): string => html.repeat(count)
 
 export const bootShellVersion = (): string =>
@@ -345,7 +431,9 @@ export const bootShellVersion = (): string =>
 
 export const bootShellBuildTime = (): string => {
   const raw =
-    typeof REACT_APP_BUILD_TIME !== 'undefined' ? REACT_APP_BUILD_TIME : 'Unknown'
+    typeof REACT_APP_BUILD_TIME !== 'undefined'
+      ? REACT_APP_BUILD_TIME
+      : 'Unknown'
   if (raw === 'Unknown') {
     return raw
   }
@@ -413,6 +501,22 @@ const statusHtml = (): string => `
 // Terminal state: no spinner and no "may take some time" — both actively
 // mislead when nothing more is coming. The version and build time stay, since
 // that is precisely what someone diagnosing this needs to read off the screen.
+// The confirm line is rendered up front and hidden rather than injected on
+// click, so arming the button never changes the markup this module produces —
+// only attributes and one `hidden` flag. That keeps the string the React
+// renderer diffs against stable, same reason the status message is imperative.
+const errorActionHtml = (action: BootShellErrorAction): string => `
+      <div class="boot-shell-error-action">
+        <button type="button" class="boot-shell-error-button" ${BOOT_SHELL_ACTION_ATTR}="${escapeAttr(
+          action.id,
+        )}" ${BOOT_SHELL_ARMED_LABEL_ATTR}="${escapeAttr(
+          action.confirmLabel,
+        )}">${escapeHtml(action.label)}</button>
+        <p class="boot-shell-error-action-confirm" hidden>${escapeHtml(
+          action.confirmMessage,
+        )}</p>
+      </div>`
+
 const errorHtml = (error: BootShellError): string => `
     <div class="boot-shell-error" role="alert">
       <div class="boot-shell-error-icon">${ERROR_ICON_SVG}</div>
@@ -422,7 +526,7 @@ const errorHtml = (error: BootShellError): string => `
           ? ''
           : `
       <p class="boot-shell-error-detail">${escapeHtml(error.detail)}</p>`
-      }
+      }${error.action === undefined ? '' : errorActionHtml(error.action)}
     </div>`
 
 /**
@@ -458,10 +562,7 @@ export const bootShellInnerHtml = (
   <div class="boot-shell-body">
     <div class="boot-shell-left">
       <div class="boot-shell-left-tabs">
-        ${repeat(
-          2,
-          '<div class="boot-shell-block boot-shell-left-tab"></div>',
-        )}
+        ${repeat(2, '<div class="boot-shell-block boot-shell-left-tab"></div>')}
       </div>
       ${repeat(3, '<div class="boot-shell-block boot-shell-left-row"></div>')}
     </div>

--- a/src/data/db/index.ts
+++ b/src/data/db/index.ts
@@ -232,34 +232,46 @@ export const closeDb = async (): Promise<void> => {
  * - This should create the completely new DB with no data.
  *
  */
+let deletePromise: Promise<boolean> | null = null
+
 export const deleteDb = async (): Promise<boolean> => {
-  try {
-    if (db) {
-      db.close()
-      logDb.info('[DeleteDB] DB is closed')
-    }
-    
-    // Dexie.delete hangs if another tab holds the connection. Enforce a timeout
-    // so we can report the failure instead of deadlocking.
-    const deleted = await Promise.race([
-      Dexie.delete(DB_NAME).then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000))
-    ])
-
-    if (!deleted) {
-      logDb.error(`[DeleteDB] Failed to delete ${DB_NAME}: blocked or timed out`)
-      return false
-    }
-
-    logDb.info(`[DeleteDB]  ${DB_NAME} is deleted`)
-    db = new CyDB(DB_NAME)
-    await db.open()
-    logDb.info(`[DeleteDB] ${DB_NAME} is opened and ready to use`)
-    return true
-  } catch (err) {
-    logDb.error('[DeleteDB] Failed to reset DB', err)
-    return false
+  if (deletePromise !== null) {
+    return deletePromise
   }
+
+  deletePromise = (async () => {
+    try {
+      if (db) {
+        db.close()
+        logDb.info('[DeleteDB] DB is closed')
+      }
+      
+      // Dexie.delete hangs if another tab holds the connection. Enforce a timeout
+      // so we can report the failure instead of deadlocking.
+      const deleted = await Promise.race([
+        Dexie.delete(DB_NAME).then(() => true),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000)),
+      ])
+
+      if (!deleted) {
+        logDb.error(`[DeleteDB] Failed to delete ${DB_NAME}: blocked or timed out`)
+        return false
+      }
+
+      logDb.info(`[DeleteDB]  ${DB_NAME} is deleted`)
+      db = new CyDB(DB_NAME)
+      await db.open()
+      logDb.info(`[DeleteDB] ${DB_NAME} is opened and ready to use`)
+      return true
+    } catch (err) {
+      logDb.error('[DeleteDB] Failed to reset DB', err)
+      return false
+    } finally {
+      deletePromise = null
+    }
+  })()
+
+  return deletePromise
 }
 export const getAllNetworkKeys = async (): Promise<IdType[]> => {
   return (await db.cyNetworks.toCollection().primaryKeys()) as IdType[]

--- a/src/data/db/index.ts
+++ b/src/data/db/index.ts
@@ -232,19 +232,33 @@ export const closeDb = async (): Promise<void> => {
  * - This should create the completely new DB with no data.
  *
  */
-export const deleteDb = async (): Promise<void> => {
+export const deleteDb = async (): Promise<boolean> => {
   try {
     if (db) {
       db.close()
       logDb.info('[DeleteDB] DB is closed')
     }
-    await Dexie.delete(DB_NAME)
+    
+    // Dexie.delete hangs if another tab holds the connection. Enforce a timeout
+    // so we can report the failure instead of deadlocking.
+    const deleted = await Promise.race([
+      Dexie.delete(DB_NAME).then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000))
+    ])
+
+    if (!deleted) {
+      logDb.error(`[DeleteDB] Failed to delete ${DB_NAME}: blocked or timed out`)
+      return false
+    }
+
     logDb.info(`[DeleteDB]  ${DB_NAME} is deleted`)
     db = new CyDB(DB_NAME)
     await db.open()
     logDb.info(`[DeleteDB] ${DB_NAME} is opened and ready to use`)
+    return true
   } catch (err) {
     logDb.error('[DeleteDB] Failed to reset DB', err)
+    return false
   }
 }
 export const getAllNetworkKeys = async (): Promise<IdType[]> => {


### PR DESCRIPTION
The DATABASE boot phase failed with instructions to clear "cyweb-db" by hand in DevTools > Application > IndexedDB. Replace that with the action itself.

Recoveries are declared as data on BootShellError.action and dispatched by id through the new shell/bootShellActions.ts. Two reasons for the indirection: the markup module must stay dependency-free, and neither renderer can attach an onClick since both write the shell as an HTML string -- so one delegated listener on document serves both and survives a repaint. Registration happens on the failure path rather than at module scope, so a healthy boot does not pay for a listener it will never use.

The action reuses the error page's wording and its deleteDb() primitive. Error.tsx itself cannot be reused: it is MUI plus react-router plus store hooks, and this failure aborts the boot before React mounts.

Kept from the previous behaviour's reasoning:

- Arm, then confirm. The first click swaps the label and reveals what will be destroyed; only the second click runs. Clearing the database has no undo and the shell is too early for the app's ConfirmationDialog.
- Never offered for `unavailable`. Clearing data does not fix a blocked IndexedDB (private browsing), and offering it there would send people to destroy data for no reason.

Also cut the schema-too-new copy down to the instruction. It explained how the state arises -- two builds on one address, a switched branch, a rollback -- plus a tip about serving on another port, which buried the one thing to do. Now: "Reset your local workspace to continue." with the versions as the detail line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a boot recovery option for incompatible database schema (`schema-too-new`) with a destructive, two-step “Reset Workspace and Reload” flow.

- **Bug Fixes**
  - Prevented the recovery control from appearing when local storage is blocked/unavailable.
  - Improved reset reliability so users can retry if the first reset attempt fails.

- **Documentation**
  - Updated startup/boot shell documentation to explain the recovery button behavior and confirmation flow.

- **Tests**
  - Extended HTML/DOM parity and security checks for recovery actions, including proper attribute escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->