### PR TITLE
Install React and service apps from one ?installApp= parameter

### DIFF
--- a/docs/design/module-federation/specifications/app-install-from-appstore.md
+++ b/docs/design/module-federation/specifications/app-install-from-appstore.md
@@ -44,7 +44,7 @@ The App Store redirects or links to Cytoscape Web with an install parameter, suc
 repeatable, and installs service apps as well as React apps — the fetched payload
 decides which. It replaced `?addserviceapp=`, which is removed.)
 
-Cytoscape Web consumes the parameter during startup, fetches and validates each URL, asks the user to confirm what will be installed, and removes the parameter from the URL. Confirming adds the app to the workspace and the in-memory catalog.
+Cytoscape Web consumes the parameter during startup, fetches and validates each URL, asks the user to confirm what will be installed, and removes the parameter from the URL. Confirming then installs by kind: a React app is added to `workspace.installedApps` and merged into the in-memory catalog, while a service app is registered through `AppStore.addService(url)`.
 
 ### Pros
 

--- a/docs/design/module-federation/specifications/app-install-from-appstore.md
+++ b/docs/design/module-federation/specifications/app-install-from-appstore.md
@@ -40,9 +40,11 @@ The App Store redirects or links to Cytoscape Web with an install parameter, suc
 `?installApp=https%3A%2F%2Fapps.cytoscape.org%2Fweb%2Fhello%2Fmanifest.json`
 
 (The parameter name `installApp` is the canonical one adopted by
-[workspace-app-install-design.md](./workspace-app-install-design.md) §7.2.)
+[workspace-app-install-design.md](./workspace-app-install-design.md) §7.2. It is
+repeatable, and installs service apps as well as React apps — the fetched payload
+decides which. It replaced `?addserviceapp=`, which is removed.)
 
-Cytoscape Web consumes the parameter during startup or route initialization, validates the app entry, adds it to the in-memory catalog, and then removes the parameter from the URL.
+Cytoscape Web consumes the parameter during startup, fetches and validates each URL, asks the user to confirm what will be installed, and removes the parameter from the URL. Confirming adds the app to the workspace and the in-memory catalog.
 
 ### Pros
 

--- a/docs/design/module-federation/specifications/workspace-app-install-design.md
+++ b/docs/design/module-federation/specifications/workspace-app-install-design.md
@@ -336,9 +336,10 @@ carries a **pointer to app metadata**, not the metadata itself:
 https://web.cytoscape.org/?installApp=https%3A%2F%2Fapps.cytoscape.org%2Fweb%2Fhello%2Fmanifest.json
 ```
 
-`?installApp=` installs **both app kinds** and is **repeatable** (cytoscape-web
-#639). It replaced `?addserviceapp=`, which is removed. `runInstallIntents`
-fetches each URL and `classifyInstallPayload` resolves what is behind it:
+`?installApp=` installs **both app kinds** and is **repeatable**
+(cytoscape-web `#639`). It replaced `?addserviceapp=`, which is removed.
+`runInstallIntents` fetches each URL and `classifyInstallPayload` resolves what
+is behind it:
 
 | | React app | Service app |
 | --- | --- | --- |

--- a/docs/design/module-federation/specifications/workspace-app-install-design.md
+++ b/docs/design/module-federation/specifications/workspace-app-install-design.md
@@ -330,11 +330,34 @@ uninstallApp(id: string): Promise<void>
 
 The App Store **Install** button links/redirects to Cytoscape Web with an
 install intent. To avoid embedding large metadata in the URL, the parameter
-carries a **pointer to a single-entry manifest**, not the entry itself:
+carries a **pointer to app metadata**, not the metadata itself:
 
 ```text
 https://web.cytoscape.org/?installApp=https%3A%2F%2Fapps.cytoscape.org%2Fweb%2Fhello%2Fmanifest.json
 ```
+
+`?installApp=` installs **both app kinds** and is **repeatable** (cytoscape-web
+#639). It replaced `?addserviceapp=`, which is removed. `runInstallIntents`
+fetches each URL and `classifyInstallPayload` resolves what is behind it:
+
+| | React app | Service app |
+| --- | --- | --- |
+| Payload | array, or a single entry object, with a valid `url` | object with `cyWebActions` / `cyWebMenuItem` / `serviceInputDefinition` |
+| Validated by | `parseManifest()` | `ServiceMetadataSchema` |
+| Origin gate | `appInstallAllowedOrigins` (§9) | none |
+| Installed by | `installApp(entry, { activate: true })` | `AppStore.addService(url)` |
+
+An optional `type` field (`client` / `service`, the `AppType` enum) overrides the
+structural check when the App Store starts emitting it. It is not required:
+making it so would break every manifest already published.
+
+**Nothing installs inside the boot phase.** The URL comes from an arbitrary link,
+so `INTENTS` only resolves the apps and returns them as `PendingAppInstall[]`.
+`AppShell` names each one — kind, version, author, description, source URL — in
+`AppInstallConfirmationDialog`, and installs on confirm. Failures are isolated
+per URL: one dead host does not lose the others. A React app from a
+non-allow-listed origin is rejected before the dialog, so the user is never asked
+about an install that cannot happen.
 
 `AppShell` (which already uses `useSearchParams`) consumes it:
 
@@ -343,18 +366,28 @@ sequenceDiagram
     participant Store as App Store
     participant Browser
     participant Shell as AppShell
+    participant User
     participant Mgr as useAppManager
     participant WS as WorkspaceStore
 
-    Store->>Browser: Open /?installApp=#lt;manifestUrl#gt;
+    Store->>Browser: Open /?installApp=#lt;url#gt;
     Browser->>Shell: Initial load (search params)
-    Shell->>Shell: Read installApp param
-    Shell->>Mgr: fetch + parseManifest(manifestUrl) → entry
-    Mgr->>Mgr: validate + origin allow-list + version check
-    Mgr->>WS: installApp(entry) → workspace.installedApps (persist)
-    Mgr->>Mgr: merge into catalog, optionally activateApp(id)
-    Shell->>Browser: Remove installApp from URL (history-clean)
+    Shell->>Shell: INTENTS: fetch each installApp URL
+    Shell->>Shell: classifyInstallPayload → client | service
+    Shell->>Shell: client: reject non-allow-listed origin (§9)
+    Shell->>Browser: ROUTE: remove installApp from URL (history-clean)
+    Shell->>User: Confirmation dialog naming every resolved app
+    User->>Shell: Install
+    Shell->>Mgr: installApp(entry, {activate:true}) per React app
+    Mgr->>Mgr: origin allow-list + version check
+    Mgr->>WS: workspace.installedApps (persist)
+    Mgr->>Mgr: merge into catalog, activateApp(id)
+    Shell->>Shell: addService(url) per service app
 ```
+
+The dialog therefore appears **after** the params are stripped: install moved out
+of the boot phase, and the workspace-hydration precondition (§8.3) still holds
+because `PUBLISH` runs before `INTENTS`.
 
 Per the routing spec, the search parameter is consumed on initial load and then
 removed from the URL. Install must be idempotent (re-running the same intent
@@ -475,6 +508,28 @@ remote URLs, so both must pass the same gate:
 
 These complement, and do not replace, the App Store's managed-CDN immutability
 and human review (see [app-store-design.md](./app-store-design.md) §15).
+
+### 9.1 Service apps are gated differently
+
+Steps 1–4 apply to React apps only. A service app never executes code in the
+host — it receives data over HTTP and returns results — so the service-app
+ecosystem is deliberately open to any origin, and an allow-list would break every
+existing service link. Its gates are:
+
+1. **Schema validation** — `ServiceMetadataSchema`
+   (`src/models/AppModel/serviceMetadataSchema.ts`), enforced in
+   `AppStore.serviceFetcher` and so on every path that registers or refreshes a
+   service app. Deliberately lenient: the service-app spec ships with the
+   Cytoscape Web paper and gains fields independently of this repo, so unknown
+   keys pass through, and `author`/`citation` accept `null` because endpoints
+   send it.
+2. **User confirmation** — the only gate on the origin. Since #639 a React app
+   is confirmed as well, so the dialog is common to both; the allow-list is what
+   remains asymmetric.
+
+`looksLikeServiceMetadata` (a service marker *plus* schema validity) is stricter
+than the registration schema, and only classification uses it. Requiring a marker
+to register would reject service apps that work today.
 
 ---
 

--- a/docs/specifications/ROUTING_SPECIFICATION.md
+++ b/docs/specifications/ROUTING_SPECIFICATION.md
@@ -198,10 +198,15 @@ Query paramters will set the initial ui state and subsequently removed from the 
 
 **App install intents**:
 
-- `installApp`: URL of a single-entry app manifest to install (App Store intent)
-- `addserviceapp`: URL(s) of external service-app endpoint(s) to register. May
-  be repeated to add multiple. Because the URL comes from an arbitrary link,
-  the app prompts the user to confirm before adding (CW-521).
+- `installApp`: URL of an app to install. May be repeated to install several.
+  Each URL is fetched and its payload decides which kind of app it is: an array
+  (or single-entry object) with a `url` is a React app manifest; an object with
+  `cyWebActions` / `cyWebMenuItem` / `serviceInputDefinition` is service-app
+  metadata. An optional `type` field (`client` / `service`) overrides the
+  structural check. Because the URL comes from an arbitrary link, the app names
+  every resolved app in a confirmation dialog before installing any of them. A
+  React app must additionally come from an `appInstallAllowedOrigins` origin;
+  service apps may come from any origin.
 
 **Behavior**:
 

--- a/src/boot/bootPhases.ts
+++ b/src/boot/bootPhases.ts
@@ -20,7 +20,7 @@ export const BootPhase = {
   IMPORTS: 'imports',
   /** Publish to the stores, start the event bus, fire cywebapi:ready. */
   PUBLISH: 'publish',
-  /** `?installApp=` / `?addserviceapp=` intents. */
+  /** `?installApp=` intents: fetch and classify, then hand to AppShell. */
   INTENTS: 'intents',
   /** Restore UI state from the URL, then navigate and strip the params. */
   ROUTE: 'route',

--- a/src/boot/boot_docs/boot.md
+++ b/src/boot/boot_docs/boot.md
@@ -47,7 +47,7 @@ index.html
                                      ├─ phase IMPORTS     ?import=<url>
                                      ├─ phase PUBLISH     per-tab network, stores, event bus,
                                      │                   cywebapi:ready  [workspace-hydrated]
-                                     ├─ phase INTENTS     ?installApp= / ?addserviceapp=
+                                     ├─ phase INTENTS     ?installApp= (fetch + classify)
                                      └─ phase ROUTE       restore URL state, navigate, strip params
                                           └─ <WorkspaceEditor/>          [workspace-editor-mounted]
                                                                           → publishBootReport()

--- a/src/boot/steps/appShellBootContext.ts
+++ b/src/boot/steps/appShellBootContext.ts
@@ -1,4 +1,3 @@
-import type { AppCatalogEntry } from '@/models/AppModel'
 import type { IdType } from '@/models/IdType'
 import type { NetworkSummary } from '@/models/NetworkSummaryModel'
 import type { Workspace } from '@/models/WorkspaceModel'
@@ -30,10 +29,12 @@ export interface AppShellBootContext {
   loadNetworkSummaries: (
     networkIds: IdType[],
   ) => Promise<Record<IdType, NetworkSummary>>
-  installApp: (
-    entry: AppCatalogEntry,
-    options?: { activate?: boolean },
-  ) => Promise<void>
+  /**
+   * Origins allowed to serve a React app bundle (§9), from AppConfigContext.
+   * Passed in because runInstallIntents rejects a disallowed origin before the
+   * confirmation dialog, and a plain async step cannot read React context.
+   */
+  appInstallAllowedOrigins: string[]
 }
 
 /**

--- a/src/boot/steps/runAppShellBoot.test.ts
+++ b/src/boot/steps/runAppShellBoot.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useAppStore } from '@/data/hooks/stores/AppStore'
+import { useMessageStore } from '@/data/hooks/stores/MessageStore'
 import { useNetworkSummaryStore } from '@/data/hooks/stores/NetworkSummaryStore'
 import { useWorkspaceStore } from '@/data/hooks/stores/WorkspaceStore'
 import { resetBootStateForTesting } from '../bootState'
@@ -296,9 +297,16 @@ describe('runAppShellBoot: install intents', () => {
   const MANIFEST_URL = `${ALLOWED_ORIGIN}/web/mcodeweb/manifest.json`
   const SERVICE_URL = 'https://svc.example.com/service'
 
+  beforeEach(() => {
+    useMessageStore.getState().resetMessages()
+  })
+
   afterEach(() => {
     useAppStore.setState({ serviceApps: {} })
   })
+
+  const messages = (): string[] =>
+    useMessageStore.getState().messages.map((m) => m.message)
 
   it('classifies an array manifest as a React app without installing it', async () => {
     stubFetchByUrl({ [MANIFEST_URL]: REACT_MANIFEST })
@@ -377,7 +385,9 @@ describe('runAppShellBoot: install intents', () => {
     expect(ctx.navigate).toHaveBeenCalled()
   })
 
-  it('drops a service app that is already registered', async () => {
+  it('says so instead of silently doing nothing when already installed', async () => {
+    // Skipping in silence made an App Store link look broken: no dialog, no
+    // message, no way to tell a working link from a dead one.
     useAppStore.setState({
       serviceApps: { [SERVICE_URL]: { url: SERVICE_URL } as never },
     })
@@ -389,6 +399,43 @@ describe('runAppShellBoot: install intents', () => {
     const result = await runAppShellBoot(ctx)
 
     expect(result.pendingAppInstalls).toEqual([])
+    expect(messages()).toContain('Already installed: Update tables example')
+  })
+
+  it('rejects a relative or non-http URL without fetching it', async () => {
+    // A relative value would otherwise resolve against Cytoscape Web's own
+    // origin and fetch something the link never named.
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const ctx = makeContext({
+      search: new URLSearchParams(
+        'installApp=/api/internal&installApp=file:///etc/passwd',
+      ),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.pendingAppInstalls).toEqual([])
+    expect(messages()).toHaveLength(2)
+    expect(ctx.navigate).toHaveBeenCalled()
+  })
+
+  it('lists an app once when two manifest URLs resolve to the same entry', async () => {
+    const mirror = `${ALLOWED_ORIGIN}/mirror/manifest.json`
+    stubFetchByUrl({
+      [MANIFEST_URL]: REACT_MANIFEST,
+      [mirror]: REACT_MANIFEST,
+    })
+    const ctx = makeContext({
+      search: new URLSearchParams(
+        `installApp=${MANIFEST_URL}&installApp=${mirror}`,
+      ),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(result.pendingAppInstalls).toHaveLength(1)
   })
 
   it('does not block the boot when an install intent fails', async () => {

--- a/src/boot/steps/runAppShellBoot.test.ts
+++ b/src/boot/steps/runAppShellBoot.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useAppStore } from '@/data/hooks/stores/AppStore'
 import { useNetworkSummaryStore } from '@/data/hooks/stores/NetworkSummaryStore'
 import { useWorkspaceStore } from '@/data/hooks/stores/WorkspaceStore'
 import { resetBootStateForTesting } from '../bootState'
@@ -45,6 +46,41 @@ const WORKSPACE = {
   networkModified: {},
 }
 
+const ALLOWED_ORIGIN = 'https://apps.example.com'
+
+/** A single-entry React app manifest, as the App Store serves it: an array. */
+const REACT_MANIFEST = [
+  {
+    id: 'mcodeweb',
+    name: 'MCODE Web',
+    version: '0.1.0',
+    url: `${ALLOWED_ORIGIN}/web/mcodeweb/0.1.0/remoteEntry.js`,
+    author: 'Bader Lab',
+  },
+]
+
+/** Service-app metadata, as an endpoint serves it: a bare object, no `url`. */
+const SERVICE_METADATA = {
+  name: 'Update tables example',
+  version: '0.9.0',
+  cyWebActions: ['updateTables'],
+  author: null,
+  citation: null,
+  parameters: [],
+}
+
+/** Resolves each URL to its own payload, so concurrent fetches cannot swap. */
+const stubFetchByUrl = (payloads: Record<string, unknown>): void => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) =>
+      payloads[url] === undefined
+        ? { ok: false, status: 404 }
+        : { ok: true, status: 200, json: async () => payloads[url] },
+    ),
+  )
+}
+
 const makeContext = (
   overrides: Partial<AppShellBootContext> = {},
 ): AppShellBootContext => ({
@@ -53,7 +89,7 @@ const makeContext = (
   pathname: '/',
   navigate: vi.fn(),
   loadNetworkSummaries: vi.fn().mockResolvedValue({}),
-  installApp: vi.fn().mockResolvedValue(undefined),
+  appInstallAllowedOrigins: [ALLOWED_ORIGIN],
   ...overrides,
 })
 
@@ -257,16 +293,102 @@ describe('runAppShellBoot: per-tab network resolution', () => {
 })
 
 describe('runAppShellBoot: install intents', () => {
-  it('returns service-app URLs for confirmation rather than adding them', async () => {
+  const MANIFEST_URL = `${ALLOWED_ORIGIN}/web/mcodeweb/manifest.json`
+  const SERVICE_URL = 'https://svc.example.com/service'
+
+  afterEach(() => {
+    useAppStore.setState({ serviceApps: {} })
+  })
+
+  it('classifies an array manifest as a React app without installing it', async () => {
+    stubFetchByUrl({ [MANIFEST_URL]: REACT_MANIFEST })
     const ctx = makeContext({
-      search: new URLSearchParams('addserviceapp=https://svc.example.com'),
+      search: new URLSearchParams({ installApp: MANIFEST_URL }),
     })
 
     const result = await runAppShellBoot(ctx)
 
-    expect(result.serviceAppUrlsNeedingConfirmation).toEqual([
-      'https://svc.example.com',
+    expect(result.pendingAppInstalls).toHaveLength(1)
+    const pending = result.pendingAppInstalls[0]
+    expect(pending.type).toBe('client')
+    if (pending.type === 'client') {
+      expect(pending.entry.id).toBe('mcodeweb')
+      expect(pending.entry.name).toBe('MCODE Web')
+    }
+    // Nothing may be installed before the user has seen the dialog.
+    expect(useWorkspaceStore.getState().workspace.installedApps ?? []).toEqual(
+      [],
+    )
+  })
+
+  it('classifies service metadata as a service app and carries it for display', async () => {
+    stubFetchByUrl({ [SERVICE_URL]: SERVICE_METADATA })
+    const ctx = makeContext({
+      search: new URLSearchParams({ installApp: SERVICE_URL }),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(result.pendingAppInstalls).toHaveLength(1)
+    const pending = result.pendingAppInstalls[0]
+    expect(pending.type).toBe('service')
+    if (pending.type === 'service') {
+      expect(pending.metadata.name).toBe('Update tables example')
+    }
+    // Registration happens on confirm, not here.
+    expect(useAppStore.getState().serviceApps).toEqual({})
+  })
+
+  it('routes a repeated installApp with one of each kind, preserving order', async () => {
+    stubFetchByUrl({
+      [MANIFEST_URL]: REACT_MANIFEST,
+      [SERVICE_URL]: SERVICE_METADATA,
+    })
+    const ctx = makeContext({
+      search: new URLSearchParams(
+        `installApp=${MANIFEST_URL}&installApp=${SERVICE_URL}`,
+      ),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(result.pendingAppInstalls.map((item) => item.type)).toEqual([
+      'client',
+      'service',
     ])
+  })
+
+  it('rejects a React app whose bundle is not from an allowed origin', async () => {
+    stubFetchByUrl({
+      [MANIFEST_URL]: [
+        {
+          ...REACT_MANIFEST[0],
+          url: 'https://evil.example.com/remoteEntry.js',
+        },
+      ],
+    })
+    const ctx = makeContext({
+      search: new URLSearchParams({ installApp: MANIFEST_URL }),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(result.pendingAppInstalls).toEqual([])
+    expect(ctx.navigate).toHaveBeenCalled()
+  })
+
+  it('drops a service app that is already registered', async () => {
+    useAppStore.setState({
+      serviceApps: { [SERVICE_URL]: { url: SERVICE_URL } as never },
+    })
+    stubFetchByUrl({ [SERVICE_URL]: SERVICE_METADATA })
+    const ctx = makeContext({
+      search: new URLSearchParams({ installApp: SERVICE_URL }),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(result.pendingAppInstalls).toEqual([])
   })
 
   it('does not block the boot when an install intent fails', async () => {
@@ -280,6 +402,18 @@ describe('runAppShellBoot: install intents', () => {
 
     await runAppShellBoot(ctx)
 
+    expect(ctx.navigate).toHaveBeenCalled()
+  })
+
+  it('keeps booting when the payload is neither a manifest nor service metadata', async () => {
+    stubFetchByUrl({ [MANIFEST_URL]: { hello: 'world' } })
+    const ctx = makeContext({
+      search: new URLSearchParams({ installApp: MANIFEST_URL }),
+    })
+
+    const result = await runAppShellBoot(ctx)
+
+    expect(result.pendingAppInstalls).toEqual([])
     expect(ctx.navigate).toHaveBeenCalled()
   })
 })

--- a/src/boot/steps/runAppShellBoot.ts
+++ b/src/boot/steps/runAppShellBoot.ts
@@ -3,6 +3,7 @@ import {
   getTabNetworkId,
   resolveInitialNetworkId,
 } from '@/data/tabState/tabNetwork'
+import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
 import { createWorkspace } from '@/models/WorkspaceModel/impl/workspaceImpl'
 import { BootPhase } from '../bootPhases'
 import { runPhase } from '../runBoot'
@@ -29,8 +30,8 @@ import { runUrlImports } from './runUrlImports'
 // the address bar, so a reload reproduced the same failure.
 
 export interface AppShellBootResult {
-  /** Service-app URLs the user must confirm before they are added. */
-  serviceAppUrlsNeedingConfirmation: string[]
+  /** Apps the URL asked to install, resolved but awaiting user confirmation. */
+  pendingAppInstalls: PendingAppInstall[]
 }
 
 const emptyWorkspaceDraft = (): WorkspaceDraft => ({
@@ -98,8 +99,6 @@ export const runAppShellBoot = async (
   })
 
   return {
-    serviceAppUrlsNeedingConfirmation: intents.ok
-      ? intents.value.serviceAppUrlsNeedingConfirmation
-      : [],
+    pendingAppInstalls: intents.ok ? intents.value.pendingAppInstalls : [],
   }
 }

--- a/src/boot/steps/runInstallIntents.ts
+++ b/src/boot/steps/runInstallIntents.ts
@@ -1,78 +1,142 @@
 import { useAppStore } from '@/data/hooks/stores/AppStore'
 import { useMessageStore } from '@/data/hooks/stores/MessageStore'
 import { logStartup } from '@/debug'
-import { serviceAppUrlsToAdd } from '@/models/AppModel/impl'
+import { AppType } from '@/models/AppModel/AppType'
+import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { normalizeServiceAppUrl } from '@/models/AppModel/impl'
 import { MessageSeverity } from '@/models/MessageModel'
-import { parseSingleEntryManifest } from '@/features/AppManager/install/installGate'
+import { classifyInstallPayload } from '@/features/AppManager/install/classifyInstallPayload'
+import { isAllowedOrigin } from '@/features/AppManager/install/installGate'
 import type { AppShellBootContext } from './appShellBootContext'
 
-/** A URL pointing to a single-entry manifest (workspace-app-install-design §7.2). */
+/**
+ * One or more app URLs to install. Each is fetched and its payload decides
+ * whether it is a React app manifest or service-app metadata
+ * (workspace-app-install-design §7.2). Repeatable.
+ */
 const INSTALL_APP_QUERY_KEY = 'installApp'
 
-/** One or more external service endpoints to register (CW-521). */
-const ADD_SERVICE_APP_QUERY_KEY = 'addserviceapp'
-
 /**
- * The manifest host comes from a URL parameter, so it is arbitrary and may be
+ * The install host comes from a URL parameter, so it is arbitrary and may be
  * unreachable rather than merely slow. runPhase catches errors but cannot
  * impose a deadline, so without this an unresponsive host stalls the INTENTS
  * phase indefinitely — holding the boot shell open and, worse, never reaching
  * the ROUTE phase that strips the query params, so a reload retries the same
  * dead host forever.
  */
-const MANIFEST_FETCH_TIMEOUT_MS = 10000
+const INSTALL_FETCH_TIMEOUT_MS = 10000
+
+const reportFailure = (url: string, reason: string, error?: unknown): void => {
+  useMessageStore.getState().addMessage({
+    message: `Failed to install app from ${url}: ${reason}`,
+    duration: 5000,
+    severity: MessageSeverity.ERROR,
+  })
+  logStartup.warn(`[boot]: install intent failed for ${url}: ${reason}`, error)
+}
+
+/**
+ * Fetch one install URL and resolve what it points at. Returns undefined and
+ * reports the reason when the URL cannot be turned into an installable app.
+ */
+const resolveInstallUrl = async (
+  url: string,
+  appInstallAllowedOrigins: string[],
+): Promise<PendingAppInstall | undefined> => {
+  let payload: unknown
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(INSTALL_FETCH_TIMEOUT_MS),
+    })
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    payload = await response.json()
+  } catch (error) {
+    reportFailure(
+      url,
+      error instanceof Error ? error.message : 'unknown error',
+      error,
+    )
+    return undefined
+  }
+
+  const classified = classifyInstallPayload(payload)
+  if (classified === undefined) {
+    reportFailure(
+      url,
+      'the response is neither an app manifest nor service metadata',
+    )
+    return undefined
+  }
+
+  if (classified.type === AppType.Service) {
+    return {
+      type: AppType.Service,
+      url: normalizeServiceAppUrl(url),
+      metadata: classified.metadata,
+    }
+  }
+
+  // A React app's bundle is loaded as code into this origin, so the allow-list
+  // (§9) stays a hard gate — the confirmation dialog is an addition to it, not a
+  // replacement. Checked here rather than only inside installApp so a rejected
+  // app never reaches the dialog and the user is not asked about an install that
+  // cannot happen. Service apps have no allow-list: the dialog is their gate.
+  if (!isAllowedOrigin(classified.entry.url, appInstallAllowedOrigins)) {
+    reportFailure(url, 'its URL is not from an allowed origin')
+    return undefined
+  }
+
+  return { type: AppType.Client, url, entry: classified.entry }
+}
 
 /**
  * Processes app-install intents carried by the URL.
  *
- * Runs after publishWorkspace, because installApp's persisted write is only
- * accepted once the workspace is hydrated (§8.3).
+ * Runs after publishWorkspace, because the install that follows writes to the
+ * workspace, which is only accepted once hydrated (§8.3).
  *
- * Returns the service-app URLs that need confirmation. These are NOT installed
- * here: they come from an arbitrary link, so AppShell prompts first.
+ * Nothing is installed here. Every URL comes from an arbitrary link, so the apps
+ * are resolved and returned for AppShell to name in a confirmation dialog.
+ * Failures are isolated per URL: one dead host does not lose the others.
  */
 export const runInstallIntents = async (
   ctx: AppShellBootContext,
-): Promise<{ serviceAppUrlsNeedingConfirmation: string[] }> => {
-  const installAppUrl = ctx.search.get(INSTALL_APP_QUERY_KEY)
+): Promise<{ pendingAppInstalls: PendingAppInstall[] }> => {
+  const requested = ctx.search.getAll(INSTALL_APP_QUERY_KEY)
+  if (requested.length === 0) {
+    return { pendingAppInstalls: [] }
+  }
 
-  if (installAppUrl !== null) {
-    try {
-      const response = await fetch(installAppUrl, {
-        signal: AbortSignal.timeout(MANIFEST_FETCH_TIMEOUT_MS),
-      })
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`)
-      }
-      const entry = parseSingleEntryManifest(await response.json())
-      if (entry === undefined) {
-        throw new Error('manifest contained no valid app entry')
-      }
-      // An install intent implies activation (§7.3). The §9 gate inside
-      // installApp still applies (origin allow-list, host compatibility) and
-      // surfaces its own messages, so only fetch/parse errors land here.
-      await ctx.installApp(entry, { activate: true })
-    } catch (error) {
-      useMessageStore.getState().addMessage({
-        message: `Failed to install app from ${installAppUrl}: ${
-          error instanceof Error ? error.message : 'unknown error'
-        }`,
-        duration: 5000,
-        severity: MessageSeverity.ERROR,
-      })
-      logStartup.warn(
-        `[boot]: install intent failed for ${installAppUrl}`,
-        error,
-      )
+  const resolved = await Promise.all(
+    requested.map(async (url) =>
+      url.trim() === ''
+        ? undefined
+        : resolveInstallUrl(url.trim(), ctx.appInstallAllowedOrigins),
+    ),
+  )
+
+  const { serviceApps } = useAppStore.getState()
+  const seen = new Set<string>()
+  const pendingAppInstalls: PendingAppInstall[] = []
+
+  for (const pending of resolved) {
+    if (pending === undefined || seen.has(pending.url)) {
+      continue
     }
+    // Already-registered service apps are dropped silently, as ?addserviceapp=
+    // did. React apps are never dropped: installApp is an upsert, so a repeated
+    // intent is how a version update arrives.
+    if (
+      pending.type === AppType.Service &&
+      serviceApps[pending.url] !== undefined
+    ) {
+      continue
+    }
+    seen.add(pending.url)
+    pendingAppInstalls.push(pending)
   }
 
-  const requested = ctx.search.getAll(ADD_SERVICE_APP_QUERY_KEY)
-
-  return {
-    serviceAppUrlsNeedingConfirmation:
-      requested.length === 0
-        ? []
-        : serviceAppUrlsToAdd(requested, useAppStore.getState().serviceApps),
-  }
+  return { pendingAppInstalls }
 }

--- a/src/boot/steps/runInstallIntents.ts
+++ b/src/boot/steps/runInstallIntents.ts
@@ -3,6 +3,7 @@ import { useMessageStore } from '@/data/hooks/stores/MessageStore'
 import { logStartup } from '@/debug'
 import { AppType } from '@/models/AppModel/AppType'
 import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { pendingInstallName } from '@/models/AppModel/PendingAppInstall'
 import { normalizeServiceAppUrl } from '@/models/AppModel/impl'
 import { MessageSeverity } from '@/models/MessageModel'
 import { classifyInstallPayload } from '@/features/AppManager/install/classifyInstallPayload'
@@ -45,8 +46,19 @@ const resolveInstallUrl = async (
 ): Promise<PendingAppInstall | undefined> => {
   let payload: unknown
   try {
-    const response = await fetch(url, {
+    // The value is whatever the link put in the query string, so check it is an
+    // absolute http(s) URL before requesting it. A relative value would
+    // otherwise resolve against Cytoscape Web's own origin and fetch something
+    // the link never named.
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`unsupported URL scheme "${parsed.protocol}"`)
+    }
+    const response = await fetch(parsed.href, {
       signal: AbortSignal.timeout(INSTALL_FETCH_TIMEOUT_MS),
+      // No ambient session credentials: the URL is untrusted, and app metadata
+      // is public by definition.
+      credentials: 'omit',
     })
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`)
@@ -120,22 +132,46 @@ export const runInstallIntents = async (
   const { serviceApps } = useAppStore.getState()
   const seen = new Set<string>()
   const pendingAppInstalls: PendingAppInstall[] = []
+  const alreadyInstalled: string[] = []
 
   for (const pending of resolved) {
-    if (pending === undefined || seen.has(pending.url)) {
+    if (pending === undefined) {
       continue
     }
-    // Already-registered service apps are dropped silently, as ?addserviceapp=
-    // did. React apps are never dropped: installApp is an upsert, so a repeated
-    // intent is how a version update arrives.
+    // Keyed on what the payload resolved to, not the URL that served it: two
+    // manifest URLs can describe the same app id, and listing it twice would
+    // both read as a duplicate in the dialog and install it twice.
+    const identity =
+      pending.type === AppType.Client
+        ? `${AppType.Client}:${pending.entry.id}`
+        : `${AppType.Service}:${pending.url}`
+    if (seen.has(identity)) {
+      continue
+    }
+    seen.add(identity)
+    // An already-registered service app is not installed again: re-registering
+    // overwrites the stored ServiceApp and discards the parameter values the
+    // user set on it. React apps are never dropped — installApp is an upsert, so
+    // a repeated intent is how a version update arrives.
     if (
       pending.type === AppType.Service &&
       serviceApps[pending.url] !== undefined
     ) {
+      alreadyInstalled.push(pendingInstallName(pending))
       continue
     }
-    seen.add(pending.url)
     pendingAppInstalls.push(pending)
+  }
+
+  // Say so rather than doing nothing. Skipping in silence makes an App Store
+  // link look broken: no dialog opens, no message appears, and the user has no
+  // way to tell a working link from a dead one.
+  if (alreadyInstalled.length > 0) {
+    useMessageStore.getState().addMessage({
+      message: `Already installed: ${alreadyInstalled.join(', ')}`,
+      duration: 4000,
+      severity: MessageSeverity.INFO,
+    })
   }
 
   return { pendingAppInstalls }

--- a/src/data/db/validator.ts
+++ b/src/data/db/validator.ts
@@ -397,8 +397,11 @@ const ServiceAppSchema = z.object({
   serviceInputDefinition: ServiceInputDefinitionSchema.optional(),
   cyWebActions: z.array(ServiceAppActionSchema),
   cyWebMenuItem: CyWebMenuItemSchema,
-  author: z.string(),
-  citation: z.string(),
+  // Nullable: endpoints send null rather than omitting these. Requiring a string
+  // rejected a snapshot containing the cytocontainer example service, which
+  // sends null for both.
+  author: z.string().nullish(),
+  citation: z.string().nullish(),
   parameters: z.array(ServiceAppParameterSchema),
 })
 

--- a/src/data/hooks/stores/AppStore.ts
+++ b/src/data/hooks/stores/AppStore.ts
@@ -10,7 +10,7 @@ import { AppSource } from '../../../models/AppModel/InstalledApp'
 import { ManifestSource } from '../../../models/AppModel/ManifestSource'
 import { ServiceApp } from '../../../models/AppModel/ServiceApp'
 import { ServiceAppTask } from '../../../models/AppModel/ServiceAppTask'
-import { ServiceMetadata } from '../../../models/AppModel/ServiceMetadata'
+import { parseServiceMetadata } from '../../../models/AppModel/serviceMetadataSchema'
 import { AppStore } from '../../../models/StoreModel/AppStoreModel'
 import * as AppStoreImpl from '../../../models/StoreModel/impl/appStoreImpl'
 import { RootMenu } from '../../../models/AppModel/RootMenu'
@@ -38,7 +38,14 @@ export const serviceFetcher = async (url: string): Promise<ServiceApp> => {
     throw new Error('Failed to fetch the service metadata.')
   }
 
-  const metadata: ServiceMetadata = await response.json()
+  // The endpoint is user-supplied, so the payload is external input: validate it
+  // rather than casting. Without this, a malformed response registers as a
+  // service app and fails later, deep in the menu or the input dialog.
+  const metadata = parseServiceMetadata(await response.json())
+  if (metadata === undefined) {
+    throw new Error('The response is not valid service app metadata.')
+  }
+
   const serviceApp: ServiceApp = {
     url,
     ...metadata,

--- a/src/features/AppManager/AppInstallConfirmationDialog.spec.tsx
+++ b/src/features/AppManager/AppInstallConfirmationDialog.spec.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AppType } from '@/models/AppModel/AppType'
+import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { AppInstallConfirmationDialog } from './AppInstallConfirmationDialog'
+
+const REACT_APP: PendingAppInstall = {
+  type: AppType.Client,
+  url: 'https://apps-stage.cytoscape.org/web/mcodeweb/manifest.json',
+  entry: {
+    id: 'mcodeweb',
+    name: 'MCODE Web',
+    version: '0.1.0',
+    url: 'https://apps-stage.cytoscape.org/web/mcodeweb/0.1.0/remoteEntry.js',
+    author: 'Bader Lab, University of Toronto',
+  },
+}
+
+const SERVICE_APP: PendingAppInstall = {
+  type: AppType.Service,
+  url: 'https://svc.example.com/updatetables',
+  metadata: {
+    name: 'Update tables example',
+    version: '0.9.0',
+    description: "Adds a new column, named 'test_col' by default.",
+    // Endpoints really do send null here.
+    author: null as unknown as string,
+    citation: null as unknown as string,
+    cyWebActions: ['updateTables'],
+    cyWebMenuItem: { root: 'Tools', path: [] } as never,
+    parameters: [],
+  },
+}
+
+const renderDialog = (
+  pending: PendingAppInstall[],
+): { onConfirm: () => void; onCancel: () => void } => {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <AppInstallConfirmationDialog
+      pending={pending}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />,
+  )
+  return { onConfirm, onCancel }
+}
+
+describe('AppInstallConfirmationDialog', () => {
+  it('names both app kinds and labels which is which', () => {
+    // The point of the dialog: the user must be able to tell a React app from a
+    // service app, since one parameter now installs either.
+    renderDialog([REACT_APP, SERVICE_APP])
+
+    expect(screen.getByText('MCODE Web')).toBeTruthy()
+    expect(screen.getByText('App')).toBeTruthy()
+    expect(screen.getByText(/v0\.1\.0.*Bader Lab/)).toBeTruthy()
+
+    expect(screen.getByText('Update tables example')).toBeTruthy()
+    expect(screen.getByText('Service')).toBeTruthy()
+    expect(screen.getByText(/Adds a new column/)).toBeTruthy()
+  })
+
+  it('shows the source URL of every app', () => {
+    // Origin is the only trust signal for a service app, so it must be visible.
+    renderDialog([REACT_APP, SERVICE_APP])
+
+    expect(screen.getByText(REACT_APP.url)).toBeTruthy()
+    expect(screen.getByText(SERVICE_APP.url)).toBeTruthy()
+  })
+
+  it('tolerates an app that declares no version or author', () => {
+    renderDialog([
+      {
+        type: AppType.Service,
+        url: 'https://svc.example.com/bare',
+        metadata: { name: 'Bare service' } as never,
+      },
+    ])
+
+    expect(screen.getByText('Bare service')).toBeTruthy()
+  })
+
+  it('stays closed when nothing is pending', () => {
+    renderDialog([])
+
+    expect(screen.queryByTestId('app-install-confirmation-dialog')).toBeNull()
+  })
+
+  it('reports confirm and cancel separately', () => {
+    const { onConfirm, onCancel } = renderDialog([REACT_APP])
+
+    fireEvent.click(
+      screen.getByTestId('app-install-confirmation-dialog-confirm'),
+    )
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      screen.getByTestId('app-install-confirmation-dialog-cancel'),
+    )
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/AppManager/AppInstallConfirmationDialog.spec.tsx
+++ b/src/features/AppManager/AppInstallConfirmationDialog.spec.tsx
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { AppType } from '@/models/AppModel/AppType'
 import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { RootMenu } from '@/models/AppModel/RootMenu'
+import { ServiceAppAction } from '@/models/AppModel/ServiceAppAction'
 import { AppInstallConfirmationDialog } from './AppInstallConfirmationDialog'
 
 const REACT_APP: PendingAppInstall = {
@@ -24,11 +26,11 @@ const SERVICE_APP: PendingAppInstall = {
     name: 'Update tables example',
     version: '0.9.0',
     description: "Adds a new column, named 'test_col' by default.",
-    // Endpoints really do send null here.
-    author: null as unknown as string,
-    citation: null as unknown as string,
-    cyWebActions: ['updateTables'],
-    cyWebMenuItem: { root: 'Tools', path: [] } as never,
+    // Endpoints really do send null here — ServiceMetadata allows it.
+    author: null,
+    citation: null,
+    cyWebActions: [ServiceAppAction.UpdateTables],
+    cyWebMenuItem: { root: RootMenu.Tools, path: [] },
     parameters: [],
   },
 }

--- a/src/features/AppManager/AppInstallConfirmationDialog.tsx
+++ b/src/features/AppManager/AppInstallConfirmationDialog.tsx
@@ -13,9 +13,9 @@ import {
   Typography,
 } from '@mui/material'
 
-import { AppType } from '../../models/AppModel/AppType'
-import type { PendingAppInstall } from '../../models/AppModel/PendingAppInstall'
-import { pendingInstallName } from '../../models/AppModel/PendingAppInstall'
+import { AppType } from '@/models/AppModel/AppType'
+import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { pendingInstallName } from '@/models/AppModel/PendingAppInstall'
 
 interface AppInstallConfirmationDialogProps {
   /** Apps the URL asked to install. The dialog is hidden when empty. */

--- a/src/features/AppManager/AppInstallConfirmationDialog.tsx
+++ b/src/features/AppManager/AppInstallConfirmationDialog.tsx
@@ -1,0 +1,163 @@
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@mui/material'
+
+import { AppType } from '../../models/AppModel/AppType'
+import type { PendingAppInstall } from '../../models/AppModel/PendingAppInstall'
+import { pendingInstallName } from '../../models/AppModel/PendingAppInstall'
+
+interface AppInstallConfirmationDialogProps {
+  /** Apps the URL asked to install. The dialog is hidden when empty. */
+  pending: PendingAppInstall[]
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/** Version and author, whichever of the two the app actually declared. */
+const subtitleOf = (pending: PendingAppInstall): string => {
+  const version =
+    pending.type === AppType.Client
+      ? pending.entry.version
+      : pending.metadata.version
+  const author =
+    pending.type === AppType.Client
+      ? pending.entry.author
+      : pending.metadata.author
+  return [
+    version !== undefined && version !== '' ? `v${version}` : undefined,
+    author !== undefined && author !== null && author !== ''
+      ? author
+      : undefined,
+  ]
+    .filter((part) => part !== undefined)
+    .join(' — ')
+}
+
+const descriptionOf = (pending: PendingAppInstall): string => {
+  const description =
+    pending.type === AppType.Client
+      ? pending.entry.description
+      : pending.metadata.description
+  return description === undefined || description === null ? '' : description
+}
+
+/**
+ * Asks the user to confirm apps an `?installApp=` link wants to add.
+ *
+ * A URL can install either a React app or a service app, from an arbitrary
+ * origin, so the user is told what each item actually is before anything is
+ * added — name, kind, version, author, description and source URL. Confirm is
+ * all-or-nothing; Cancel installs nothing.
+ */
+export const AppInstallConfirmationDialog = ({
+  pending,
+  onConfirm,
+  onCancel,
+}: AppInstallConfirmationDialogProps): JSX.Element => {
+  return (
+    <Dialog
+      data-testid="app-install-confirmation-dialog"
+      open={pending.length > 0}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="app-install-confirmation-dialog-title"
+    >
+      <DialogTitle id="app-install-confirmation-dialog-title">
+        Install into this workspace?
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This link wants to add the following to Cytoscape Web:
+        </DialogContentText>
+        <List dense sx={{ maxHeight: 320, overflowY: 'auto' }}>
+          {pending.map((item) => (
+            <ListItem
+              key={item.url}
+              data-testid={`app-install-row-${
+                item.type === AppType.Client ? item.entry.id : item.url
+              }`}
+              disableGutters
+              alignItems="flex-start"
+            >
+              <ListItemText
+                disableTypography
+                primary={
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      mb: 0.25,
+                    }}
+                  >
+                    <Typography variant="subtitle1" color="text.primary">
+                      {pendingInstallName(item)}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={item.type === AppType.Client ? 'App' : 'Service'}
+                      color={
+                        item.type === AppType.Client ? 'primary' : 'secondary'
+                      }
+                      variant="outlined"
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      {subtitleOf(item)}
+                    </Typography>
+                  </Box>
+                }
+                secondary={
+                  <Box>
+                    {descriptionOf(item) !== '' && (
+                      <Typography variant="body2" color="text.secondary">
+                        {descriptionOf(item)}
+                      </Typography>
+                    )}
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ wordBreak: 'break-all' }}
+                    >
+                      {item.url}
+                    </Typography>
+                  </Box>
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+        <DialogContentText variant="body2">
+          Only install apps from sources you trust.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          data-testid="app-install-confirmation-dialog-cancel"
+          variant="outlined"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        <Button
+          data-testid="app-install-confirmation-dialog-confirm"
+          variant="contained"
+          onClick={onConfirm}
+          autoFocus
+        >
+          Install
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/features/AppManager/install/classifyInstallPayload.test.ts
+++ b/src/features/AppManager/install/classifyInstallPayload.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyInstallPayload } from './classifyInstallPayload'
+
+// Both payloads are the real examples from cytoscape-web#639, trimmed only where
+// a field plays no part in classification. The nulls in the service metadata are
+// load-bearing: ServiceMetadata declares author/citation as required strings,
+// but this is what an endpoint actually sends.
+
+const REACT_MANIFEST_ENTRY = {
+  id: 'mcodeweb',
+  name: 'MCODE Web',
+  version: '0.1.0',
+  url: 'https://apps-stage.cytoscape.org/web/mcodeweb/0.1.0/remoteEntry.js',
+  author: 'Bader Lab, University of Toronto',
+  description: '',
+  license: '',
+  tags: [],
+}
+
+const SERVICE_METADATA = {
+  name: 'Update tables example',
+  version: '0.9.0',
+  cyWebActions: ['updateTables'],
+  description: "Adds a new column, named 'test_col' by default.",
+  author: null,
+  citation: null,
+  cyWebMenuItem: {
+    root: 'Tools',
+    path: [{ name: 'Update tables example', gravity: 1 }],
+  },
+  serviceInputDefinition: {
+    type: 'network',
+    scope: 'all',
+    inputNetwork: { format: 'cx2', model: 'network' },
+    inputColumns: null,
+  },
+  showDescriptionInDialog: false,
+  parameters: [
+    {
+      displayName: 'Specify column name',
+      description: 'Column with specified name will be added',
+      type: 'text',
+      defaultValue: 'test_col',
+      valueList: null,
+      minValue: null,
+      maxValue: null,
+    },
+  ],
+}
+
+describe('classifyInstallPayload', () => {
+  it('classifies an array as a React app manifest', () => {
+    const result = classifyInstallPayload([REACT_MANIFEST_ENTRY])
+
+    expect(result?.type).toBe('client')
+    if (result?.type === 'client') {
+      expect(result.entry.id).toBe('mcodeweb')
+      expect(result.entry.url).toBe(REACT_MANIFEST_ENTRY.url)
+    }
+  })
+
+  it('classifies a single-object manifest as a React app', () => {
+    // The example in the issue is a bare object, so the App Store may serve
+    // either shape.
+    const result = classifyInstallPayload(REACT_MANIFEST_ENTRY)
+
+    expect(result?.type).toBe('client')
+    if (result?.type === 'client') {
+      expect(result.entry.id).toBe('mcodeweb')
+    }
+  })
+
+  it('classifies service metadata as a service app', () => {
+    const result = classifyInstallPayload(SERVICE_METADATA)
+
+    expect(result?.type).toBe('service')
+    if (result?.type === 'service') {
+      expect(result.metadata.name).toBe('Update tables example')
+      expect(result.metadata.parameters).toHaveLength(1)
+    }
+  })
+
+  it('keeps unknown fields on service metadata', () => {
+    // The service-app spec ships with the paper and gains fields independently
+    // of this repo, so stripping them would silently drop capabilities.
+    const result = classifyInstallPayload({
+      ...SERVICE_METADATA,
+      futureField: 'kept',
+    })
+
+    expect(result?.type).toBe('service')
+    if (result?.type === 'service') {
+      expect(
+        (result.metadata as unknown as Record<string, unknown>).futureField,
+      ).toBe('kept')
+    }
+  })
+
+  it('honors an explicit type of service over structure', () => {
+    // Has a valid `url`, so structure alone would call it a React app.
+    const result = classifyInstallPayload({
+      ...SERVICE_METADATA,
+      type: 'service',
+      url: 'https://apps.cytoscape.org/web/x/remoteEntry.js',
+    })
+
+    expect(result?.type).toBe('service')
+  })
+
+  it('honors an explicit type of client over structure', () => {
+    // Has cyWebActions, so structure alone would call it a service app.
+    const result = classifyInstallPayload({
+      ...REACT_MANIFEST_ENTRY,
+      type: 'client',
+      cyWebActions: ['updateTables'],
+    })
+
+    expect(result?.type).toBe('client')
+  })
+
+  it('rejects a manifest entry with no valid url', () => {
+    const { url: _url, ...withoutUrl } = REACT_MANIFEST_ENTRY
+
+    expect(classifyInstallPayload([withoutUrl])).toBeUndefined()
+    expect(classifyInstallPayload(withoutUrl)).toBeUndefined()
+  })
+
+  it('rejects a payload that is neither shape', () => {
+    expect(classifyInstallPayload({ hello: 'world' })).toBeUndefined()
+    expect(classifyInstallPayload([])).toBeUndefined()
+    expect(classifyInstallPayload(null)).toBeUndefined()
+    expect(classifyInstallPayload('a string')).toBeUndefined()
+  })
+
+  it('rejects service metadata with no name', () => {
+    const { name: _name, ...unnamed } = SERVICE_METADATA
+
+    expect(classifyInstallPayload(unnamed)).toBeUndefined()
+  })
+})

--- a/src/features/AppManager/install/classifyInstallPayload.test.ts
+++ b/src/features/AppManager/install/classifyInstallPayload.test.ts
@@ -119,6 +119,17 @@ describe('classifyInstallPayload', () => {
     expect(result?.type).toBe('client')
   })
 
+  it('ignores type inside an array, which stays a React manifest', () => {
+    // Documented limitation: a service classification must carry metadata, and a
+    // manifest entry carries only a url. Honoring type: 'service' here would
+    // need a second fetch, which this function cannot do.
+    const result = classifyInstallPayload([
+      { ...REACT_MANIFEST_ENTRY, type: 'service' },
+    ])
+
+    expect(result?.type).toBe('client')
+  })
+
   it('rejects a manifest entry with no valid url', () => {
     const { url: _url, ...withoutUrl } = REACT_MANIFEST_ENTRY
 

--- a/src/features/AppManager/install/classifyInstallPayload.ts
+++ b/src/features/AppManager/install/classifyInstallPayload.ts
@@ -1,10 +1,10 @@
-import { AppCatalogEntry } from '../../../models/AppModel/AppCatalogEntry'
-import { AppType } from '../../../models/AppModel/AppType'
+import type { AppCatalogEntry } from '@/models/AppModel/AppCatalogEntry'
+import { AppType } from '@/models/AppModel/AppType'
 import {
-  looksLikeServiceMetadata,
   parseServiceMetadata,
-} from '../../../models/AppModel/serviceMetadataSchema'
-import { ServiceMetadata } from '../../../models/AppModel/ServiceMetadata'
+  serviceMetadataIfMarked,
+} from '@/models/AppModel/serviceMetadataSchema'
+import type { ServiceMetadata } from '@/models/AppModel/ServiceMetadata'
 import { parseSingleEntryManifest } from './installGate'
 
 /**
@@ -35,8 +35,8 @@ export type ClassifiedInstallPayload =
  *
  * 1. An array is a manifest. This is the only shape the App Store serves today,
  *    so existing `?installApp=` links keep their exact behavior.
- * 2. An explicit `type` field wins over structure. Optional, because making it
- *    required would break every manifest already published on
+ * 2. On a bare object, an explicit `type` field wins over structure. Optional,
+ *    because making it required would break every manifest already published on
  *    apps-stage.cytoscape.org until the App Store republishes them.
  * 3. A service marker (`cyWebActions` / `cyWebMenuItem` /
  *    `serviceInputDefinition`) means service.
@@ -45,6 +45,12 @@ export type ClassifiedInstallPayload =
  *
  * Rules 2-4 handle a bare object rather than an array because a manifest may be
  * served either way (the React example in cytoscape-web#639 is a single object).
+ *
+ * `type` is deliberately not consulted inside an array. A service
+ * classification has to carry metadata, and a manifest entry carries only a
+ * `url` — resolving `type: 'service'` there would mean fetching that URL, which
+ * this function cannot do. If the App Store ever lists service apps in a
+ * manifest, that fetch belongs in the caller, not here.
  */
 export const classifyInstallPayload = (
   data: unknown,
@@ -72,10 +78,9 @@ export const classifyInstallPayload = (
     return entry === undefined ? undefined : { type: AppType.Client, entry }
   }
 
-  if (looksLikeServiceMetadata(data)) {
-    // Guaranteed to parse: looksLikeServiceMetadata already ran the schema.
-    const metadata = parseServiceMetadata(data) as ServiceMetadata
-    return { type: AppType.Service, metadata }
+  const marked = serviceMetadataIfMarked(data)
+  if (marked !== undefined) {
+    return { type: AppType.Service, metadata: marked }
   }
 
   const entry = parseSingleEntryManifest([data])

--- a/src/features/AppManager/install/classifyInstallPayload.ts
+++ b/src/features/AppManager/install/classifyInstallPayload.ts
@@ -1,0 +1,83 @@
+import { AppCatalogEntry } from '../../../models/AppModel/AppCatalogEntry'
+import { AppType } from '../../../models/AppModel/AppType'
+import {
+  looksLikeServiceMetadata,
+  parseServiceMetadata,
+} from '../../../models/AppModel/serviceMetadataSchema'
+import { ServiceMetadata } from '../../../models/AppModel/ServiceMetadata'
+import { parseSingleEntryManifest } from './installGate'
+
+/**
+ * What a fetched `?installApp=` payload turned out to be.
+ *
+ * Pure and framework-free, like the rest of this directory: `?installApp=`
+ * accepts one URL for both app kinds, so the payload behind it has to be
+ * resolved before anything is installed or shown to the user.
+ */
+export type ClassifiedInstallPayload =
+  | { type: typeof AppType.Client; entry: AppCatalogEntry }
+  | { type: typeof AppType.Service; metadata: ServiceMetadata }
+
+/**
+ * Decide whether a fetched payload is a React app manifest or service-app
+ * metadata. Returns undefined when it is neither — the caller reports that.
+ *
+ * The two shapes are structurally disjoint, so no change to either published
+ * format is required:
+ *
+ * | | React app manifest | Service app metadata |
+ * | --- | --- | --- |
+ * | Top level | array (or a single entry object) | object |
+ * | Required | `url` (the remoteEntry.js) | no `url` |
+ * | Distinctive | `id`, `tags` | `cyWebActions`, `cyWebMenuItem`, `serviceInputDefinition` |
+ *
+ * Order of resolution:
+ *
+ * 1. An array is a manifest. This is the only shape the App Store serves today,
+ *    so existing `?installApp=` links keep their exact behavior.
+ * 2. An explicit `type` field wins over structure. Optional, because making it
+ *    required would break every manifest already published on
+ *    apps-stage.cytoscape.org until the App Store republishes them.
+ * 3. A service marker (`cyWebActions` / `cyWebMenuItem` /
+ *    `serviceInputDefinition`) means service.
+ * 4. Otherwise try the manifest parser on a single-object payload — it requires
+ *    a valid `url`, which service metadata never has.
+ *
+ * Rules 2-4 handle a bare object rather than an array because a manifest may be
+ * served either way (the React example in cytoscape-web#639 is a single object).
+ */
+export const classifyInstallPayload = (
+  data: unknown,
+): ClassifiedInstallPayload | undefined => {
+  if (Array.isArray(data)) {
+    const entry = parseSingleEntryManifest(data)
+    return entry === undefined ? undefined : { type: AppType.Client, entry }
+  }
+
+  if (typeof data !== 'object' || data === null) {
+    return undefined
+  }
+
+  const declaredType = (data as { type?: unknown }).type
+
+  if (declaredType === AppType.Service) {
+    const metadata = parseServiceMetadata(data)
+    return metadata === undefined
+      ? undefined
+      : { type: AppType.Service, metadata }
+  }
+
+  if (declaredType === AppType.Client) {
+    const entry = parseSingleEntryManifest([data])
+    return entry === undefined ? undefined : { type: AppType.Client, entry }
+  }
+
+  if (looksLikeServiceMetadata(data)) {
+    // Guaranteed to parse: looksLikeServiceMetadata already ran the schema.
+    const metadata = parseServiceMetadata(data) as ServiceMetadata
+    return { type: AppType.Service, metadata }
+  }
+
+  const entry = parseSingleEntryManifest([data])
+  return entry === undefined ? undefined : { type: AppType.Client, entry }
+}

--- a/src/features/AppManager/install/installConfirmedApps.test.ts
+++ b/src/features/AppManager/install/installConfirmedApps.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AppType } from '@/models/AppModel/AppType'
+import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { installConfirmedApps } from './installConfirmedApps'
+
+const reactApp = (id: string): PendingAppInstall => ({
+  type: AppType.Client,
+  url: `https://apps.example.com/${id}/manifest.json`,
+  entry: {
+    id,
+    name: `App ${id}`,
+    url: `https://apps.example.com/${id}/remoteEntry.js`,
+    author: 'Someone',
+  },
+})
+
+const serviceApp = (name: string): PendingAppInstall => ({
+  type: AppType.Service,
+  url: `https://svc.example.com/${name}`,
+  metadata: { name } as never,
+})
+
+const makeDeps = () => ({
+  installApp: vi.fn().mockResolvedValue(undefined),
+  addService: vi.fn().mockResolvedValue(undefined),
+  addMessage: vi.fn(),
+  warn: vi.fn(),
+})
+
+describe('installConfirmedApps', () => {
+  it('sends each kind to its own install path', async () => {
+    const deps = makeDeps()
+
+    await installConfirmedApps([reactApp('alpha'), serviceApp('beta')], deps)
+
+    // A React app arrives activated: an install intent implies activation.
+    expect(deps.installApp).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'alpha' }),
+      { activate: true },
+    )
+    expect(deps.addService).toHaveBeenCalledWith('https://svc.example.com/beta')
+    expect(deps.addService).toHaveBeenCalledTimes(1)
+    expect(deps.installApp).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports each install by name', async () => {
+    const deps = makeDeps()
+
+    await installConfirmedApps([reactApp('alpha'), serviceApp('beta')], deps)
+
+    expect(deps.addMessage.mock.calls.map((c) => c[0].message)).toEqual([
+      'Added App alpha',
+      'Added beta',
+    ])
+  })
+
+  it('keeps installing after one app fails, and says which failed', async () => {
+    // The regression that matters: a link may carry several apps, and one dead
+    // endpoint must not silently abandon the ones after it.
+    const deps = makeDeps()
+    deps.addService.mockRejectedValueOnce(new Error('endpoint down'))
+
+    await installConfirmedApps(
+      [serviceApp('bad'), reactApp('alpha'), serviceApp('good')],
+      deps,
+    )
+
+    expect(deps.addMessage.mock.calls.map((c) => c[0].message)).toEqual([
+      'Failed to add bad from https://svc.example.com/bad: endpoint down',
+      'Added App alpha',
+      'Added good',
+    ])
+    expect(deps.installApp).toHaveBeenCalledTimes(1)
+    expect(deps.addService).toHaveBeenCalledTimes(2)
+    expect(deps.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('installs sequentially rather than all at once', async () => {
+    const order: string[] = []
+    const deps = makeDeps()
+    deps.addService.mockImplementation(async (url: string) => {
+      order.push(`start ${url}`)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      order.push(`end ${url}`)
+    })
+
+    await installConfirmedApps([serviceApp('one'), serviceApp('two')], deps)
+
+    expect(order).toEqual([
+      'start https://svc.example.com/one',
+      'end https://svc.example.com/one',
+      'start https://svc.example.com/two',
+      'end https://svc.example.com/two',
+    ])
+  })
+
+  it('does nothing when the user confirmed nothing', async () => {
+    const deps = makeDeps()
+
+    await installConfirmedApps([], deps)
+
+    expect(deps.installApp).not.toHaveBeenCalled()
+    expect(deps.addService).not.toHaveBeenCalled()
+    expect(deps.addMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/AppManager/install/installConfirmedApps.ts
+++ b/src/features/AppManager/install/installConfirmedApps.ts
@@ -1,0 +1,60 @@
+import type { AppCatalogEntry } from '@/models/AppModel/AppCatalogEntry'
+import { AppType } from '@/models/AppModel/AppType'
+import type { PendingAppInstall } from '@/models/AppModel/PendingAppInstall'
+import { pendingInstallName } from '@/models/AppModel/PendingAppInstall'
+import type { Message } from '@/models/MessageModel'
+import { MessageSeverity } from '@/models/MessageModel'
+
+export interface InstallConfirmedAppsDeps {
+  installApp: (
+    entry: AppCatalogEntry,
+    options?: { activate?: boolean },
+  ) => Promise<void>
+  addService: (url: string) => Promise<void>
+  addMessage: (message: Message) => void
+  warn: (message: string, error: unknown) => void
+}
+
+/**
+ * Installs the apps the user confirmed in the install dialog.
+ *
+ * Extracted from AppShell so the dispatch, ordering and error isolation are
+ * testable without rendering the whole shell.
+ *
+ * Sequential and individually caught on purpose: one link may carry several
+ * apps, and a single bad endpoint must not abandon the ones after it.
+ */
+export const installConfirmedApps = async (
+  confirmed: readonly PendingAppInstall[],
+  deps: InstallConfirmedAppsDeps,
+): Promise<void> => {
+  for (const pending of confirmed) {
+    const name = pendingInstallName(pending)
+    try {
+      if (pending.type === AppType.Client) {
+        // An install intent implies activation (§7.3). The §9 gate inside
+        // installApp still applies and surfaces its own messages.
+        await deps.installApp(pending.entry, { activate: true })
+      } else {
+        // Refetches the endpoint the boot already read. Deliberate: addService
+        // owns the ServiceApp shape and its persistence, and the boot's copy
+        // exists only to name the app in the dialog.
+        await deps.addService(pending.url)
+      }
+      deps.addMessage({
+        message: `Added ${name}`,
+        duration: 4000,
+        severity: MessageSeverity.SUCCESS,
+      })
+    } catch (error) {
+      deps.addMessage({
+        message: `Failed to add ${name} from ${pending.url}: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`,
+        duration: 5000,
+        severity: MessageSeverity.ERROR,
+      })
+      deps.warn(`installApp intent failed for ${pending.url}`, error)
+    }
+  }
+}

--- a/src/features/AppManager/manifest/parseManifest.ts
+++ b/src/features/AppManager/manifest/parseManifest.ts
@@ -2,16 +2,17 @@ import { z } from 'zod'
 
 import { logApp } from '../../../debug'
 import { AppCatalogEntry } from '../../../models/AppModel/AppCatalogEntry'
+import { AppType } from '../../../models/AppModel/AppType'
 
 const JS_IDENTIFIER_PATTERN = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
 
 const AppManifestEntrySchema = z
   .object({
-    id: z
-      .string()
-      .regex(JS_IDENTIFIER_PATTERN)
-      .optional(),
+    id: z.string().regex(JS_IDENTIFIER_PATTERN).optional(),
     name: z.string().min(1).optional(),
+    // Optional hint from the App Store. Absent today, so payload classification
+    // falls back to structure — see classifyInstallPayload.
+    type: z.enum([AppType.Service, AppType.Client]).optional(),
     url: z.string().url(),
     author: z.string().min(1).optional().default('unknown'),
     description: z.string().optional(),
@@ -39,7 +40,9 @@ export const AppManifestSchema = z.array(AppManifestEntrySchema)
  */
 export function parseManifest(data: unknown): AppCatalogEntry[] {
   if (!Array.isArray(data)) {
-    logApp.warn('[parseManifest]: Manifest is not an array, returning empty catalog')
+    logApp.warn(
+      '[parseManifest]: Manifest is not an array, returning empty catalog',
+    )
     return []
   }
 
@@ -61,7 +64,10 @@ export function parseManifest(data: unknown): AppCatalogEntry[] {
     // Resolve id: prefer explicit id, fall back to name
     let id = parsed.id
     if (id === undefined) {
-      if (parsed.name !== undefined && JS_IDENTIFIER_PATTERN.test(parsed.name)) {
+      if (
+        parsed.name !== undefined &&
+        JS_IDENTIFIER_PATTERN.test(parsed.name)
+      ) {
         id = parsed.name
       } else {
         logApp.warn(
@@ -84,8 +90,11 @@ export function parseManifest(data: unknown): AppCatalogEntry[] {
       id,
       url: parsed.url,
       author: parsed.author,
+      ...(parsed.type !== undefined && { type: parsed.type }),
       ...(parsed.name !== undefined && { name: parsed.name }),
-      ...(parsed.description !== undefined && { description: parsed.description }),
+      ...(parsed.description !== undefined && {
+        description: parsed.description,
+      }),
       ...(parsed.version !== undefined && { version: parsed.version }),
       ...(parsed.tags !== undefined && { tags: parsed.tags }),
       ...(parsed.icon !== undefined && { icon: parsed.icon }),
@@ -94,7 +103,9 @@ export function parseManifest(data: unknown): AppCatalogEntry[] {
       ...(parsed.compatibleHostVersions !== undefined && {
         compatibleHostVersions: parsed.compatibleHostVersions,
       }),
-      ...(parsed.dependencies !== undefined && { dependencies: parsed.dependencies }),
+      ...(parsed.dependencies !== undefined && {
+        dependencies: parsed.dependencies,
+      }),
     }
 
     entries.push(entry)

--- a/src/features/AppShell.tsx
+++ b/src/features/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material'
-import { ReactElement, useEffect, useRef, useState } from 'react'
+import { ReactElement, useContext, useEffect, useRef, useState } from 'react'
 import {
   Outlet,
   useNavigate,
@@ -7,6 +7,7 @@ import {
   useSearchParams,
 } from 'react-router-dom'
 
+import { AppConfigContext } from '../AppConfigContext'
 import { markBoot } from '../boot/metrics/bootMarks'
 import { BootShell } from '../boot/shell/BootShell'
 import { runAppShellBoot } from '../boot/steps/runAppShellBoot'
@@ -15,9 +16,12 @@ import { useMessageStore } from '../data/hooks/stores/MessageStore'
 import { useAppManager } from '../data/hooks/stores/useAppManager'
 import { useLoadNetworkSummaries } from '../data/hooks/useLoadNetworkSummaries'
 import { logStartup } from '../debug'
+import { AppType } from '../models/AppModel/AppType'
+import type { PendingAppInstall } from '../models/AppModel/PendingAppInstall'
+import { pendingInstallName } from '../models/AppModel/PendingAppInstall'
 import { MessageSeverity } from '../models/MessageModel'
+import { AppInstallConfirmationDialog } from './AppManager/AppInstallConfirmationDialog'
 import { AppManagerCommandsProvider } from './AppManager/AppManagerCommandsContext'
-import { ConfirmationDialog } from './ConfirmationDialog'
 import { markCrossTabSyncReady } from '@/data/sync/crossTabSyncGate'
 import { SyncTabsAction } from './SyncTabs'
 import { ToolBar } from './ToolBar'
@@ -27,7 +31,7 @@ import { ToolBar } from './ToolBar'
  *
  * Startup itself lives in src/boot/steps/ — this component owns only the
  * React-side concerns (the mount-time URL snapshot, the run-once guard, and
- * the service-app confirmation prompt) and delegates the rest to
+ * the app-install confirmation prompt) and delegates the rest to
  * runAppShellBoot.
  */
 const AppShell = (): ReactElement => {
@@ -36,12 +40,15 @@ const AppShell = (): ReactElement => {
   const navigate = useNavigate()
   const [search] = useSearchParams()
   const loadNetworkSummaries = useLoadNetworkSummaries()
+  const { appInstallAllowedOrigins } = useContext(AppConfigContext)
 
   const addMessage = useMessageStore((state) => state.addMessage)
   const addService = useAppStore((state) => state.addService)
 
-  // Service-app URLs requested via ?addserviceapp=, awaiting user confirmation.
-  const [serviceAppsToAdd, setServiceAppsToAdd] = useState<string[]>([])
+  // Apps requested via ?installApp=, awaiting user confirmation.
+  const [pendingAppInstalls, setPendingAppInstalls] = useState<
+    PendingAppInstall[]
+  >([])
 
   const initialized = useRef(false)
 
@@ -66,11 +73,11 @@ const AppShell = (): ReactElement => {
       pathname: window.location.pathname,
       navigate,
       loadNetworkSummaries,
-      installApp: appManagerCommands.installApp,
+      appInstallAllowedOrigins,
     })
-      .then(({ serviceAppUrlsNeedingConfirmation }) => {
-        if (serviceAppUrlsNeedingConfirmation.length > 0) {
-          setServiceAppsToAdd(serviceAppUrlsNeedingConfirmation)
+      .then(({ pendingAppInstalls: pending }) => {
+        if (pending.length > 0) {
+          setPendingAppInstalls(pending)
         }
       })
       // runAppShellBoot isolates its own phases, so reaching here means the
@@ -97,28 +104,42 @@ const AppShell = (): ReactElement => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-guarded run-once init; snapshots URL state by design
   }, [])
 
-  const handleConfirmAddServiceApps = (): void => {
-    const urls = serviceAppsToAdd
-    setServiceAppsToAdd([])
+  // Installs every confirmed app in turn. Sequential and individually caught: a
+  // link may carry several apps, and one bad endpoint must not abandon the rest.
+  const handleConfirmAppInstalls = (): void => {
+    const confirmed = pendingAppInstalls
+    setPendingAppInstalls([])
     void (async () => {
-      for (const url of urls) {
+      for (const pending of confirmed) {
+        const name = pendingInstallName(pending)
         try {
-          await addService(url)
+          if (pending.type === AppType.Client) {
+            // An install intent implies activation (§7.3). The §9 gate inside
+            // installApp still applies and surfaces its own messages.
+            await appManagerCommands.installApp(pending.entry, {
+              activate: true,
+            })
+          } else {
+            // Refetches the endpoint the boot already read. Deliberate:
+            // addService owns the ServiceApp shape and its persistence, and the
+            // boot's copy exists only to name the app in the dialog.
+            await addService(pending.url)
+          }
           addMessage({
-            message: `Added service app: ${url}`,
+            message: `Added ${name}`,
             duration: 4000,
             severity: MessageSeverity.SUCCESS,
           })
         } catch (error) {
           addMessage({
-            message: `Failed to add service app from ${url}: ${
+            message: `Failed to add ${name} from ${pending.url}: ${
               error instanceof Error ? error.message : 'unknown error'
             }`,
             duration: 5000,
             severity: MessageSeverity.ERROR,
           })
           logStartup.warn(
-            `[AppShell]: addserviceapp intent failed for ${url}`,
+            `[AppShell]: installApp intent failed for ${pending.url}`,
             error,
           )
         }
@@ -161,21 +182,10 @@ const AppShell = (): ReactElement => {
         </Box>
         <SyncTabsAction />
       </Box>
-      <ConfirmationDialog
-        open={serviceAppsToAdd.length > 0}
-        setOpen={(open) => {
-          if (!open) {
-            setServiceAppsToAdd([])
-          }
-        }}
-        title="Add service app?"
-        message={`This link wants to add the following service app${
-          serviceAppsToAdd.length > 1 ? 's' : ''
-        } to Cytoscape Web:\n\n${serviceAppsToAdd.join(
-          '\n',
-        )}\n\nOnly add service apps from sources you trust.`}
-        buttonTitle="Add"
-        onConfirm={handleConfirmAddServiceApps}
+      <AppInstallConfirmationDialog
+        pending={pendingAppInstalls}
+        onConfirm={handleConfirmAppInstalls}
+        onCancel={() => setPendingAppInstalls([])}
       />
     </AppManagerCommandsProvider>
   )

--- a/src/features/AppShell.tsx
+++ b/src/features/AppShell.tsx
@@ -16,11 +16,10 @@ import { useMessageStore } from '../data/hooks/stores/MessageStore'
 import { useAppManager } from '../data/hooks/stores/useAppManager'
 import { useLoadNetworkSummaries } from '../data/hooks/useLoadNetworkSummaries'
 import { logStartup } from '../debug'
-import { AppType } from '../models/AppModel/AppType'
 import type { PendingAppInstall } from '../models/AppModel/PendingAppInstall'
-import { pendingInstallName } from '../models/AppModel/PendingAppInstall'
 import { MessageSeverity } from '../models/MessageModel'
 import { AppInstallConfirmationDialog } from './AppManager/AppInstallConfirmationDialog'
+import { installConfirmedApps } from './AppManager/install/installConfirmedApps'
 import { AppManagerCommandsProvider } from './AppManager/AppManagerCommandsContext'
 import { markCrossTabSyncReady } from '@/data/sync/crossTabSyncGate'
 import { SyncTabsAction } from './SyncTabs'
@@ -104,47 +103,18 @@ const AppShell = (): ReactElement => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- ref-guarded run-once init; snapshots URL state by design
   }, [])
 
-  // Installs every confirmed app in turn. Sequential and individually caught: a
-  // link may carry several apps, and one bad endpoint must not abandon the rest.
   const handleConfirmAppInstalls = (): void => {
     const confirmed = pendingAppInstalls
+    // Cleared before the awaits so the dialog closes on the click, not when the
+    // last install settles.
     setPendingAppInstalls([])
-    void (async () => {
-      for (const pending of confirmed) {
-        const name = pendingInstallName(pending)
-        try {
-          if (pending.type === AppType.Client) {
-            // An install intent implies activation (§7.3). The §9 gate inside
-            // installApp still applies and surfaces its own messages.
-            await appManagerCommands.installApp(pending.entry, {
-              activate: true,
-            })
-          } else {
-            // Refetches the endpoint the boot already read. Deliberate:
-            // addService owns the ServiceApp shape and its persistence, and the
-            // boot's copy exists only to name the app in the dialog.
-            await addService(pending.url)
-          }
-          addMessage({
-            message: `Added ${name}`,
-            duration: 4000,
-            severity: MessageSeverity.SUCCESS,
-          })
-        } catch (error) {
-          addMessage({
-            message: `Failed to add ${name} from ${pending.url}: ${
-              error instanceof Error ? error.message : 'unknown error'
-            }`,
-            duration: 5000,
-            severity: MessageSeverity.ERROR,
-          })
-          logStartup.warn(
-            `[AppShell]: installApp intent failed for ${pending.url}`,
-            error,
-          )
-        }
-      }
-    })()
+    void installConfirmedApps(confirmed, {
+      installApp: appManagerCommands.installApp,
+      addService,
+      addMessage,
+      warn: (message, error) =>
+        logStartup.warn(`[AppShell]: ${message}`, error),
+    })
   }
 
   return (

--- a/src/models/AppModel/AppCatalogEntry.ts
+++ b/src/models/AppModel/AppCatalogEntry.ts
@@ -1,4 +1,4 @@
-import { AppType } from './AppType'
+import type { AppType } from './AppType'
 
 /**
  * Represents a single app entry from the manifest catalog.

--- a/src/models/AppModel/AppCatalogEntry.ts
+++ b/src/models/AppModel/AppCatalogEntry.ts
@@ -1,3 +1,5 @@
+import { AppType } from './AppType'
+
 /**
  * Represents a single app entry from the manifest catalog.
  * Used to display available apps and resolve remote entry URLs.
@@ -5,6 +7,12 @@
 export interface AppCatalogEntry {
   /** Module Federation scope name */
   id: string
+  /**
+   * Which kind of app this entry describes. Optional: the App Store does not
+   * emit it yet, and `?installApp=` payloads are classified structurally when
+   * it is absent (see classifyInstallPayload). When present it wins.
+   */
+  type?: AppType
   /** Human-readable display name (falls back to id) */
   name?: string
   /** Full remote entry URL */

--- a/src/models/AppModel/AppType.ts
+++ b/src/models/AppModel/AppType.ts
@@ -15,3 +15,5 @@ export const AppType = {
   Service: 'service' as const,
   Client: 'client' as const,
 } as const
+
+export type AppType = (typeof AppType)[keyof typeof AppType]

--- a/src/models/AppModel/PendingAppInstall.ts
+++ b/src/models/AppModel/PendingAppInstall.ts
@@ -1,5 +1,5 @@
 import type { AppCatalogEntry } from './AppCatalogEntry'
-import type { AppType } from './AppType'
+import { AppType } from './AppType'
 import type { ServiceMetadata } from './ServiceMetadata'
 
 /**
@@ -15,20 +15,20 @@ import type { ServiceMetadata } from './ServiceMetadata'
  */
 export type PendingAppInstall =
   | {
-      type: typeof AppType.Client
+      readonly type: typeof AppType.Client
       /** The manifest URL the link supplied. */
-      url: string
-      entry: AppCatalogEntry
+      readonly url: string
+      readonly entry: AppCatalogEntry
     }
   | {
-      type: typeof AppType.Service
+      readonly type: typeof AppType.Service
       /** The service endpoint, normalized by `normalizeServiceAppUrl`. */
-      url: string
-      metadata: ServiceMetadata
+      readonly url: string
+      readonly metadata: ServiceMetadata
     }
 
 /** Human-readable label for a pending install, for dialogs and messages. */
 export const pendingInstallName = (pending: PendingAppInstall): string =>
-  pending.type === 'client'
+  pending.type === AppType.Client
     ? (pending.entry.name ?? pending.entry.id)
     : pending.metadata.name

--- a/src/models/AppModel/PendingAppInstall.ts
+++ b/src/models/AppModel/PendingAppInstall.ts
@@ -1,0 +1,34 @@
+import type { AppCatalogEntry } from './AppCatalogEntry'
+import type { AppType } from './AppType'
+import type { ServiceMetadata } from './ServiceMetadata'
+
+/**
+ * An app the URL asked to install, fetched and classified but not yet installed.
+ *
+ * `?installApp=` carries an arbitrary URL, so the boot resolves what is actually
+ * behind it — a React app manifest or service-app metadata — and hands the
+ * result to AppShell, which names each item in a confirmation dialog. Nothing is
+ * installed until the user confirms.
+ *
+ * The metadata is carried for display only. Registration refetches through
+ * `addService`, which owns the ServiceApp shape and its persistence.
+ */
+export type PendingAppInstall =
+  | {
+      type: typeof AppType.Client
+      /** The manifest URL the link supplied. */
+      url: string
+      entry: AppCatalogEntry
+    }
+  | {
+      type: typeof AppType.Service
+      /** The service endpoint, normalized by `normalizeServiceAppUrl`. */
+      url: string
+      metadata: ServiceMetadata
+    }
+
+/** Human-readable label for a pending install, for dialogs and messages. */
+export const pendingInstallName = (pending: PendingAppInstall): string =>
+  pending.type === 'client'
+    ? (pending.entry.name ?? pending.entry.id)
+    : pending.metadata.name

--- a/src/models/AppModel/ServiceMetadata.ts
+++ b/src/models/AppModel/ServiceMetadata.ts
@@ -19,7 +19,9 @@ export interface ServiceMetadata {
   serviceInputDefinition?: ServiceInputDefinition
   cyWebActions: ServiceAppAction[]
   cyWebMenuItem: CyWebMenuItem
-  author: string
-  citation:string
+  // Nullable because endpoints send null rather than omitting them — the live
+  // cytocontainer example service does exactly that for both.
+  author: string | null
+  citation: string | null
   parameters: ServiceAppParameter[]
 }

--- a/src/models/AppModel/impl/index.test.ts
+++ b/src/models/AppModel/impl/index.test.ts
@@ -13,7 +13,6 @@ import {
   normalizeServiceAppUrl,
   resolveParameterValue,
   sendsNoData,
-  serviceAppUrlsToAdd,
   shouldShowServiceDescription,
   validateParameter,
 } from './index'
@@ -38,29 +37,11 @@ describe('AppModel impl', () => {
     })
   })
 
-  describe('serviceAppUrlsToAdd', () => {
-    it('returns normalized, new, de-duplicated urls', () => {
-      const existing = { 'https://x/a': {} }
-      const requested = [
-        'https://x/a/', // already installed (after normalization)
-        ' https://x/b ', // new, needs normalization
-        'https://x/b', // duplicate of the above
-        '   ', // empty
-      ]
-      expect(serviceAppUrlsToAdd(requested, existing)).toEqual(['https://x/b'])
-    })
-
-    it('returns an empty array when nothing is new', () => {
-      expect(serviceAppUrlsToAdd([], {})).toEqual([])
-      expect(
-        serviceAppUrlsToAdd(['https://x/a'], { 'https://x/a': {} }),
-      ).toEqual([])
-    })
-  })
-
   describe('columnTypeMatchesFilter', () => {
     it('matches every column when the filter is absent or empty', () => {
-      expect(columnTypeMatchesFilter(ValueTypeName.String, undefined)).toBe(true)
+      expect(columnTypeMatchesFilter(ValueTypeName.String, undefined)).toBe(
+        true,
+      )
       expect(columnTypeMatchesFilter(ValueTypeName.String, null)).toBe(true)
       expect(columnTypeMatchesFilter(ValueTypeName.Long, '')).toBe(true)
     })
@@ -76,8 +57,12 @@ describe('AppModel impl', () => {
     it('matches the number alias for any numeric type', () => {
       expect(columnTypeMatchesFilter(ValueTypeName.Long, 'number')).toBe(true)
       expect(columnTypeMatchesFilter(ValueTypeName.Double, 'number')).toBe(true)
-      expect(columnTypeMatchesFilter(ValueTypeName.Integer, 'number')).toBe(true)
-      expect(columnTypeMatchesFilter(ValueTypeName.String, 'number')).toBe(false)
+      expect(columnTypeMatchesFilter(ValueTypeName.Integer, 'number')).toBe(
+        true,
+      )
+      expect(columnTypeMatchesFilter(ValueTypeName.String, 'number')).toBe(
+        false,
+      )
     })
 
     it('matches the list alias for any list type', () => {
@@ -89,9 +74,9 @@ describe('AppModel impl', () => {
     })
 
     it('matches wholenumber only for integer columns', () => {
-      expect(columnTypeMatchesFilter(ValueTypeName.Integer, 'wholenumber')).toBe(
-        true,
-      )
+      expect(
+        columnTypeMatchesFilter(ValueTypeName.Integer, 'wholenumber'),
+      ).toBe(true)
       expect(columnTypeMatchesFilter(ValueTypeName.Long, 'wholenumber')).toBe(
         false,
       )
@@ -128,7 +113,9 @@ describe('AppModel impl', () => {
     it('resolves ndexUUID params from the context url', () => {
       const param = makeParam('net', ParameterUiType.NdexUuid)
       expect(
-        resolveParameterValue(param, { ndexNetworkUrl: 'https://x/v3/networks/1' }),
+        resolveParameterValue(param, {
+          ndexNetworkUrl: 'https://x/v3/networks/1',
+        }),
       ).toBe('https://x/v3/networks/1')
     })
 
@@ -172,7 +159,9 @@ describe('AppModel impl', () => {
         makeParam('networkUrl', ParameterUiType.NdexUuid),
       ]
       expect(
-        buildCustomParameters(params, { ndexNetworkUrl: 'https://x/v3/networks/1' }),
+        buildCustomParameters(params, {
+          ndexNetworkUrl: 'https://x/v3/networks/1',
+        }),
       ).toEqual({
         updatedBy: 'demo',
         networkUrl: 'https://x/v3/networks/1',

--- a/src/models/AppModel/impl/index.ts
+++ b/src/models/AppModel/impl/index.ts
@@ -26,29 +26,6 @@ export const normalizeServiceAppUrl = (url: string): string => {
 }
 
 /**
- * Given a list of requested service-app URLs (e.g. from an addserviceapp query
- * param) and the currently installed service apps, return the normalized,
- * de-duplicated URLs that are new and worth installing. Empty and
- * already-installed URLs are dropped.
- */
-export const serviceAppUrlsToAdd = (
-  requestedUrls: string[],
-  existing: Record<string, unknown>,
-): string[] => {
-  const seen = new Set<string>()
-  const result: string[] = []
-  requestedUrls.forEach((raw) => {
-    const url = normalizeServiceAppUrl(raw)
-    if (url === '' || existing[url] !== undefined || seen.has(url)) {
-      return
-    }
-    seen.add(url)
-    result.push(url)
-  })
-  return result
-}
-
-/**
  * Build the full NDEx REST URL for a network from the configured NDEx host and
  * the network's external (NDEx) id.
  */

--- a/src/models/AppModel/index.ts
+++ b/src/models/AppModel/index.ts
@@ -12,7 +12,7 @@ export { RootMenu } from './RootMenu'
 export type { ServiceApp } from './ServiceApp'
 export type { ServiceMetadata } from './ServiceMetadata'
 export {
-  looksLikeServiceMetadata,
   parseServiceMetadata,
+  serviceMetadataIfMarked,
   ServiceMetadataSchema,
 } from './serviceMetadataSchema'

--- a/src/models/AppModel/index.ts
+++ b/src/models/AppModel/index.ts
@@ -1,8 +1,18 @@
 export type { AppCatalogEntry } from './AppCatalogEntry'
 export type { AppComponent } from './AppComponent'
 export type { AppLoadState } from './AppLoadState'
+export { AppType } from './AppType'
 export { ComponentType } from './ComponentType'
 export type { CyApp } from './CyApp'
 export type { AppSource, InstalledApp } from './InstalledApp'
 export type { ManifestSource } from './ManifestSource'
+export { pendingInstallName } from './PendingAppInstall'
+export type { PendingAppInstall } from './PendingAppInstall'
 export { RootMenu } from './RootMenu'
+export type { ServiceApp } from './ServiceApp'
+export type { ServiceMetadata } from './ServiceMetadata'
+export {
+  looksLikeServiceMetadata,
+  parseServiceMetadata,
+  ServiceMetadataSchema,
+} from './serviceMetadataSchema'

--- a/src/models/AppModel/serviceMetadataSchema.test.ts
+++ b/src/models/AppModel/serviceMetadataSchema.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  looksLikeServiceMetadata,
   parseServiceMetadata,
+  serviceMetadataIfMarked,
 } from './serviceMetadataSchema'
 
 describe('parseServiceMetadata', () => {
@@ -53,33 +53,40 @@ describe('parseServiceMetadata', () => {
   })
 })
 
-describe('looksLikeServiceMetadata', () => {
+describe('serviceMetadataIfMarked', () => {
   it.each(['cyWebActions', 'cyWebMenuItem', 'serviceInputDefinition'])(
-    'is true when %s is present',
+    'parses when %s is present',
     (marker) => {
-      expect(
-        looksLikeServiceMetadata({
-          name: 'Service A',
-          parameters: [],
-          [marker]: marker === 'cyWebActions' ? [] : {},
-        }),
-      ).toBe(true)
+      const metadata = serviceMetadataIfMarked({
+        name: 'Service A',
+        parameters: [],
+        [marker]: marker === 'cyWebActions' ? [] : {},
+      })
+
+      expect(metadata?.name).toBe('Service A')
     },
   )
 
-  it('is false for valid metadata with no service marker', () => {
+  it('returns undefined for valid metadata with no service marker', () => {
     expect(
-      looksLikeServiceMetadata({ name: 'Service A', parameters: [] }),
-    ).toBe(false)
+      serviceMetadataIfMarked({ name: 'Service A', parameters: [] }),
+    ).toBeUndefined()
   })
 
-  it('is false for a React app manifest entry', () => {
+  it('returns undefined for a React app manifest entry', () => {
     expect(
-      looksLikeServiceMetadata({
+      serviceMetadataIfMarked({
         id: 'mcodeweb',
         name: 'MCODE Web',
         url: 'https://apps.cytoscape.org/web/mcodeweb/remoteEntry.js',
       }),
-    ).toBe(false)
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when a marked payload fails the schema', () => {
+    // Marked but unusable: the marker alone must not get it registered.
+    expect(
+      serviceMetadataIfMarked({ cyWebActions: ['updateTables'] }),
+    ).toBeUndefined()
   })
 })

--- a/src/models/AppModel/serviceMetadataSchema.test.ts
+++ b/src/models/AppModel/serviceMetadataSchema.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  looksLikeServiceMetadata,
+  parseServiceMetadata,
+} from './serviceMetadataSchema'
+
+describe('parseServiceMetadata', () => {
+  it('accepts null author and citation, as real endpoints send them', () => {
+    // ServiceMetadata declares both as required strings. A schema written to
+    // match the interface literally would reject every service app in the wild.
+    const metadata = parseServiceMetadata({
+      name: 'Update tables example',
+      version: '0.9.0',
+      author: null,
+      citation: null,
+      cyWebActions: ['updateTables'],
+      parameters: [],
+    })
+
+    expect(metadata?.name).toBe('Update tables example')
+  })
+
+  it('accepts the minimum a registered service app carries today', () => {
+    // What AppStore.spec.ts registers. Requiring a service marker to register
+    // would reject these — that check belongs to classification, not validity.
+    expect(
+      parseServiceMetadata({ name: 'Service A', parameters: [] }),
+    ).toBeDefined()
+  })
+
+  it('defaults parameters to an empty array', () => {
+    // updateServiceParameter calls serviceApp.parameters.find(...), which throws
+    // when the array is absent.
+    expect(parseServiceMetadata({ name: 'Service A' })?.parameters).toEqual([])
+  })
+
+  it('preserves unknown fields', () => {
+    const metadata = parseServiceMetadata({
+      name: 'Service A',
+      futureField: 'kept',
+    })
+
+    expect((metadata as unknown as Record<string, unknown>).futureField).toBe(
+      'kept',
+    )
+  })
+
+  it('rejects a missing or empty name', () => {
+    expect(parseServiceMetadata({ parameters: [] })).toBeUndefined()
+    expect(parseServiceMetadata({ name: '' })).toBeUndefined()
+    expect(parseServiceMetadata(null)).toBeUndefined()
+  })
+})
+
+describe('looksLikeServiceMetadata', () => {
+  it.each(['cyWebActions', 'cyWebMenuItem', 'serviceInputDefinition'])(
+    'is true when %s is present',
+    (marker) => {
+      expect(
+        looksLikeServiceMetadata({
+          name: 'Service A',
+          parameters: [],
+          [marker]: marker === 'cyWebActions' ? [] : {},
+        }),
+      ).toBe(true)
+    },
+  )
+
+  it('is false for valid metadata with no service marker', () => {
+    expect(
+      looksLikeServiceMetadata({ name: 'Service A', parameters: [] }),
+    ).toBe(false)
+  })
+
+  it('is false for a React app manifest entry', () => {
+    expect(
+      looksLikeServiceMetadata({
+        id: 'mcodeweb',
+        name: 'MCODE Web',
+        url: 'https://apps.cytoscape.org/web/mcodeweb/remoteEntry.js',
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/models/AppModel/serviceMetadataSchema.ts
+++ b/src/models/AppModel/serviceMetadataSchema.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod'
+
+import type { ServiceMetadata } from './ServiceMetadata'
+
+/**
+ * Runtime validation for service-app metadata fetched from an endpoint.
+ *
+ * Two exports with deliberately different jobs:
+ *
+ * - `ServiceMetadataSchema` answers "is this a usable service app?" and gates
+ *   registration (`serviceFetcher`).
+ * - `looksLikeServiceMetadata` answers "is this a service app rather than a
+ *   React app manifest?" and gates classification of an `?installApp=` payload.
+ *
+ * The second is strictly narrower, and the difference matters: service apps in
+ * the wild (and the fixtures in AppStore.spec.ts) register successfully with
+ * nothing but a `name` and `parameters`. Requiring a service marker to
+ * *register* would reject them, including on `refreshAllServices`. A marker is
+ * how you tell the two payload shapes apart, not what makes metadata valid.
+ *
+ * Leniency elsewhere is also deliberate:
+ *
+ * - `.passthrough()` — the service-app spec ships with the Cytoscape Web paper
+ *   and gains fields independently of this repo. Unknown keys must survive into
+ *   the stored ServiceApp, not be stripped.
+ * - `author`/`citation`/`description` accept null. ServiceMetadata declares the
+ *   first two as required strings, but real endpoints send `null`, so a schema
+ *   matching the interface literally would reject working apps.
+ * - `parameters` defaults to `[]`. `updateServiceParameter` calls
+ *   `serviceApp.parameters.find(...)`, which throws when the array is absent.
+ */
+
+const MenuPathElementSchema = z
+  .object({
+    name: z.string().optional(),
+    gravity: z.number().optional(),
+  })
+  .passthrough()
+
+const CyWebMenuItemSchema = z
+  .object({
+    root: z.string().optional(),
+    path: z.array(MenuPathElementSchema).optional(),
+  })
+  .passthrough()
+
+const ServiceAppParameterSchema = z
+  .object({
+    displayName: z.string(),
+  })
+  .passthrough()
+
+export const ServiceMetadataSchema = z
+  .object({
+    name: z.string().min(1),
+    version: z.string().optional(),
+    description: z.string().nullish(),
+    showDescriptionInDialog: z.boolean().optional(),
+    author: z.string().nullish(),
+    citation: z.string().nullish(),
+    cyWebActions: z.array(z.string()).optional(),
+    cyWebMenuItem: CyWebMenuItemSchema.optional(),
+    serviceInputDefinition: z.record(z.unknown()).nullish(),
+    parameters: z.array(ServiceAppParameterSchema).optional().default([]),
+  })
+  .passthrough()
+
+/**
+ * Validate a fetched payload as service metadata.
+ *
+ * Returns the parsed metadata, or undefined when it is not a service app. The
+ * cast is safe only because the schema mirrors ServiceMetadata's required
+ * fields; zod's inferred type is wider (passthrough, nullable) than the
+ * interface, which is the point — see the leniency notes above.
+ */
+export const parseServiceMetadata = (
+  data: unknown,
+): ServiceMetadata | undefined => {
+  const result = ServiceMetadataSchema.safeParse(data)
+  return result.success
+    ? (result.data as unknown as ServiceMetadata)
+    : undefined
+}
+
+/**
+ * True when a payload is service-app metadata rather than a React app manifest.
+ *
+ * Valid metadata plus at least one field only a service app declares. A React
+ * manifest entry has none of these, and would in any case fail the schema's
+ * `name` requirement far less reliably than this — `parseManifest` accepts
+ * entries with no `name` at all.
+ */
+export const looksLikeServiceMetadata = (data: unknown): boolean => {
+  const metadata = parseServiceMetadata(data)
+  if (metadata === undefined) {
+    return false
+  }
+  const raw = data as Record<string, unknown>
+  return (
+    raw.cyWebActions !== undefined ||
+    raw.cyWebMenuItem !== undefined ||
+    raw.serviceInputDefinition !== undefined
+  )
+}

--- a/src/models/AppModel/serviceMetadataSchema.ts
+++ b/src/models/AppModel/serviceMetadataSchema.ts
@@ -9,7 +9,7 @@ import type { ServiceMetadata } from './ServiceMetadata'
  *
  * - `ServiceMetadataSchema` answers "is this a usable service app?" and gates
  *   registration (`serviceFetcher`).
- * - `looksLikeServiceMetadata` answers "is this a service app rather than a
+ * - `serviceMetadataIfMarked` answers "is this a service app rather than a
  *   React app manifest?" and gates classification of an `?installApp=` payload.
  *
  * The second is strictly narrower, and the difference matters: service apps in
@@ -83,22 +83,28 @@ export const parseServiceMetadata = (
 }
 
 /**
- * True when a payload is service-app metadata rather than a React app manifest.
+ * Parse a payload only if it is service-app metadata rather than a React app
+ * manifest: valid metadata *plus* at least one field only a service app
+ * declares. Returns undefined otherwise.
  *
- * Valid metadata plus at least one field only a service app declares. A React
- * manifest entry has none of these, and would in any case fail the schema's
- * `name` requirement far less reliably than this — `parseManifest` accepts
- * entries with no `name` at all.
+ * Stricter than `parseServiceMetadata`, and used only to tell the two payload
+ * shapes apart. Requiring a marker to *register* would reject service apps that
+ * work today — see the note above.
+ *
+ * Returns the metadata rather than a boolean so the caller does not have to
+ * parse a second time to get at it.
  */
-export const looksLikeServiceMetadata = (data: unknown): boolean => {
-  const metadata = parseServiceMetadata(data)
-  if (metadata === undefined) {
-    return false
+export const serviceMetadataIfMarked = (
+  data: unknown,
+): ServiceMetadata | undefined => {
+  if (typeof data !== 'object' || data === null) {
+    return undefined
   }
   const raw = data as Record<string, unknown>
-  return (
+  const marked =
     raw.cyWebActions !== undefined ||
     raw.cyWebMenuItem !== undefined ||
     raw.serviceInputDefinition !== undefined
-  )
+
+  return marked ? parseServiceMetadata(data) : undefined
 }


### PR DESCRIPTION
Closes #639

`?installApp=` is now the single, repeatable install intent for both app kinds, and both prompt the user before anything is added.

## Why

Two parameters carried four asymmetries beyond the name:

| | `?installApp=` (React) | `?addserviceapp=` (service) |
| --- | --- | --- |
| Multiplicity | `get()` — one value | `getAll()` — repeatable |
| User consent | none — installed silently | confirmation dialog |
| Validation | zod schema | none — raw cast |
| Origin gate | `appInstallAllowedOrigins` | none |
| Fetch deadline | 10s | none |

One parameter cannot keep them, so consolidating meant reconciling each one.

## Decisions

1. **Both kinds prompt.** This is the behavior change to `?installApp=`, which installed silently.
2. **React apps keep the origin allow-list, on top of the dialog.** A React app loads a remote `remoteEntry.js` as code in Cytoscape Web's own origin, so consent is not sufficient as the only gate. Checked before the prompt, so the user is never asked about an install that cannot happen. Service apps stay open to any origin — the dialog is their gate. (Open question 2 in the issue: the gate stays type-dependent.)
3. **Optional `type` field** in the React manifest, wired to the previously unused `AppType` enum. Optional with a structural fallback, because making it required would break every manifest already published on `apps-stage.cytoscape.org`. (Open question 1: it ships now so the App Store can emit it on its own timeline.)
4. **`?addserviceapp=` is removed**, not deprecated — it has no users.

## Classification

`classifyInstallPayload` (`src/features/AppManager/install/classifyInstallPayload.ts`), pure and framework-free like the rest of that directory:

```
1. Array                            → parseSingleEntryManifest    → client
2. Object, type === 'service'       → ServiceMetadataSchema       → service
3. Object, type === 'client'        → parseSingleEntryManifest    → client
4. Object, looksLikeServiceMetadata                               → service
5. Object, parseSingleEntryManifest([data]) succeeds              → client
6. otherwise                        → undefined, error toast
```

Rule 1 makes today's `?installApp=` behavior a strict subset of the new behavior. Rules 2–5 exist because the React example in #639 is a bare object with a stray trailing `]`, so the App Store may serve either shape — which is what makes the `type` field load-bearing for the single-object case.

## Validation

New `ServiceMetadataSchema` (`src/models/AppModel/serviceMetadataSchema.ts`) replaces the raw cast in `serviceFetcher`, so an unvalidated payload is no longer reachable from a link that looks like an app install.

Two exports with different jobs:

- `ServiceMetadataSchema` — validity, gates registration. Deliberately lenient: `.passthrough()` because the service-app spec ships with the paper and gains fields independently of this repo; `author`/`citation` accept `null` because endpoints send it; `parameters` defaults to `[]` because `updateServiceParameter` calls `.parameters.find(...)`.
- `looksLikeServiceMetadata` — discrimination, strictly narrower (schema *plus* a service marker).

Keeping them separate matters. The fixtures in `AppStore.spec.ts` register service apps with nothing but `{ name, parameters }`; folding the marker check into the validity schema breaks four passing tests and would reject real apps on `refreshAllServices`. A marker is how you tell the two payload shapes apart, not what makes metadata valid.

## Changed

**New**

| File | Purpose |
| --- | --- |
| `src/models/AppModel/serviceMetadataSchema.ts` | `ServiceMetadataSchema`, `parseServiceMetadata`, `looksLikeServiceMetadata` |
| `src/models/AppModel/PendingAppInstall.ts` | Discriminated union the `INTENTS` phase returns |
| `src/features/AppManager/install/classifyInstallPayload.ts` | The classification rule above |
| `src/features/AppManager/AppInstallConfirmationDialog.tsx` | The dialog |

**Modified**

- `src/boot/steps/runInstallIntents.ts` — the main rewrite. `getAll('installApp')`, fetch each under the 10s `AbortSignal.timeout` (service URLs now have a deadline; they had none), classify, origin pre-check for React apps, dedupe. Per-URL error isolation: one dead host does not lose the others. Installs nothing.
- `src/boot/steps/appShellBootContext.ts` — swaps `installApp`, now unused, for `appInstallAllowedOrigins`, which a plain async step cannot read from React context.
- `src/features/AppShell.tsx` — holds `PendingAppInstall[]`, renders the dialog, installs on confirm via `installApp` or `addService` with per-item toasts.
- `src/data/hooks/stores/AppStore.ts` — `serviceFetcher` validates. The Layout-menu action check is unchanged.
- `parseManifest.ts` / `AppCatalogEntry.ts` / `AppType.ts` / `AppModel/index.ts` — the optional `type` field and the `AppType` type alias + export.

**Removed**

`serviceAppUrlsToAdd` and its tests. It went dead once the pipeline deduped across both kinds; `normalizeServiceAppUrl` stays.

**Docs**

`ROUTING_SPECIFICATION.md`, `boot.md`, `bootPhases.ts`, plus `workspace-app-install-design.md` §7.2 (payload table, revised sequence diagram) and a new §9.1 explaining why service apps are gated differently.

## The dialog

Captured from the running app with both payloads passed in one URL:

```
┌─ Install into this workspace? ──────────────────────────┐
│ This link wants to add the following to Cytoscape Web:  │
│                                                         │
│ MCODE Web  (App)   v0.1.0 — Bader Lab, U. of Toronto    │
│ Finds densely connected regions of a network.           │
│ http://localhost:8899/manifest.json                     │
│                                                         │
│ Update tables example  (Service)   v0.9.0               │
│ Adds a new column, named 'test_col' by default, to …    │
│ http://localhost:8899/service.json                      │
│                                                         │
│ Only install apps from sources you trust.               │
│                            [CANCEL]  [INSTALL]          │
└─────────────────────────────────────────────────────────┘
```

Confirm is all-or-nothing. Cancel installs nothing and stays silent, as before. The dialog appears after `ROUTE` has stripped the params; the workspace-hydration precondition (§8.3) still holds because `PUBLISH` runs before `INTENTS`.

## Verification

**Unit** — 25 new tests across `classifyInstallPayload.test.ts` (one case per rule, driven by both real payloads from the issue), `serviceMetadataSchema.test.ts`, `AppInstallConfirmationDialog.spec.tsx`, and the `install intents` block in `runAppShellBoot.test.ts` (each kind, repeated mixed, disallowed origin, already-registered service, malformed payload).

`AppStore.spec.ts` passes **unmodified** — that is the guard on schema leniency.

`npm run lint` clean.

Full suite: 3332/3338. Five failures — `openDatabasePhase`, `SnackbarMessageList`, `TableColumnForm`, and two Vizmapper StyleManager specs — all pass in isolation, and the failing set changed between runs (3, then 5, 2 shared). Pre-existing flakes from the 1s global test timeout under worker contention; none in app-install code.

**Manual**, driven with Playwright against a local manifest and service endpoint:

```
CONFIRM toast lines: [ 'Added Update tables example' ]
CONFIRM persisted: {"serviceApps":["Update tables example"],"installedApps":["mcodeweb:active"]}
DISALLOWED dialog shown: false
DISALLOWED error toast: true
DISALLOWED app still booted: true
```

One dialog listed both apps; confirming registered the service app and installed + activated the React app; params were stripped before the dialog appeared. A manifest pointing at `https://evil.example.com/remoteEntry.js` produced an error toast and no dialog.

**Caveat:** any endpoint serving `?installApp=` must send `Access-Control-Allow-Origin` — my test server needed it before the fetch worked. This was already true, since `?installApp=` already fetched.

No E2E spec covered either parameter, so none was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added URL-based installation for client and service apps using repeatable `installApp` parameters.
  * Added a consolidated confirmation dialog with app details before installation.
  * Client apps can activate immediately; service apps are added to the workspace.
  * Added validation, origin restrictions, duplicate filtering, and per-app error handling.

* **Bug Fixes**
  * Invalid or failed installation requests no longer interrupt startup.
  * Removed the legacy `addserviceapp` installation parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->