### PR TITLE
Allow self-loops from the node context menu

### DIFF
--- a/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -185,6 +185,12 @@ const CyjsRenderer = ({
       sourceNodeId: edgeCreationMode.sourceNodeId,
     })
 
+    // Leaving the mode does not move the pointer, so the node under it keeps
+    // its target highlight until an unrelated mouseout: clear it here instead.
+    if (!edgeCreationMode.active && cy !== null) {
+      cy.nodes().removeClass('edge-creation-target')
+    }
+
     // Apply cursor style to Cytoscape container when edge creation mode changes
     if (cy !== null && cyContainer.current) {
       const container = cy.container()

--- a/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -39,6 +39,12 @@ import {
 import { CxToCyCanvas } from './annotations/cyjsAnnotationRenderer'
 import { addCyElements } from './cyjsFactoryUtil'
 import { applyViewModel, createCyjsDataMapper } from './cyjsRenderUtil'
+import {
+  EDGE_CREATION_MODE_OFF,
+  EdgeCreationModeState,
+  isEdgeCreationTarget,
+  resolveEdgeCreationTap,
+} from './edgeCreationMode'
 import { ContextMenuState, NetworkContextMenu } from './NetworkContextMenu'
 import { registerCyExtensions } from './registerCyExtensions'
 import { isGraphVisible } from './viewportRecovery'
@@ -126,13 +132,8 @@ const CyjsRenderer = ({
   })
 
   // Edge creation mode state
-  const [edgeCreationMode, setEdgeCreationMode] = useState<{
-    active: boolean
-    sourceNodeId: IdType | null
-  }>({
-    active: false,
-    sourceNodeId: null,
-  })
+  const [edgeCreationMode, setEdgeCreationMode] =
+    useState<EdgeCreationModeState>(EDGE_CREATION_MODE_OFF)
 
   // When cxttap fires, the MUI Menu opens and its backdrop renders before the
   // browser's contextmenu event fires. The contextmenu event then targets the
@@ -173,7 +174,7 @@ const CyjsRenderer = ({
 
   // Reset edge creation mode when switching networks
   useEffect(() => {
-    setEdgeCreationMode({ active: false, sourceNodeId: null })
+    setEdgeCreationMode(EDGE_CREATION_MODE_OFF)
   }, [id])
   // Ref to track edge creation mode for event handlers
   const edgeCreationModeRef = useRef(edgeCreationMode)
@@ -443,8 +444,12 @@ const CyjsRenderer = ({
       e.stopPropagation()
       e.stopImmediatePropagation()
 
-      const targetNodeId: IdType = e.target.data('id')
-      const sourceNodeId = currentMode.sourceNodeId
+      // Tapping the source node itself creates a self-loop
+      const endpoints = resolveEdgeCreationTap(currentMode, e.target.data('id'))
+      if (endpoints === null) {
+        return
+      }
+      const { sourceNodeId, targetNodeId } = endpoints
 
       logUi.info(
         '[CyjsRenderer] edgeCreationTapHandler: Processing edge creation',
@@ -454,20 +459,11 @@ const CyjsRenderer = ({
         },
       )
 
-      // Check for self-loop
-      if (targetNodeId === sourceNodeId) {
-        logUi.info(
-          '[CyjsRenderer] edgeCreationTapHandler: Self-loop detected, preventing',
-        )
-        // TODO: Show tooltip or prevent self-loop
-        return
-      }
-
       // Exit edge creation mode
       logUi.info(
         '[CyjsRenderer] edgeCreationTapHandler: Exiting edge creation mode and creating edge',
       )
-      setEdgeCreationMode({ active: false, sourceNodeId: null })
+      setEdgeCreationMode(EDGE_CREATION_MODE_OFF)
 
       // Create edge directly with default empty attributes
       createEdge(id, sourceNodeId, targetNodeId, { attributes: {} })
@@ -498,7 +494,7 @@ const CyjsRenderer = ({
           logUi.info(
             '[CyjsRenderer] General tap handler: Background click, exiting edge creation mode',
           )
-          setEdgeCreationMode({ active: false, sourceNodeId: null })
+          setEdgeCreationMode(EDGE_CREATION_MODE_OFF)
         } else if (targetIsNode) {
           // Node click: let the edge creation handler process it
           // Don't do normal selection
@@ -745,15 +741,18 @@ const CyjsRenderer = ({
       const targetNode = e.target
       setHoveredElement(targetNode.data('id'))
 
-      // In edge creation mode, highlight valid target nodes
+      // In edge creation mode, highlight valid target nodes.
+      // The source node is a valid target too: it creates a self-loop.
       const currentMode = edgeCreationModeRef.current
       const targetIsNode =
         typeof targetNode.isNode === 'function' && targetNode.isNode()
-      if (currentMode.active && targetIsNode) {
-        const nodeId = targetNode.data('id')
-        if (nodeId !== currentMode.sourceNodeId) {
-          targetNode.addClass('edge-creation-target')
-        }
+      if (
+        isEdgeCreationTarget(
+          currentMode,
+          targetIsNode ? targetNode.data('id') : null,
+        )
+      ) {
+        targetNode.addClass('edge-creation-target')
       }
     })
     // Remove hover class and clear hovered element on mouseout
@@ -1408,7 +1407,7 @@ const CyjsRenderer = ({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (e.key === 'Escape' && edgeCreationMode.active) {
-        setEdgeCreationMode({ active: false, sourceNodeId: null })
+        setEdgeCreationMode(EDGE_CREATION_MODE_OFF)
       }
     }
 
@@ -1424,7 +1423,7 @@ const CyjsRenderer = ({
 
     const handleBackgroundClick = (e: EventObject): void => {
       if (e.target === cy) {
-        setEdgeCreationMode({ active: false, sourceNodeId: null })
+        setEdgeCreationMode(EDGE_CREATION_MODE_OFF)
       }
     }
 

--- a/src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  EDGE_CREATION_MODE_OFF,
+  isEdgeCreationTarget,
+  resolveEdgeCreationTap,
+} from './edgeCreationMode'
+
+describe('resolveEdgeCreationTap', () => {
+  it('returns null when the mode is inactive', () => {
+    expect(resolveEdgeCreationTap(EDGE_CREATION_MODE_OFF, 'n1')).toBeNull()
+  })
+
+  it('returns null when there is no source node', () => {
+    expect(
+      resolveEdgeCreationTap({ active: true, sourceNodeId: null }, 'n1'),
+    ).toBeNull()
+  })
+
+  it('returns null when the tapped element is not a node', () => {
+    expect(
+      resolveEdgeCreationTap({ active: true, sourceNodeId: 'n1' }, null),
+    ).toBeNull()
+  })
+
+  it('resolves a tap on another node into an edge', () => {
+    expect(
+      resolveEdgeCreationTap({ active: true, sourceNodeId: 'n1' }, 'n2'),
+    ).toEqual({ sourceNodeId: 'n1', targetNodeId: 'n2' })
+  })
+
+  it('resolves a tap on the source node into a self-loop', () => {
+    expect(
+      resolveEdgeCreationTap({ active: true, sourceNodeId: 'n1' }, 'n1'),
+    ).toEqual({ sourceNodeId: 'n1', targetNodeId: 'n1' })
+  })
+})
+
+describe('isEdgeCreationTarget', () => {
+  it('is false when the mode is inactive', () => {
+    expect(isEdgeCreationTarget(EDGE_CREATION_MODE_OFF, 'n1')).toBe(false)
+  })
+
+  it('is true for a node other than the source', () => {
+    expect(
+      isEdgeCreationTarget({ active: true, sourceNodeId: 'n1' }, 'n2'),
+    ).toBe(true)
+  })
+
+  it('is true for the source node itself, so self-loops can be previewed', () => {
+    expect(
+      isEdgeCreationTarget({ active: true, sourceNodeId: 'n1' }, 'n1'),
+    ).toBe(true)
+  })
+})

--- a/src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.ts
@@ -9,7 +9,7 @@
  * tested without a Cytoscape.js instance.
  */
 
-import { IdType } from '../../../models/IdType'
+import { IdType } from '@/models/IdType'
 
 /**
  * Edge creation mode state: which node an edge is being drawn from, if any.

--- a/src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.ts
@@ -1,0 +1,68 @@
+/**
+ * edgeCreationMode.ts
+ *
+ * State and pure decision logic for the renderer's edge creation mode, which is
+ * entered from the node context menu ("Create Edge from this Node") and left by
+ * clicking a node, clicking the background, or pressing ESC.
+ *
+ * The logic lives here rather than inline in `CyjsRenderer` so it can be unit
+ * tested without a Cytoscape.js instance.
+ */
+
+import { IdType } from '../../../models/IdType'
+
+/**
+ * Edge creation mode state: which node an edge is being drawn from, if any.
+ */
+export interface EdgeCreationModeState {
+  active: boolean
+  sourceNodeId: IdType | null
+}
+
+/**
+ * The inactive state, used to enter and leave the mode.
+ */
+export const EDGE_CREATION_MODE_OFF: EdgeCreationModeState = {
+  active: false,
+  sourceNodeId: null,
+}
+
+/**
+ * Endpoints of the edge a tap resolved to.
+ */
+export interface EdgeCreationEndpoints {
+  sourceNodeId: IdType
+  targetNodeId: IdType
+}
+
+/**
+ * Decide which edge, if any, a tap should create.
+ *
+ * Tapping the source node itself is a valid gesture: it creates a self-loop.
+ *
+ * @param mode - Current edge creation mode state
+ * @param targetNodeId - ID of the tapped node, or null if a non-node was tapped
+ * @returns The edge endpoints to create, or null if the tap should be ignored
+ */
+export const resolveEdgeCreationTap = (
+  mode: EdgeCreationModeState,
+  targetNodeId: IdType | null,
+): EdgeCreationEndpoints | null => {
+  if (!mode.active || mode.sourceNodeId === null || targetNodeId === null) {
+    return null
+  }
+
+  return { sourceNodeId: mode.sourceNodeId, targetNodeId }
+}
+
+/**
+ * Whether a hovered node is a valid target while edge creation mode is active.
+ * The source node qualifies, since tapping it creates a self-loop.
+ *
+ * @param mode - Current edge creation mode state
+ * @param nodeId - ID of the hovered node, or null if a non-node is hovered
+ */
+export const isEdgeCreationTarget = (
+  mode: EdgeCreationModeState,
+  nodeId: IdType | null,
+): boolean => resolveEdgeCreationTap(mode, nodeId) !== null

--- a/test/playwright/self-loop-creation.spec.ts
+++ b/test/playwright/self-loop-creation.spec.ts
@@ -1,0 +1,145 @@
+import { type Page } from '@playwright/test'
+
+import { expect, gotoAndSeedNetwork, test } from './fixtures'
+
+// Self-loop creation through the node context menu: right-click a node,
+// pick "Create Edge from this Node", then left-click the same node. The
+// renderer used to drop that second click, so no edge was created.
+
+type CyWebApiWindow = {
+  CyWebApi?: {
+    workspace: {
+      getCurrentNetworkId: () => {
+        success: boolean
+        data?: { networkId: string }
+      }
+    }
+    element: {
+      getEdgeIds: (networkId: string) => {
+        success: boolean
+        data?: { edgeIds: string[] }
+      }
+      getEdge: (
+        networkId: string,
+        edgeId: string,
+      ) => {
+        success: boolean
+        data?: { sourceId: string; targetId: string }
+      }
+    }
+  }
+}
+
+const getCurrentNetworkId = async (page: Page): Promise<string> =>
+  page.evaluate(() => {
+    const api = (window as unknown as CyWebApiWindow).CyWebApi
+    const current = api?.workspace.getCurrentNetworkId()
+    return current?.success ? (current.data?.networkId ?? '') : ''
+  })
+
+const getEdgeIds = async (page: Page, networkId: string): Promise<string[]> =>
+  page.evaluate((id) => {
+    const api = (window as unknown as CyWebApiWindow).CyWebApi
+    const result = api?.element.getEdgeIds(id)
+    return result?.success ? (result.data?.edgeIds ?? []) : []
+  }, networkId)
+
+const getEdgeEndpoints = async (
+  page: Page,
+  networkId: string,
+  edgeId: string,
+): Promise<{ sourceId: string; targetId: string } | null> =>
+  page.evaluate(
+    ([id, edge]) => {
+      const api = (window as unknown as CyWebApiWindow).CyWebApi
+      const result = api?.element.getEdge(id, edge)
+      return result?.success ? (result.data ?? null) : null
+    },
+    [networkId, edgeId],
+  )
+
+/**
+ * Screen coordinates of the first rendered node, read from the Cytoscape.js
+ * instance registered on the renderer's container element. The network is
+ * drawn on a canvas, so there is no DOM element to click on instead. The view
+ * is fitted first: a seeded network is not laid out, so its nodes can sit
+ * outside the visible viewport.
+ */
+const firstNodeScreenPosition = async (
+  page: Page,
+): Promise<{ x: number; y: number } | null> =>
+  page.evaluate(() => {
+    const container = document.getElementById('cy-container') as
+      | (HTMLElement & { _cyreg?: { cy?: any } })
+      | null
+    const cy = container?._cyreg?.cy
+    if (container == null || cy === undefined || cy.nodes().length === 0) {
+      return null
+    }
+    cy.fit(undefined, 100)
+    const rendered = cy.nodes()[0].renderedPosition()
+    const rect = container.getBoundingClientRect()
+    const x = rect.left + rendered.x
+    const y = rect.top + rendered.y
+    const onScreen =
+      rendered.x > 0 &&
+      rendered.y > 0 &&
+      rendered.x < rect.width &&
+      rendered.y < rect.height
+    return onScreen ? { x, y } : null
+  })
+
+test.describe('Self-loop creation', () => {
+  test('the node context menu creates an edge from a node to itself', async ({
+    page,
+  }) => {
+    await gotoAndSeedNetwork(page)
+
+    const networkId = await getCurrentNetworkId(page)
+    expect(networkId).not.toBe('')
+
+    await expect(page.locator('[data-testid="cyjs-renderer"]')).toBeVisible()
+    await expect
+      .poll(async () => (await getEdgeIds(page, networkId)).length)
+      .toBe(1)
+
+    // Wait until the nodes are rendered and visible in the viewport
+    let node: { x: number; y: number } | null = null
+    await expect
+      .poll(async () => {
+        node = await firstNodeScreenPosition(page)
+        return node !== null
+      })
+      .toBe(true)
+    const { x, y } = node as unknown as { x: number; y: number }
+
+    await page.mouse.click(x, y, { button: 'right' })
+
+    const menuItem = page.getByRole('menuitem', {
+      name: 'Create Edge from this Node',
+    })
+    await expect(menuItem).toBeVisible()
+    await menuItem.click()
+
+    await expect(page.getByText('Edge creation mode')).toBeVisible()
+    // The menu's backdrop swallows canvas clicks until the close transition ends
+    await expect(page.locator('[role="menu"]')).toHaveCount(0)
+
+    // Click the same node again: this is the self-loop gesture
+    await page.mouse.click(x, y)
+
+    await expect
+      .poll(async () => (await getEdgeIds(page, networkId)).length)
+      .toBe(2)
+
+    // Exactly one of the two edges connects a node to itself
+    const edgeIds = await getEdgeIds(page, networkId)
+    const endpoints = await Promise.all(
+      edgeIds.map(async (edgeId) => getEdgeEndpoints(page, networkId, edgeId)),
+    )
+    const selfLoops = endpoints.filter(
+      (e) => e !== null && e.sourceId === e.targetId,
+    )
+    expect(selfLoops).toHaveLength(1)
+  })
+})

--- a/test/playwright/self-loop-creation.spec.ts
+++ b/test/playwright/self-loop-creation.spec.ts
@@ -68,12 +68,9 @@ const getEdgeEndpoints = async (
 const firstNodeScreenPosition = async (
   page: Page,
 ): Promise<{ x: number; y: number } | null> =>
-  page.evaluate(() => {
-    const container = document.getElementById('cy-container') as
-      | (HTMLElement & { _cyreg?: { cy?: any } })
-      | null
-    const cy = container?._cyreg?.cy
-    if (container == null || cy === undefined || cy.nodes().length === 0) {
+  page.getByTestId('cyjs-renderer').evaluate((container) => {
+    const cy = (container as HTMLElement & { _cyreg?: { cy?: any } })._cyreg?.cy
+    if (cy === undefined || cy.nodes().length === 0) {
       return null
     }
     cy.fit(undefined, 100)


### PR DESCRIPTION
-- Addresses #669

Self-loops now work through the node context menu.

## The cause

[CyjsRenderer.tsx:457](src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx:457) had an explicit guard that dropped the click when the tapped node was the source node:

```
// Check for self-loop
if (targetNodeId === sourceNodeId) { /* TODO: Show tooltip or prevent self-loop */ return }
```

Nothing downstream objected — `useCreateEdge` already has a passing `should allow self-loops` test — so the renderer was the only blocker. A matching exclusion in the hover handler also refused to highlight the source node as a valid target.

## The change

- New [edgeCreationMode.ts](src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.ts): the mode's state type, an `EDGE_CREATION_MODE_OFF` constant (five copies of the literal were scattered through the renderer), and the pure `resolveEdgeCreationTap` / `isEdgeCreationTarget` decisions — extracted so the behavior is testable without a Cytoscape instance.
- [CyjsRenderer.tsx](src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx) uses them; the tap on the source node now resolves to a source==target edge, and hovering it shows the `edge-creation-target` highlight.

## Verification

- [edgeCreationMode.test.ts](src/features/NetworkPanel/CyjsRenderer/edgeCreationMode.test.ts) — 8 unit tests, written before the module.
- [self-loop-creation.spec.ts](test/playwright/self-loop-creation.spec.ts) — drives the real gesture (right-click node → menu item → left-click same node) and asserts the model gains an edge whose source equals its target. I confirmed it fails when the old guard is put back, and the loop renders on the canvas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating self-loop edges by selecting the same node as both the source and target.
  * Improved edge-creation mode to clearly identify valid target nodes and handle cancellation consistently.

* **Tests**
  * Added coverage for edge creation, including self-loops, invalid targets, inactive mode, and missing nodes.
  * Added end-to-end verification for creating a self-loop from a node’s context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->