### PR TITLE
Render hook

### DIFF
--- a/docs/design/custom-graphics-image/node-graphics-render-hook.md
+++ b/docs/design/custom-graphics-image/node-graphics-render-hook.md
@@ -1,0 +1,258 @@
+# Node graphics render hook
+
+**Status:** Implemented (v1, synchronous hooks)
+**Audience:** Cytoscape Web maintainers and app authors
+
+## What this adds
+
+An external app registers one function. Cytoscape Web calls it with each node
+whose data changed, and draws the returned image as that node's Cytoscape.js
+`background-image`.
+
+```js
+const api = await window.CyWebApi.whenReady()
+
+api.nodeGraphics.setRenderHook(({ nodeId, attributes }) => {
+  const pct = Number(attributes.confidence)
+  if (!Number.isFinite(pct)) return null // leave this node to the Vizmapper
+  return `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+    <circle cx='50' cy='50' r='48' fill='none' stroke='#4caf50'
+            stroke-width='4' stroke-dasharray='${pct * 302} 302'/>
+  </svg>`
+})
+```
+
+Before this, the only way to put an image on a node was a Vizmapper
+custom-graphics slot (`nodeImageChart1..9`) driven by a table column. That
+suffices when the image is a function of network data, and nothing else.
+
+## Constraint that drove the design: hook images never reach CX2
+
+Vizmapper custom graphics are part of the user's visual style, so they export to
+CX2 and are meant to. Hook images are not. They belong to a running app, may be
+recomputed on any state change, and must leave no trace in an exported file.
+
+This rules out the obvious implementation — writing hook output into
+`nodeImageChartN` defaults or bypasses — because `VisualStyle` is exactly what
+`buildVisualStyleAspects` serializes.
+
+There is a second reason the export would be pointless. Cytoscape Desktop loads
+custom-graphic image bytes from its session `CustomGraphicsManager` pool, not
+from the network file, so an exported image reference renders as "?" in a fresh
+Desktop session regardless of URL scheme. See `.serena/memories/lessons.md`
+[2026-07-18].
+
+### How non-export is guaranteed
+
+`exportCyNetworkToCx2` (`src/models/CxModel/impl/exporter.ts:43`) destructures
+its entire input at `:48-62`: `network`, `visualStyle`, `nodeTable`, `edgeTable`,
+`visualStyleOptions`, `networkViews[0]`, `otherAspects`, `networkAttributes`,
+`visualStyleSet`. Style aspects come from `buildVisualStyleAspects(vs, …)` and
+`buildCyWebVisualStylesAspect`, which take `vs` as their only style input.
+`networkView` is read at exactly two lines, `:141-142`, for `x` and `y`.
+
+Five independent reasons a hook image cannot appear:
+
+1. `NodeGraphicsStore` is not a `CyNetwork` field, and no path reaches it from
+   any of the seven `CyNetwork` assembly sites.
+2. The hook never writes `VisualStyleStore`, so custom-graphics aspects are
+   byte-identical.
+3. The hook never writes `ViewModelStore`. Excluded even though the exporter
+   reads only x/y, because `NodeView.values` *is* serialized to IndexedDB and
+   cross-tab diffed.
+4. The image never enters `ele.data()`.
+5. The store has no persistence middleware, so nothing reaches Dexie.
+
+Regression test: `src/models/CxModel/impl/exporter.nodeGraphics.test.ts` asserts
+byte-identical export with and without hook images, and that a Vizmapper image
+bypass still exports.
+
+## Why element style bypasses, not element data
+
+Everything else in the renderer drives visual properties through `ele.data()`
+plus one shared stylesheet. This is the only place that calls `ele.style()`.
+
+Two facts make the `data()` route unusable:
+
+1. The `background-image` stylesheet mappers exist only when the visual style has
+   a usable custom-graphics slot — the `getFirstValidCustomGraphicVp` gate at
+   `cyjsRenderUtil.ts:291`. A hook must work regardless of the user's Vizmapper
+   setup, so it cannot depend on that mapper existing.
+2. `updateCyElements` sweeps stale custom-graphics keys on every pass
+   (`cyjsRenderUtil.ts:528-533`), and `SpecialPropertyName.BackgroundImage` is in
+   that list. A hook-written `data('backgroundImage', …)` is wiped by the next
+   `applyViewModel`.
+
+A bypass sidesteps both by not participating in either mechanism, and it survives
+a stylesheet swap. Verified in `node_modules/cytoscape/dist/cytoscape.cjs.js`:
+
+| Fact | Location |
+| --- | --- |
+| `cy.style(sheet)` installs a new Style object, never calling `cleanElements` | `:19259-19278` |
+| `cleanElements(eles, true)` is reached only from `styfn.clear`, which the app never calls, and preserves bypass props anyway | `:19140`, `:16547-16570` |
+| Reapplying a stylesheet value over a bypass keeps the bypass and stores the stylesheet value underneath as `bypassed` | `:16535-16538` |
+
+The third row is also why the hook wins over a Vizmapper image for free.
+
+Consequences worth noting: `cyjsRenderUtil.ts` is unmodified, so
+`renderStylePreview.ts` is untouched and Vizmapper thumbnails can never show hook
+images. That is correct — a thumbnail previews a style, and the hook is not part
+of the style.
+
+## Architecture
+
+```
+App (Module Federation plugin / window.CyWebApi)
+  │  apis.nodeGraphics.setRenderHook(fn)
+  ▼
+src/app-api/core/nodeGraphicsApi.ts          per-app factory + anonymous singleton
+  │  useNodeGraphicsStore.getState().setHook(...)
+  ▼
+src/data/hooks/stores/NodeGraphicsStore.ts   EPHEMERAL: hooks[] + images{net}{node}
+  ▲                                          registerAppCleanup at module load
+  │  setImages(networkId, entries)
+src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+  │    invalidation · coalescing · chunking · circuit breaker
+  │  returns images[networkId]
+  ▼
+src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
+       node.style({ 'background-image': ..., ... })      cy-only, never in data
+```
+
+`nodeGraphicsResolve.ts` sits between the hook and the store, validating and
+defaulting whatever the app returned.
+
+### Files
+
+| File | Role |
+| --- | --- |
+| `src/models/StoreModel/NodeGraphicsStoreModel.ts` | Types |
+| `src/data/hooks/stores/NodeGraphicsStore.ts` | Hook registry + resolved images |
+| `src/app-api/core/nodeGraphicsApi.ts` | Public API |
+| `src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.ts` | Validate + default a hook result |
+| `src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts` | Write bypasses into cy |
+| `src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts` | Decide when to run hooks |
+| `src/models/VisualStyleModel/impl/imageSourceImpl.ts` | Shared scheme policy + SVG sizing |
+| `src/models/TableModel/impl/tableDiff.ts` | `detectRowDelta` for changed vs removed rows |
+
+## The hook contract
+
+```ts
+type NodeGraphicsRenderHook = (request: NodeGraphicsRequest) => NodeGraphicsResult
+
+interface NodeGraphicsRequest {
+  readonly networkId: IdType
+  readonly nodeId: IdType
+  readonly attributes: Record<AttributeName, ValueType> // shallow copy
+  readonly width?: number
+  readonly height?: number
+}
+
+type NodeGraphicsResult = string | NodeGraphicsImage | null | undefined
+```
+
+`attributes` is a copy, not the live row. Passing the live `NodeView` would hand
+the app a Map that is either immer-frozen (an app write throws) or not yet frozen
+(an app write silently corrupts the render).
+
+**Synchronous in v1.** An app needing async work computes and caches it in its
+own code, then calls `refresh()` so the hook can return the cached value. Native
+`Promise` support is a follow-on.
+
+**Must not throw.** A throw yields no image for that node. After 20 throws or
+slow calls (>16 ms), the hook is disabled for the session — checked per call, so
+a hook that starts failing on node 1 of 100000 stops being called on node 21.
+
+Accepted image sources: `http(s)://` URLs, `data:` URIs, raw `<svg>` markup
+(promoted to a data URI). Rejected: `blob:` (dead by the time a style reapplies)
+and `file:`. Same policy as the Vizmapper passthrough path — one implementation
+in `imageSourceImpl.ts`.
+
+## Precedence and draw order
+
+A hook image wins over a Vizmapper image on the same node. Returning `null` drops
+the bypass and the Vizmapper mapper reasserts itself on the next restyle, leaving
+no residue in the saved style.
+
+**Pie and ring charts still draw on top by default.** Cytoscape's node draw order
+is shape → `drawImages(inside)` → border → `drawPie` → stripe →
+`drawImages(over)`. `background-image-containment` defaults to `'inside'`, so a
+Vizmapper pie covers a hook image. This matches how two Vizmapper slots already
+behave. Pass `containment: 'over'` to own the node face.
+
+Multiple apps: hooks run in registration order and the first non-`null` result
+wins. An app returning `null` for nodes it does not own yields to the next one.
+An always-returning hook starves later hooks — which is why per-node filtering is
+the next phase.
+
+## Invalidation
+
+Renderer-scoped: called from `CyjsRenderer`, so no hook work happens for
+background networks, and mounting is the natural first-run trigger.
+
+| Trigger | Action |
+| --- | --- |
+| Mount / network switch | Run every node |
+| Hook registered or replaced | Run every node |
+| Last hook removed | Drop every image for the network |
+| Table edit | Run the rows whose object identity changed |
+| Node deleted | Drop its image, no hook call |
+| `refresh(networkId?, nodeIds?)` | Run the named nodes, or all |
+| Unmount | Cancel queued work, drop the network's images |
+| Undo / redo | Automatic — `useUndoStack` replays the same TableStore actions |
+
+### Why coalescing is mandatory
+
+`InMemoryTable` rebuilds **every** row object on `createColumn`, `deleteColumn`,
+`setColumnName`, `duplicateColumn`, `applyValueToElements`, `setTable`, and `add`.
+So a single column rename reports every node as changed.
+
+1. Pending nodes are a `Set`; writes within 50 ms merge into one flush.
+2. A flush processes 200 nodes per animation frame, writing once per chunk, so a
+   large batch repaints progressively rather than stalling.
+3. A generation counter is captured at flush start. A chunk from an older
+   generation drops its results, which is what makes rapid network switching and
+   hook re-registration safe.
+4. `isHydrating()` defers the flush. A peer tab's edit arrives as a full-table
+   replace, so every row looks changed; the pending set is preserved, so nothing
+   is lost.
+5. An image string-identical to the stored one is skipped — the main defense
+   against Cytoscape's unbounded image cache.
+
+## Known limitations
+
+| Limitation | Detail |
+| --- | --- |
+| **Cytoscape's image cache is unbounded** | `BRp.getCachedImage` retains one `Image` per distinct URL with no eviction, freed only by `cy.destroy()`. Mitigated by string-equality dedupe and a 2000-distinct-image cap per network. **Prefer stable URLs over freshly generated data URIs.** This is the likeliest production problem. |
+| Synchronous only | Async images go through `refresh()`. |
+| PNG export drops remote images | `crossOrigin: 'null'` (the default) taints the canvas, and Cytoscape excludes tainted images from `cy.png()`. Use data URIs or `crossOrigin: 'anonymous'`. |
+| No HierarchyViewer circle-packing support | Only the two `CyjsRenderer` mount sites are covered. |
+| Images recompute on network switch | The sync hook is renderer-scoped. If it hurts, promote the images slice to survive unmount and evict on `network:deleted`. |
+| Breaks the `ele.data()` convention | Deliberate; see above. `nodeGraphicsApply.ts` carries the reasoning inline. |
+
+## Deferred
+
+- Per-node filtering, so an app declares which nodes it owns instead of
+  returning `null` for the rest.
+- Native `Promise` support.
+- A push `setNodeGraphics` write API. The store and apply layer already support
+  it; only a second fill path is missing.
+- Stacking hook and Vizmapper layers (`background-image` accepts a list).
+- The remaining `background-*` properties. The type union at
+  `cyjsVisualPropertyName.ts:67-86` lists ~20; v1 wires 5.
+- Edge graphics.
+
+## Relationship to the earlier design note
+
+`scratch/custom-node-graphics/dynamic-node-graphics.md` §4 recommended a push
+API (`setNodeGraphics`) over a render-time hook, partly because push "round-trips
+through CX2". That property is now an explicit non-goal, which removes the
+argument. The hook model was chosen instead because the host can coalesce
+invalidation once, correctly, rather than every app reimplementing it — and
+because per-node filtering only makes sense when the host drives the calls.
+
+That note remains accurate about the substrate (`background-image`, SVG data URIs
+as the draw-anything path) and about the discrete-vs-continuous distinction. A
+per-frame factory is still the wrong tool for data-driven updates, and this
+design is not one: hooks run on discrete invalidation, never inside the paint
+loop.

--- a/docs/design/custom-graphics-image/node-graphics-render-hook.md
+++ b/docs/design/custom-graphics-image/node-graphics-render-hook.md
@@ -263,8 +263,11 @@ background networks, and mounting is the natural first-run trigger.
 So a single column rename reports every node as changed.
 
 1. Pending nodes are a `Set`; writes within 50 ms merge into one flush.
-2. A flush processes 200 nodes per animation frame, writing once per chunk, so a
-   large batch repaints progressively rather than stalling.
+2. A flush processes up to 200 nodes per animation frame, and stops early once a
+   chunk has spent 8 ms, so a large batch repaints progressively rather than
+   stalling. Both bounds are needed: a hook taking 12 ms per node stays under the
+   16 ms slow-call threshold, so a node count alone would not bound the frame.
+   At least one node always runs, so progress never stalls.
 3. A generation counter is captured at flush start. A chunk from an older
    generation drops its results, which is what makes rapid network switching and
    hook re-registration safe.
@@ -283,7 +286,7 @@ So a single column rename reports every node as changed.
 
 | Limitation                                | Detail                                                                                                                                                                                                                                                                                      |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Cytoscape's image cache is unbounded**  | `BRp.getCachedImage` retains one `Image` per distinct URL with no eviction, freed only by `cy.destroy()`. Mitigated by string-equality dedupe and a 2000-distinct-image cap per network. **Prefer stable URLs over freshly generated data URIs.** This is the likeliest production problem. |
+| **Cytoscape's image cache is unbounded**  | `BRp.getCachedImage` retains one `Image` per distinct URL with no eviction, freed only by `cy.destroy()`. Mitigated by string-equality dedupe and a 2000-distinct-URL cap per renderer, counted in `nodeGraphicsApply.ts` on the URL actually handed to Cytoscape — an SVG re-wrapped per node size is a distinct URL per size, so counting hook images instead would miss it. **Prefer stable URLs over freshly generated data URIs.** This is the likeliest production problem. |
 | Synchronous only                          | Async images go through `refresh()`.                                                                                                                                                                                                                                                        |
 | PNG export drops remote images            | `crossOrigin: 'null'` (the default) taints the canvas, and Cytoscape excludes tainted images from `cy.png()`. Use data URIs or `crossOrigin: 'anonymous'`.                                                                                                                                  |
 | No HierarchyViewer circle-packing support | Only the two `CyjsRenderer` mount sites are covered.                                                                                                                                                                                                                                        |

--- a/docs/design/custom-graphics-image/node-graphics-render-hook.md
+++ b/docs/design/custom-graphics-image/node-graphics-render-hook.md
@@ -101,7 +101,7 @@ of the style.
 
 ## Architecture
 
-```
+```text
 App (Module Federation plugin / window.CyWebApi)
   │  apis.nodeGraphics.setRenderHook(fn)
   ▼
@@ -252,6 +252,7 @@ background networks, and mounting is the natural first-run trigger.
 | Table edit                      | Run the rows whose object identity changed                     |
 | Node deleted                    | Drop its image, no hook call                                   |
 | `refresh(networkId?, nodeIds?)` | Run the named nodes, or all                                    |
+| Two `refresh` calls in one tick | Node ids merge; either call omitting `nodeIds` runs all         |
 | Unmount                         | Cancel queued work, drop the network's images                  |
 | Undo / redo                     | Automatic — `useUndoStack` replays the same TableStore actions |
 
@@ -270,8 +271,13 @@ So a single column rename reports every node as changed.
 4. `isHydrating()` defers the flush. A peer tab's edit arrives as a full-table
    replace, so every row looks changed; the pending set is preserved, so nothing
    is lost.
-5. An image string-identical to the stored one is skipped — the main defense
-   against Cytoscape's unbounded image cache.
+5. A result identical to the stored one in every field is skipped — the main
+   defense against Cytoscape's unbounded image cache. All fields are compared, not
+   just the image: a hook that keeps the URL and changes only `opacity` is making
+   a real change.
+6. A refresh request merges with one the renderer has not read yet, then is
+   acknowledged once its nodes are queued. Merging without the ack would make
+   every later refresh re-run every node ever refreshed for that network.
 
 ## Known limitations
 

--- a/docs/design/custom-graphics-image/node-graphics-render-hook.md
+++ b/docs/design/custom-graphics-image/node-graphics-render-hook.md
@@ -58,7 +58,7 @@ Five independent reasons a hook image cannot appear:
 2. The hook never writes `VisualStyleStore`, so custom-graphics aspects are
    byte-identical.
 3. The hook never writes `ViewModelStore`. Excluded even though the exporter
-   reads only x/y, because `NodeView.values` *is* serialized to IndexedDB and
+   reads only x/y, because `NodeView.values` _is_ serialized to IndexedDB and
    cross-tab diffed.
 4. The image never enters `ele.data()`.
 5. The store has no persistence middleware, so nothing reaches Dexie.
@@ -86,11 +86,11 @@ Two facts make the `data()` route unusable:
 A bypass sidesteps both by not participating in either mechanism, and it survives
 a stylesheet swap. Verified in `node_modules/cytoscape/dist/cytoscape.cjs.js`:
 
-| Fact | Location |
-| --- | --- |
-| `cy.style(sheet)` installs a new Style object, never calling `cleanElements` | `:19259-19278` |
+| Fact                                                                                                                         | Location                 |
+| ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `cy.style(sheet)` installs a new Style object, never calling `cleanElements`                                                 | `:19259-19278`           |
 | `cleanElements(eles, true)` is reached only from `styfn.clear`, which the app never calls, and preserves bypass props anyway | `:19140`, `:16547-16570` |
-| Reapplying a stylesheet value over a bypass keeps the bypass and stores the stylesheet value underneath as `bypassed` | `:16535-16538` |
+| Reapplying a stylesheet value over a bypass keeps the bypass and stores the stylesheet value underneath as `bypassed`        | `:16535-16538`           |
 
 The third row is also why the hook wins over a Vizmapper image for free.
 
@@ -124,21 +124,23 @@ defaulting whatever the app returned.
 
 ### Files
 
-| File | Role |
-| --- | --- |
-| `src/models/StoreModel/NodeGraphicsStoreModel.ts` | Types |
-| `src/data/hooks/stores/NodeGraphicsStore.ts` | Hook registry + resolved images |
-| `src/app-api/core/nodeGraphicsApi.ts` | Public API |
-| `src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.ts` | Validate + default a hook result |
-| `src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts` | Write bypasses into cy |
-| `src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts` | Decide when to run hooks |
-| `src/models/VisualStyleModel/impl/imageSourceImpl.ts` | Shared scheme policy + SVG sizing |
-| `src/models/TableModel/impl/tableDiff.ts` | `detectRowDelta` for changed vs removed rows |
+| File                                                            | Role                                         |
+| --------------------------------------------------------------- | -------------------------------------------- |
+| `src/models/StoreModel/NodeGraphicsStoreModel.ts`               | Types                                        |
+| `src/data/hooks/stores/NodeGraphicsStore.ts`                    | Hook registry + resolved images              |
+| `src/app-api/core/nodeGraphicsApi.ts`                           | Public API                                   |
+| `src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.ts` | Validate + default a hook result             |
+| `src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts`   | Write bypasses into cy                       |
+| `src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts` | Decide when to run hooks                     |
+| `src/models/VisualStyleModel/impl/imageSourceImpl.ts`           | Shared scheme policy + SVG sizing            |
+| `src/models/TableModel/impl/tableDiff.ts`                       | `detectRowDelta` for changed vs removed rows |
 
 ## The hook contract
 
 ```ts
-type NodeGraphicsRenderHook = (request: NodeGraphicsRequest) => NodeGraphicsResult
+type NodeGraphicsRenderHook = (
+  request: NodeGraphicsRequest,
+) => NodeGraphicsResult
 
 interface NodeGraphicsRequest {
   readonly networkId: IdType
@@ -168,6 +170,58 @@ Accepted image sources: `http(s)://` URLs, `data:` URIs, raw `<svg>` markup
 and `file:`. Same policy as the Vizmapper passthrough path — one implementation
 in `imageSourceImpl.ts`.
 
+## Worked example: STRING node images
+
+STRING networks carry two node-image values, and both need handling the contract
+above does not do for you.
+
+| STRING column            | Value shape                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `stringdb::imageurl`     | `https://version-12-0.string-db.org//images/Proteinpictures/pdb/1f/1fgu_A.png` |
+| `stringdb::STRING style` | `string:data:image/png;base64,iVBORw0KGgo…`                                    |
+
+```js
+const strip = (v) => String(v).replace(/^string:(?=data:|https?:)/, '')
+
+api.nodeGraphics.setRenderHook(({ attributes }) => {
+  const raw =
+    attributes['stringdb::STRING style'] ?? attributes['stringdb::imageurl']
+  if (raw == null) return null
+  return {
+    image: strip(raw),
+    fit: 'contain',
+    // Required for the remote host — see below.
+    crossOrigin: 'null',
+  }
+})
+```
+
+**The `string:` prefix must be stripped.** `string:data:image/png;base64,…` is not
+a recognised scheme, so `normalizeImageSource` rejects it as `unrecognized` and the
+node silently gets no image. The prefix is a STRING app namespace marker, not part
+of the URI.
+
+**The remote host sends no CORS header.** Measured: `GET` on the structure URL
+returns `200 image/png`, `content-length: 33667`, and **no
+`Access-Control-Allow-Origin`**. So `crossOrigin: 'anonymous'` fails to load it at
+all and `'null'` is required — which taints the canvas, so Cytoscape omits that
+image from `cy.png()`. The base64 value is same-origin and survives PNG export
+either way. This is the general shape of the problem with remote node images:
+the failure looks identical to "the feature is broken", so preflight with an
+`Image()` under both modes when adding a new source.
+
+**Both STRING images are 240×240.** Square, so a square node uses the whole
+graphic; on the default 75×35 node they letterbox to a 35px square — correct, just
+small. Rasters skip the SVG size wrapper entirely, so Cytoscape's native
+`background-fit` sizes them and their aspect ratio is preserved without the drift
+workaround being involved.
+
+Note for STRING specifically: `.serena/memories/lessons.md` [2026-07-18] records
+that Desktop loads custom-graphic image bytes from its session pool rather than the
+network file, so these images do not round-trip to a fresh Desktop session even by
+the Vizmapper path — independent of this feature keeping hook images out of CX2 by
+design.
+
 ## Precedence and draw order
 
 A hook image wins over a Vizmapper image on the same node. Returning `null` drops
@@ -190,16 +244,16 @@ the next phase.
 Renderer-scoped: called from `CyjsRenderer`, so no hook work happens for
 background networks, and mounting is the natural first-run trigger.
 
-| Trigger | Action |
-| --- | --- |
-| Mount / network switch | Run every node |
-| Hook registered or replaced | Run every node |
-| Last hook removed | Drop every image for the network |
-| Table edit | Run the rows whose object identity changed |
-| Node deleted | Drop its image, no hook call |
-| `refresh(networkId?, nodeIds?)` | Run the named nodes, or all |
-| Unmount | Cancel queued work, drop the network's images |
-| Undo / redo | Automatic — `useUndoStack` replays the same TableStore actions |
+| Trigger                         | Action                                                         |
+| ------------------------------- | -------------------------------------------------------------- |
+| Mount / network switch          | Run every node                                                 |
+| Hook registered or replaced     | Run every node                                                 |
+| Last hook removed               | Drop every image for the network                               |
+| Table edit                      | Run the rows whose object identity changed                     |
+| Node deleted                    | Drop its image, no hook call                                   |
+| `refresh(networkId?, nodeIds?)` | Run the named nodes, or all                                    |
+| Unmount                         | Cancel queued work, drop the network's images                  |
+| Undo / redo                     | Automatic — `useUndoStack` replays the same TableStore actions |
 
 ### Why coalescing is mandatory
 
@@ -221,14 +275,14 @@ So a single column rename reports every node as changed.
 
 ## Known limitations
 
-| Limitation | Detail |
-| --- | --- |
-| **Cytoscape's image cache is unbounded** | `BRp.getCachedImage` retains one `Image` per distinct URL with no eviction, freed only by `cy.destroy()`. Mitigated by string-equality dedupe and a 2000-distinct-image cap per network. **Prefer stable URLs over freshly generated data URIs.** This is the likeliest production problem. |
-| Synchronous only | Async images go through `refresh()`. |
-| PNG export drops remote images | `crossOrigin: 'null'` (the default) taints the canvas, and Cytoscape excludes tainted images from `cy.png()`. Use data URIs or `crossOrigin: 'anonymous'`. |
-| No HierarchyViewer circle-packing support | Only the two `CyjsRenderer` mount sites are covered. |
-| Images recompute on network switch | The sync hook is renderer-scoped. If it hurts, promote the images slice to survive unmount and evict on `network:deleted`. |
-| Breaks the `ele.data()` convention | Deliberate; see above. `nodeGraphicsApply.ts` carries the reasoning inline. |
+| Limitation                                | Detail                                                                                                                                                                                                                                                                                      |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cytoscape's image cache is unbounded**  | `BRp.getCachedImage` retains one `Image` per distinct URL with no eviction, freed only by `cy.destroy()`. Mitigated by string-equality dedupe and a 2000-distinct-image cap per network. **Prefer stable URLs over freshly generated data URIs.** This is the likeliest production problem. |
+| Synchronous only                          | Async images go through `refresh()`.                                                                                                                                                                                                                                                        |
+| PNG export drops remote images            | `crossOrigin: 'null'` (the default) taints the canvas, and Cytoscape excludes tainted images from `cy.png()`. Use data URIs or `crossOrigin: 'anonymous'`.                                                                                                                                  |
+| No HierarchyViewer circle-packing support | Only the two `CyjsRenderer` mount sites are covered.                                                                                                                                                                                                                                        |
+| Images recompute on network switch        | The sync hook is renderer-scoped. If it hurts, promote the images slice to survive unmount and evict on `network:deleted`.                                                                                                                                                                  |
+| Breaks the `ele.data()` convention        | Deliberate; see above. `nodeGraphicsApply.ts` carries the reasoning inline.                                                                                                                                                                                                                 |
 
 ## Deferred
 

--- a/src/app-api/AGENTS.md
+++ b/src/app-api/AGENTS.md
@@ -28,6 +28,12 @@ src/app-api/
 │   ├── exportApi.ts
 │   ├── workspaceApi.ts         ← workspace state reads/writes (WorkspaceStore + NetworkSummaryStore)
 │   ├── contextMenuApi.ts       ← context menu item registry (ContextMenuItemStore)
+│   ├── nodeGraphicsApi.ts      ← node-graphics render hook registry (NodeGraphicsStore)
+│   ├── resourceApi.ts          ← per-app panel/menu component registry (AppResourceStore)
+│   ├── perAppApis.ts           ← buildPerAppApis(appId): the ONLY place AppContextApis is assembled
+│   ├── ready.ts                ← isReady / whenReadySignal / markReady
+│   ├── undo.ts                 ← corePostEdit
+│   ├── validation.ts
 │   ├── scopedApi.ts            ← forNetwork(id?): network-scoped domains with networkId pre-bound
 │   └── index.ts                 ← Assembles CyWebApi object (incl. forNetwork); assigned to window.CyWebApi
 ├── event-bus/                   ← Typed event bus (Step 2, after Phase 1e)
@@ -73,13 +79,23 @@ src/app-api/
    through `event-bus/dispatchCyWebEvent.ts`. Never call `window.dispatchEvent(new CustomEvent(...))`
    directly anywhere else.
 9. **`initEventBus()` is called once after hydration** — `window.CyWebApi = CyWebApi` is assigned
-   in `src/init.tsx` (before React renders). `initEventBus()` and `cywebapi:ready` are called in
-   `src/features/AppShell.tsx` immediately after `setWorkspace(workspace)` completes, so
-   subscriptions are never active during the IndexedDB → store hydration transition and no
-   spurious `network:created` / `network:switched` events fire on startup.
+   via a dynamic import in `src/boot/bootstrap.tsx:41-42`. `initEventBus()` and `cywebapi:ready`
+   are called in `src/boot/steps/publishWorkspace.ts:39,45`, immediately after
+   `setWorkspace(workspace)` completes, so subscriptions are never active during the
+   IndexedDB → store hydration transition and no spurious `network:created` /
+   `network:switched` events fire on startup.
 10. **Layout events come from `core/layoutApi.ts`** — Not from store subscriptions. `layout:started`
     fires before `LayoutStore.setIsRunning(true)`, `layout:completed` fires inside the layout
     promise resolution. Errors do NOT dispatch `layout:completed`.
+11. **Per-app API objects are built in exactly one place** — `core/perAppApis.ts`
+    `buildPerAppApis(appId)`. Adding a per-app domain means editing that one function. Do NOT
+    spread `CyWebApi` and override factories inline at a call site; three sites used to do that
+    and a missed one produced an app silently lacking the new domain.
+12. **App-supplied node graphics are renderer-only** — A render hook's images must NEVER be
+    written to `VisualStyleStore` or `ViewModelStore`: both serialize (to CX2 and to IndexedDB
+    respectively). They live in the non-persisted `NodeGraphicsStore` and reach Cytoscape.js as
+    element style bypasses. Guarded by `src/models/CxModel/impl/exporter.nodeGraphics.test.ts`;
+    rationale in `docs/design/custom-graphics-image/node-graphics-render-hook.md`.
 
 ## Two-Layer Pattern
 

--- a/src/app-api/AGENTS.md
+++ b/src/app-api/AGENTS.md
@@ -96,6 +96,11 @@ src/app-api/
     respectively). They live in the non-persisted `NodeGraphicsStore` and reach Cytoscape.js as
     element style bypasses. Guarded by `src/models/CxModel/impl/exporter.nodeGraphics.test.ts`;
     rationale in `docs/design/custom-graphics-image/node-graphics-render-hook.md`.
+    Two failure modes look identical to a broken feature, so check them first when a
+    hook draws nothing: a namespace-prefixed value (STRING ships
+    `string:data:image/png;base64,…`) is an unrecognised scheme and is discarded, and a
+    remote host without an `Access-Control-Allow-Origin` header will not load under
+    `crossOrigin: 'anonymous'` at all. See the STRING example in `api_docs/Api.md`.
 
 ## Two-Layer Pattern
 

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -6,10 +6,11 @@ The app API (`src/app-api/`) is the sole public API for external apps loaded via
 Module Federation. It provides a stable contract independent of internal store and
 hook implementations.
 
-`window.CyWebApi` contains **10 domain namespaces**, including its anonymous
-Context Menu API. Plugin apps additionally receive per-app Context Menu and
-Resource Registration factories, the typed Event Bus (`useCyWebEvent`), and an
-App Lifecycle interface with declarative resource support.
+`window.CyWebApi` contains **11 domain namespaces**, including its anonymous
+Context Menu and Node Graphics APIs. Plugin apps additionally receive per-app
+Context Menu, Node Graphics, and Resource Registration factories, the typed Event
+Bus (`useCyWebEvent`), and an App Lifecycle interface with declarative resource
+support.
 
 ## Result Convention
 
@@ -1977,7 +1978,8 @@ interface AppContext {
 
 ### `AppContextApis`
 
-Per-app API object that extends `CyWebApiType` with additional per-app capabilities:
+Per-app API object. Adds `resource`, and replaces two shared domains with
+factories bound to the calling app:
 
 ```typescript
 interface AppContextApis extends CyWebApiType {
@@ -1989,7 +1991,9 @@ interface AppContextApis extends CyWebApiType {
 
 > **Note:** `window.CyWebApi` is typed as `CyWebApiType` and does NOT include
 > `resource`. Resource registration requires the per-app context available in
-> `mount()` or via `useAppContext()`.
+> `mount()` or via `useAppContext()`. `contextMenu` and `nodeGraphics` do appear
+> on `window.CyWebApi`, but as anonymous singletons with no owning app — nothing
+> registered through them is cleaned up automatically.
 
 ### `CyAppWithLifecycle`
 
@@ -2106,7 +2110,7 @@ export const MyApp: CyAppWithLifecycle = {
 
 ## `window.CyWebApi`
 
-The global `window.CyWebApi` object assembles all 10 domain APIs into a single
+The global `window.CyWebApi` object assembles all 11 domain APIs into a single
 singleton. Available after the `cywebapi:ready` event.
 
 ```typescript
@@ -2121,6 +2125,7 @@ interface CyWebApiType {
   export: ExportApi
   workspace: WorkspaceApi
   contextMenu: ContextMenuApi
+  nodeGraphics: NodeGraphicsApi
 }
 ```
 
@@ -2131,6 +2136,13 @@ window.addEventListener('cywebapi:ready', () => {
 })
 ```
 
-`AppContext.apis` extends `window.CyWebApi` with per-app `resource` and `contextMenu`
-fields. The 10 domain APIs (element, network, etc.) are shared; `resource` and the
-per-app `contextMenu` are exclusive to `AppContext.apis`.
+`AppContext.apis` extends `window.CyWebApi` with a per-app `resource` field and
+per-app `contextMenu` and `nodeGraphics` factories. The 11 domain APIs (element,
+network, etc.) are shared; `resource` is exclusive to `AppContext.apis`.
+
+`contextMenu` and `nodeGraphics` exist on both, but not as the same object. On
+`window.CyWebApi` each is an anonymous singleton with no owning app and therefore
+no lifecycle. On `AppContext.apis` each is bound to the calling `appId`, so
+everything it registers — menu items, a render hook and every image that hook
+produced — is dropped automatically when the app is disabled or uninstalled.
+Prefer the `AppContext.apis` form in any app that has a `mount()`.

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -1353,6 +1353,173 @@ export const MyApp: CyAppWithLifecycle = {
 
 ---
 
+## NodeGraphicsApi
+
+Register one function that Cytoscape Web calls with each node whose data changed.
+Return an image and the host draws it as that node's `background-image`.
+
+Access is via `AppContext.apis.nodeGraphics` (per-app factory, lifecycle-managed)
+or `window.CyWebApi.nodeGraphics` (anonymous singleton, non-React consumers only).
+There is no `cyweb/NodeGraphicsApi` Module Federation expose.
+
+> **Hook images are never exported to CX2.** They are renderer-only, applied as
+> Cytoscape.js element style bypasses. Vizmapper custom graphics
+> (`nodeImageChart1..9`) still export exactly as before. See
+> `docs/design/custom-graphics-image/node-graphics-render-hook.md`.
+
+```typescript
+// In mount() — per-app factory (recommended for plugin apps)
+mount({ apis }) {
+  apis.nodeGraphics.setRenderHook(({ nodeId, attributes }) => {
+    const pct = Number(attributes.confidence)
+    if (!Number.isFinite(pct)) return null   // leave this node to the Vizmapper
+    return `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+      <circle cx='50' cy='50' r='48' fill='none' stroke='#4caf50'
+              stroke-width='4' stroke-dasharray='${pct * 302} 302'/>
+    </svg>`
+  })
+}
+
+// Non-React consumers — anonymous singleton (no auto-cleanup)
+window.CyWebApi.nodeGraphics.setRenderHook((req) => '…')
+```
+
+### Types
+
+```typescript
+interface NodeGraphicsRequest {
+  networkId: IdType
+  nodeId: IdType
+  /** Shallow copy of the node's table row. Writes to it are ignored. */
+  attributes: Record<string, ValueType>
+  /** Current node size in model units, when the view model has it. */
+  width?: number
+  height?: number
+}
+
+interface NodeGraphicsImage {
+  /**
+   * An `http(s)://` URL, a `data:` URI, or raw `<svg>` markup.
+   * `blob:` and `file:` are rejected.
+   */
+  image: string
+  /** @default 'contain' */
+  fit?: 'contain' | 'cover' | 'none'
+  /** 0..1. @default 1 */
+  opacity?: number
+  /** @default 'null' — loads without CORS, but taints the canvas. */
+  crossOrigin?: 'anonymous' | 'use-credentials' | 'null'
+  /**
+   * 'inside' draws under pie/ring charts; 'over' draws above them.
+   * @default 'inside'
+   */
+  containment?: 'inside' | 'over'
+}
+
+/** A bare string is shorthand for `{ image }`. `null` means "no image". */
+type NodeGraphicsResult = string | NodeGraphicsImage | null | undefined
+
+/** Synchronous. Must not throw. */
+type NodeGraphicsRenderHook = (request: NodeGraphicsRequest) => NodeGraphicsResult
+```
+
+### Hook contract
+
+- **Synchronous.** For images needing async work (a fetch, an offscreen render),
+  compute and cache in your own code, then call `refresh()` so the hook can
+  return the cached value.
+- **Must not throw.** A throw yields no image for that node. After 20 throws or
+  slow calls (>16 ms) the hook is disabled for the rest of the session.
+- **Return `null` to decline a node.** It falls back to its Vizmapper custom
+  graphic, if any. With several apps registered, hooks run in registration order
+  and the first non-`null` result wins.
+- **Prefer stable URLs over freshly generated data URIs.** Cytoscape retains one
+  image per distinct URL with no eviction. The host caps a network at 2000
+  distinct images and warns once when it stops accepting new ones.
+
+### When the hook runs
+
+Automatically on: renderer mount, network switch, hook registration, and any node
+table edit (including undo and redo). Deleted nodes have their image dropped
+without a hook call. Call `refresh()` for anything the host cannot observe —
+your own state.
+
+### Methods
+
+#### `setRenderHook(hook): ApiResult<{ hookId: string }>`
+
+Registers the hook, replacing any hook this caller previously registered. Hooks
+registered via `AppContext.apis.nodeGraphics` are removed automatically, along
+with every image they produced, when the app is disabled.
+
+| Error Code | Condition                  |
+| ---------- | -------------------------- |
+| `VP9`      | `hook` is not a function   |
+
+#### `clearRenderHook(): ApiResult`
+
+Removes this caller's hook and every image it produced. Affected nodes fall back
+to their Vizmapper custom graphics.
+
+| Error Code | Condition                                  |
+| ---------- | ------------------------------------------ |
+| `APP5`     | This caller has no hook registered         |
+
+One app cannot clear another app's hook, and the anonymous singleton cannot clear
+an app-owned hook.
+
+#### `refresh(networkId?, nodeIds?): ApiResult<{ nodeCount: number }>`
+
+Re-runs the hook. Omit `networkId` for the workspace's current network; omit
+`nodeIds` for every node.
+
+| Error Code | Condition                                  |
+| ---------- | ------------------------------------------ |
+| `APP5`     | This caller has no hook registered         |
+| `APP2`     | No `networkId` given and none is current   |
+| `APP1`     | `networkId` is unknown                     |
+
+### Example — an image driven by the app's own state
+
+```typescript
+let currentThreshold = 0.5
+const cache = new Map<string, string>()
+
+export const MyApp: CyAppWithLifecycle = {
+  mount(context) {
+    // Synchronous: read from the cache the app fills elsewhere.
+    context.apis.nodeGraphics.setRenderHook(({ nodeId, attributes }) =>
+      Number(attributes.score) >= currentThreshold
+        ? (cache.get(nodeId) ?? null)
+        : null,
+    )
+
+    onSliderChange(async (value) => {
+      currentThreshold = value
+      await fillCache(cache, value) // async work lives here, not in the hook
+      // Ask the host to re-run the hook now that the cache is warm.
+      context.apis.nodeGraphics.refresh()
+    })
+  },
+
+  // No unmount needed — the hook and its images are auto-cleaned on disable.
+}
+```
+
+### Interaction with Vizmapper custom graphics
+
+| Situation | Result |
+| --- | --- |
+| Hook returns an image, node has a Vizmapper image | Hook wins |
+| Hook returns `null` | Vizmapper image shows |
+| `clearRenderHook()` | Vizmapper image returns on the next restyle |
+| Node has a Vizmapper **pie or ring** chart | The chart draws **on top** of a hook image unless you set `containment: 'over'` |
+
+The last row is Cytoscape's node draw order (shape → images(inside) → border →
+pie → stripe → images(over)), and matches how two Vizmapper slots already behave.
+
+---
+
 ## ResourceApi (`cyweb/AppIdContext`)
 
 Per-app resource registration API for panels and menu items. Available via
@@ -1766,6 +1933,7 @@ Per-app API object that extends `CyWebApiType` with additional per-app capabilit
 interface AppContextApis extends CyWebApiType {
   readonly resource: ResourceApi // per-app resource registration
   readonly contextMenu: ContextMenuApi // per-app, auto-cleaned on disable
+  readonly nodeGraphics: NodeGraphicsApi // per-app, auto-cleaned on disable
 }
 ```
 

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -1404,7 +1404,14 @@ interface NodeGraphicsImage {
    * `blob:` and `file:` are rejected.
    */
   image: string
-  /** @default 'contain' */
+  /**
+   * @default 'contain'
+   *
+   * Rasters use Cytoscape's `background-fit`. SVG sources are wrapped to the
+   * node box, so the fit is baked into the wrapper instead: `contain` → `meet`,
+   * `cover` → `slice`, `none` → natural size centred when the source declares
+   * one, `meet` otherwise.
+   */
   fit?: 'contain' | 'cover' | 'none'
   /** 0..1. @default 1 */
   opacity?: number
@@ -1437,8 +1444,10 @@ type NodeGraphicsRenderHook = (
   graphic, if any. With several apps registered, hooks run in registration order
   and the first non-`null` result wins.
 - **Prefer stable URLs over freshly generated data URIs.** Cytoscape retains one
-  image per distinct URL with no eviction. The host caps a network at 2000
-  distinct images and warns once when it stops accepting new ones.
+  image per distinct URL with no eviction. The host caps a renderer at 2000
+  distinct image URLs and warns once when it stops accepting new ones. SVG
+  sources are re-wrapped per node size, so one SVG on many differently sized
+  nodes costs one URL per size.
 
 ### When the hook runs
 

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -1420,7 +1420,9 @@ interface NodeGraphicsImage {
 type NodeGraphicsResult = string | NodeGraphicsImage | null | undefined
 
 /** Synchronous. Must not throw. */
-type NodeGraphicsRenderHook = (request: NodeGraphicsRequest) => NodeGraphicsResult
+type NodeGraphicsRenderHook = (
+  request: NodeGraphicsRequest,
+) => NodeGraphicsResult
 ```
 
 ### Hook contract
@@ -1452,18 +1454,18 @@ Registers the hook, replacing any hook this caller previously registered. Hooks
 registered via `AppContext.apis.nodeGraphics` are removed automatically, along
 with every image they produced, when the app is disabled.
 
-| Error Code | Condition                  |
-| ---------- | -------------------------- |
-| `VP9`      | `hook` is not a function   |
+| Error Code | Condition                |
+| ---------- | ------------------------ |
+| `VP9`      | `hook` is not a function |
 
 #### `clearRenderHook(): ApiResult`
 
 Removes this caller's hook and every image it produced. Affected nodes fall back
 to their Vizmapper custom graphics.
 
-| Error Code | Condition                                  |
-| ---------- | ------------------------------------------ |
-| `APP5`     | This caller has no hook registered         |
+| Error Code | Condition                          |
+| ---------- | ---------------------------------- |
+| `APP5`     | This caller has no hook registered |
 
 One app cannot clear another app's hook, and the anonymous singleton cannot clear
 an app-owned hook.
@@ -1473,11 +1475,11 @@ an app-owned hook.
 Re-runs the hook. Omit `networkId` for the workspace's current network; omit
 `nodeIds` for every node.
 
-| Error Code | Condition                                  |
-| ---------- | ------------------------------------------ |
-| `APP5`     | This caller has no hook registered         |
-| `APP2`     | No `networkId` given and none is current   |
-| `APP1`     | `networkId` is unknown                     |
+| Error Code | Condition                                |
+| ---------- | ---------------------------------------- |
+| `APP5`     | This caller has no hook registered       |
+| `APP2`     | No `networkId` given and none is current |
+| `APP1`     | `networkId` is unknown                   |
 
 ### Example — an image driven by the app's own state
 
@@ -1506,14 +1508,62 @@ export const MyApp: CyAppWithLifecycle = {
 }
 ```
 
+### Example — remote images from a STRING network
+
+STRING networks carry two node-image columns. Both need handling the contract
+above does not do for you.
+
+| Column                   | Value shape                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `stringdb::imageurl`     | `https://version-12-0.string-db.org//images/Proteinpictures/pdb/1f/1fgu_A.png` |
+| `stringdb::STRING style` | `string:data:image/png;base64,iVBORw0KGgo…`                                    |
+
+```typescript
+// `string:` is a STRING namespace marker, not part of the URI. Without stripping
+// it the value is an unrecognised scheme and the node silently gets no image.
+const strip = (v: unknown): string =>
+  String(v).replace(/^string:(?=data:|https?:)/, '')
+
+apis.nodeGraphics.setRenderHook(({ attributes }) => {
+  const raw =
+    attributes['stringdb::STRING style'] ?? attributes['stringdb::imageurl']
+  if (raw == null) return null
+
+  return {
+    image: strip(raw),
+    fit: 'contain',
+    // Required for the remote host — it sends no CORS header. See below.
+    crossOrigin: 'null',
+  }
+})
+```
+
+Two things measured against the live host, both of which look like "the feature
+is broken" when hit:
+
+- **The `string:` prefix is rejected.** `normalizeImageSource` classifies
+  `string:data:…` as `unrecognized`, so the hook's return value is discarded.
+- **The structure-image host sends no `Access-Control-Allow-Origin`.** It answers
+  `200 image/png` (33,667 bytes), so the URL is fine — but
+  `crossOrigin: 'anonymous'` fails to load it at all. `'null'` works and taints
+  the canvas, which means Cytoscape omits that image from `cy.png()`. The base64
+  value is same-origin and survives PNG export either way.
+
+When adding any new remote source, preflight it with an `Image()` under both
+`crossOrigin` modes before concluding anything about the hook.
+
+Both STRING images are 240×240. Rasters skip the SVG size wrapper entirely, so
+Cytoscape's `background-fit` sizes them natively and their aspect ratio is
+preserved; on the default 75×35 node a square image letterboxes to a 35px square.
+
 ### Interaction with Vizmapper custom graphics
 
-| Situation | Result |
-| --- | --- |
-| Hook returns an image, node has a Vizmapper image | Hook wins |
-| Hook returns `null` | Vizmapper image shows |
-| `clearRenderHook()` | Vizmapper image returns on the next restyle |
-| Node has a Vizmapper **pie or ring** chart | The chart draws **on top** of a hook image unless you set `containment: 'over'` |
+| Situation                                         | Result                                                                          |
+| ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Hook returns an image, node has a Vizmapper image | Hook wins                                                                       |
+| Hook returns `null`                               | Vizmapper image shows                                                           |
+| `clearRenderHook()`                               | Vizmapper image returns on the next restyle                                     |
+| Node has a Vizmapper **pie or ring** chart        | The chart draws **on top** of a hook image unless you set `containment: 'over'` |
 
 The last row is Cytoscape's node draw order (shape → images(inside) → border →
 pie → stripe → images(over)), and matches how two Vizmapper slots already behave.

--- a/src/app-api/core/index.ts
+++ b/src/app-api/core/index.ts
@@ -13,6 +13,8 @@ import type { LayoutApi } from './layoutApi'
 import { layoutApi } from './layoutApi'
 import type { NetworkApi } from './networkApi'
 import { networkApi } from './networkApi'
+import type { NodeGraphicsApi } from './nodeGraphicsApi'
+import { nodeGraphicsApi } from './nodeGraphicsApi'
 import type { SelectionApi } from './selectionApi'
 import { selectionApi } from './selectionApi'
 import type { TableApi } from './tableApi'
@@ -37,6 +39,11 @@ export interface CyWebApiType {
   export: ExportApi
   workspace: WorkspaceApi
   contextMenu: ContextMenuApi
+  /**
+   * Register a per-node graphics render hook. Hook output is renderer-only and
+   * is never exported to CX2 — Vizmapper custom graphics still are.
+   */
+  nodeGraphics: NodeGraphicsApi
   /**
    * Return the network-scoped domains (element, table, selection,
    * viewport, visualStyle, export, plus `layout.applyLayout`) with
@@ -68,6 +75,7 @@ export const CyWebApi: CyWebApiType = {
   export: exportApi,
   workspace: workspaceApi,
   contextMenu: contextMenuApi,
+  nodeGraphics: nodeGraphicsApi,
   forNetwork,
   isReady,
   whenReady: () => whenReadySignal().then(() => CyWebApi),

--- a/src/app-api/core/nodeGraphicsApi.test.ts
+++ b/src/app-api/core/nodeGraphicsApi.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// src/app-api/core/nodeGraphicsApi.test.ts
+// Plain tests for the nodeGraphicsApi core — no renderHook, no React context.
+import type { NodeGraphicsRenderHook } from '../../models/StoreModel/NodeGraphicsStoreModel'
+import { AppCodes, StyleCodes } from '../types/ApiResult'
+import { createNodeGraphicsApi, nodeGraphicsApi } from './nodeGraphicsApi'
+
+// ── Mock: NodeGraphicsStore ───────────────────────────────────────────────────
+// A hand-rolled stand-in so these tests assert the API's contract (validation,
+// ownership scoping, error codes) rather than re-testing store internals, which
+// NodeGraphicsStore.spec.ts covers.
+
+interface StoredHook {
+  hookId: string
+  appId?: string
+  render: NodeGraphicsRenderHook
+}
+
+let hooks: StoredHook[] = []
+let refreshRequests: Record<string, { token: number; nodeIds?: string[] }> = {}
+
+const mockSetHook = vi.fn((hook: StoredHook) => {
+  hooks = hooks.filter((h) => h.appId !== hook.appId)
+  hooks.push(hook)
+})
+const mockRemoveAllByAppId = vi.fn((appId: string) => {
+  hooks = hooks.filter((h) => h.appId === undefined || h.appId !== appId)
+})
+const mockRemoveAnonymousHook = vi.fn(() => {
+  hooks = hooks.filter((h) => h.appId !== undefined)
+})
+const mockRequestRefresh = vi.fn((networkId: string, nodeIds?: string[]) => {
+  refreshRequests[networkId] = {
+    token: (refreshRequests[networkId]?.token ?? 0) + 1,
+    nodeIds,
+  }
+})
+
+vi.mock('../../data/hooks/stores/NodeGraphicsStore', () => ({
+  useNodeGraphicsStore: {
+    getState: vi.fn(() => ({
+      get hooks() {
+        return hooks
+      },
+      setHook: mockSetHook,
+      removeAllByAppId: mockRemoveAllByAppId,
+      removeAnonymousHook: mockRemoveAnonymousHook,
+      requestRefresh: mockRequestRefresh,
+    })),
+  },
+}))
+
+// ── Mock: NetworkStore ────────────────────────────────────────────────────────
+
+const mockNetworks = new Map<string, any>()
+
+vi.mock('../../data/hooks/stores/NetworkStore', () => ({
+  useNetworkStore: {
+    getState: vi.fn(() => ({ networks: mockNetworks })),
+  },
+}))
+
+// ── Mock: WorkspaceStore ──────────────────────────────────────────────────────
+
+let currentNetworkId = 'net1'
+
+vi.mock('../../data/hooks/stores/WorkspaceStore', () => ({
+  useWorkspaceStore: {
+    getState: vi.fn(() => ({ workspace: { currentNetworkId } })),
+  },
+}))
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+const hook: NodeGraphicsRenderHook = () => 'https://example.com/a.png'
+
+describe('nodeGraphicsApi', () => {
+  beforeEach(() => {
+    hooks = []
+    refreshRequests = {}
+    currentNetworkId = 'net1'
+    mockNetworks.clear()
+    mockNetworks.set('net1', { nodes: [{ id: 'n1' }, { id: 'n2' }], edges: [] })
+    vi.clearAllMocks()
+  })
+
+  describe('setRenderHook', () => {
+    it('returns ok with a hookId', () => {
+      const result = createNodeGraphicsApi('app-a').setRenderHook(hook)
+
+      expect(result.success).toBe(true)
+      expect(result.success && result.data.hookId).toBeTruthy()
+    })
+
+    it('registers the hook against the calling app', () => {
+      createNodeGraphicsApi('app-a').setRenderHook(hook)
+
+      expect(mockSetHook).toHaveBeenCalledWith(
+        expect.objectContaining({ appId: 'app-a', render: hook }),
+      )
+    })
+
+    it('registers with no appId on the anonymous singleton', () => {
+      nodeGraphicsApi.setRenderHook(hook)
+
+      expect(mockSetHook).toHaveBeenCalledWith(
+        expect.objectContaining({ appId: undefined }),
+      )
+    })
+
+    it('issues a distinct hookId per registration', () => {
+      const api = createNodeGraphicsApi('app-a')
+      const first = api.setRenderHook(hook)
+      const second = api.setRenderHook(hook)
+
+      expect(first.success && second.success).toBe(true)
+      expect(first.success && second.success && first.data.hookId).not.toBe(
+        second.success ? second.data.hookId : '',
+      )
+    })
+
+    it.each([
+      ['a string', 'not-a-function'],
+      ['null', null],
+      ['undefined', undefined],
+      ['a number', 42],
+      ['an object', {}],
+    ])('fails with INVALID_CUSTOM_GRAPHICS when given %s', (_label, value) => {
+      const result = createNodeGraphicsApi('app-a').setRenderHook(value as any)
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        StyleCodes.INVALID_CUSTOM_GRAPHICS.code,
+      )
+      expect(mockSetHook).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearRenderHook', () => {
+    it('removes the calling app’s hook', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      const result = api.clearRenderHook()
+
+      expect(result.success).toBe(true)
+      expect(mockRemoveAllByAppId).toHaveBeenCalledWith('app-a')
+    })
+
+    it('fails with FUNCTION_NOT_AVAILABLE when the app has no hook', () => {
+      const result = createNodeGraphicsApi('app-a').clearRenderHook()
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        AppCodes.FUNCTION_NOT_AVAILABLE.code,
+      )
+    })
+
+    it('does not let one app clear another app’s hook', () => {
+      createNodeGraphicsApi('app-a').setRenderHook(hook)
+
+      const result = createNodeGraphicsApi('app-b').clearRenderHook()
+
+      expect(result.success).toBe(false)
+      expect(mockRemoveAllByAppId).not.toHaveBeenCalled()
+    })
+
+    it('uses the anonymous path for the singleton', () => {
+      nodeGraphicsApi.setRenderHook(hook)
+
+      const result = nodeGraphicsApi.clearRenderHook()
+
+      expect(result.success).toBe(true)
+      expect(mockRemoveAnonymousHook).toHaveBeenCalled()
+      expect(mockRemoveAllByAppId).not.toHaveBeenCalled()
+    })
+
+    it('does not let the singleton clear an app-owned hook', () => {
+      createNodeGraphicsApi('app-a').setRenderHook(hook)
+
+      expect(nodeGraphicsApi.clearRenderHook().success).toBe(false)
+    })
+  })
+
+  describe('refresh', () => {
+    it('bumps the refresh token for an explicit network', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      const result = api.refresh('net1')
+
+      expect(result.success).toBe(true)
+      expect(mockRequestRefresh).toHaveBeenCalledWith('net1', undefined)
+    })
+
+    it('reports the whole-network node count when no ids are given', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      const result = api.refresh('net1')
+
+      expect(result.success && result.data.nodeCount).toBe(2)
+    })
+
+    it('reports the requested count when ids are given', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      const result = api.refresh('net1', ['n1'])
+
+      expect(result.success && result.data.nodeCount).toBe(1)
+      expect(mockRequestRefresh).toHaveBeenCalledWith('net1', ['n1'])
+    })
+
+    it('falls back to the workspace current network', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      api.refresh()
+
+      expect(mockRequestRefresh).toHaveBeenCalledWith('net1', undefined)
+    })
+
+    it('fails with FUNCTION_NOT_AVAILABLE when no hook is registered', () => {
+      const result = createNodeGraphicsApi('app-a').refresh('net1')
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        AppCodes.FUNCTION_NOT_AVAILABLE.code,
+      )
+      expect(mockRequestRefresh).not.toHaveBeenCalled()
+    })
+
+    it('fails with NO_CURRENT_NETWORK when nothing is selected', () => {
+      currentNetworkId = ''
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      const result = api.refresh()
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        AppCodes.NO_CURRENT_NETWORK.code,
+      )
+    })
+
+    it('fails with NETWORK_NOT_FOUND for an unknown network', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+
+      const result = api.refresh('nope')
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        AppCodes.NETWORK_NOT_FOUND.code,
+      )
+    })
+  })
+
+  describe('never throws across the API boundary', () => {
+    it('converts a store throw into OPERATION_FAILED', () => {
+      mockSetHook.mockImplementationOnce(() => {
+        throw new Error('boom')
+      })
+
+      const result = createNodeGraphicsApi('app-a').setRenderHook(hook)
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        AppCodes.OPERATION_FAILED.code,
+      )
+    })
+
+    it('converts a throw during refresh into OPERATION_FAILED', () => {
+      const api = createNodeGraphicsApi('app-a')
+      api.setRenderHook(hook)
+      mockRequestRefresh.mockImplementationOnce(() => {
+        throw new Error('boom')
+      })
+
+      const result = api.refresh('net1')
+
+      expect(result.success).toBe(false)
+      expect(!result.success && result.error.code).toBe(
+        AppCodes.OPERATION_FAILED.code,
+      )
+    })
+  })
+})

--- a/src/app-api/core/nodeGraphicsApi.ts
+++ b/src/app-api/core/nodeGraphicsApi.ts
@@ -1,0 +1,174 @@
+// src/app-api/core/nodeGraphicsApi.ts
+//
+// Node Graphics API — an app registers one render hook; the host calls it with
+// each changed node and draws the returned image as that node's
+// Cytoscape.js background-image.
+//
+// Two access paths, matching contextMenuApi:
+//   1. Per-app factory: createNodeGraphicsApi(appId) — used by buildPerAppApis.
+//      The hook carries the appId and is cleaned up on app disable.
+//   2. Anonymous singleton: nodeGraphicsApi — for window.CyWebApi only.
+//      Never auto-cleaned; plugin apps must use AppContext.apis.nodeGraphics.
+//
+// Hook output is renderer-only and is never exported to CX2. See
+// docs/design/custom-graphics-image/node-graphics-render-hook.md.
+
+import { v4 as uuidv4 } from 'uuid'
+
+import { useNetworkStore } from '../../data/hooks/stores/NetworkStore'
+import { useNodeGraphicsStore } from '../../data/hooks/stores/NodeGraphicsStore'
+import { useWorkspaceStore } from '../../data/hooks/stores/WorkspaceStore'
+import type { IdType } from '../../models/IdType'
+import type { NodeGraphicsRenderHook } from '../../models/StoreModel/NodeGraphicsStoreModel'
+import type { ApiResult } from '../types/ApiResult'
+import { AppCodes, fail, ok, StyleCodes } from '../types/ApiResult'
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+export type {
+  NodeGraphicsContainment,
+  NodeGraphicsCrossOrigin,
+  NodeGraphicsFit,
+  NodeGraphicsImage,
+  NodeGraphicsRenderHook,
+  NodeGraphicsRequest,
+  NodeGraphicsResult,
+} from '../../models/StoreModel/NodeGraphicsStoreModel'
+
+export interface NodeGraphicsApi {
+  /**
+   * Register this app's node-graphics render hook, replacing any hook it
+   * previously registered.
+   *
+   * The host calls `hook` with each node whose table row changed, and draws a
+   * returned image as that node's background. Returning `null` leaves the node
+   * to its Vizmapper custom graphic. The hook must be synchronous and must not
+   * throw — see `refresh` for images that need async work.
+   *
+   * @returns `ok({ hookId })`; `fail(INVALID_CUSTOM_GRAPHICS)` if `hook` is not
+   *   a function
+   */
+  setRenderHook(hook: NodeGraphicsRenderHook): ApiResult<{ hookId: string }>
+
+  /**
+   * Remove this app's hook and drop every image it produced. Affected nodes
+   * fall back to their Vizmapper custom graphics.
+   *
+   * @returns `ok()`; `fail(FUNCTION_NOT_AVAILABLE)` if no hook is registered
+   */
+  clearRenderHook(): ApiResult
+
+  /**
+   * Re-run the hook for a network.
+   *
+   * Table edits invalidate automatically. This exists for images that depend on
+   * the app's own state — a slider, a selected timepoint, a completed fetch —
+   * which the host cannot observe. It is also how an app supplies async images:
+   * compute and cache off to the side, then `refresh()` so the synchronous hook
+   * can return the cached value.
+   *
+   * @param networkId - Omit to target the workspace's current network
+   * @param nodeIds - Omit for every node in the network
+   * @returns `ok({ nodeCount })`; `fail(FUNCTION_NOT_AVAILABLE)` if no hook is
+   *   registered; `fail(NO_CURRENT_NETWORK)` / `fail(NETWORK_NOT_FOUND)`
+   */
+  refresh(
+    networkId?: IdType,
+    nodeIds?: IdType[],
+  ): ApiResult<{ nodeCount: number }>
+}
+
+// ── Shared implementation ────────────────────────────────────────────────────
+
+function registerHook(
+  hook: NodeGraphicsRenderHook,
+  appId?: string,
+): ApiResult<{ hookId: string }> {
+  try {
+    if (typeof hook !== 'function') {
+      return fail(
+        StyleCodes.INVALID_CUSTOM_GRAPHICS,
+        'nodeGraphics.renderHook',
+        'hook must be a function',
+      )
+    }
+
+    const hookId = uuidv4()
+    useNodeGraphicsStore.getState().setHook({ hookId, appId, render: hook })
+    return ok({ hookId })
+  } catch (e) {
+    return fail(AppCodes.OPERATION_FAILED, String(e))
+  }
+}
+
+/** True when the caller identified by `appId` has a hook registered. */
+function hasHook(appId?: string): boolean {
+  return useNodeGraphicsStore.getState().hooks.some((h) => h.appId === appId)
+}
+
+function clearHook(appId?: string): ApiResult {
+  try {
+    if (!hasHook(appId)) {
+      return fail(AppCodes.FUNCTION_NOT_AVAILABLE, 'nodeGraphics.renderHook')
+    }
+    // Scoped by owner: an app can only clear its own hook, and the anonymous
+    // singleton can only clear the anonymous one.
+    if (appId === undefined) {
+      useNodeGraphicsStore.getState().removeAnonymousHook()
+    } else {
+      useNodeGraphicsStore.getState().removeAllByAppId(appId)
+    }
+    return ok()
+  } catch (e) {
+    return fail(AppCodes.OPERATION_FAILED, String(e))
+  }
+}
+
+function refreshHook(
+  appId: string | undefined,
+  networkId?: IdType,
+  nodeIds?: IdType[],
+): ApiResult<{ nodeCount: number }> {
+  try {
+    if (!hasHook(appId)) {
+      return fail(AppCodes.FUNCTION_NOT_AVAILABLE, 'nodeGraphics.renderHook')
+    }
+
+    const targetId =
+      networkId ?? useWorkspaceStore.getState().workspace.currentNetworkId
+    if (targetId === undefined || targetId === '') {
+      return fail(AppCodes.NO_CURRENT_NETWORK)
+    }
+
+    const network = useNetworkStore.getState().networks.get(targetId)
+    if (network === undefined) {
+      return fail(AppCodes.NETWORK_NOT_FOUND, targetId)
+    }
+
+    useNodeGraphicsStore.getState().requestRefresh(targetId, nodeIds)
+
+    return ok({
+      nodeCount: nodeIds !== undefined ? nodeIds.length : network.nodes.length,
+    })
+  } catch (e) {
+    return fail(AppCodes.OPERATION_FAILED, String(e))
+  }
+}
+
+// ── Per-app factory (lifecycle-managed, used by buildPerAppApis) ──────────────
+
+export const createNodeGraphicsApi = (appId: string): NodeGraphicsApi => ({
+  setRenderHook: (hook) => registerHook(hook, appId),
+  clearRenderHook: () => clearHook(appId),
+  refresh: (networkId, nodeIds) => refreshHook(appId, networkId, nodeIds),
+})
+
+// ── Anonymous singleton — for window.CyWebApi only ────────────────────────────
+// Plugin apps must NOT use this path; use AppContext.apis.nodeGraphics so the
+// hook is cleaned up when the app is disabled.
+
+export const nodeGraphicsApi: NodeGraphicsApi = {
+  setRenderHook: (hook) => registerHook(hook, undefined),
+  clearRenderHook: () => clearHook(undefined),
+  refresh: (networkId, nodeIds) => refreshHook(undefined, networkId, nodeIds),
+}

--- a/src/app-api/core/perAppApis.test.ts
+++ b/src/app-api/core/perAppApis.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { CyWebApi } from './index'
+import { buildPerAppApis } from './perAppApis'
+
+describe('buildPerAppApis', () => {
+  it('carries every domain from the anonymous CyWebApi surface', () => {
+    // The failure this guards: a new domain added to CyWebApi but not reachable
+    // from an app, which used to be possible because three call sites each
+    // assembled this object by hand.
+    const apis = buildPerAppApis('app-a')
+
+    for (const key of Object.keys(CyWebApi)) {
+      expect(apis, `missing domain: ${key}`).toHaveProperty(key)
+    }
+  })
+
+  it('adds resource, which window.CyWebApi deliberately lacks', () => {
+    const apis = buildPerAppApis('app-a')
+
+    expect(apis.resource).toBeDefined()
+    expect(CyWebApi).not.toHaveProperty('resource')
+  })
+
+  it('overrides contextMenu with a per-app instance', () => {
+    const apis = buildPerAppApis('app-a')
+
+    expect(apis.contextMenu).toBeDefined()
+    expect(apis.contextMenu).not.toBe(CyWebApi.contextMenu)
+  })
+
+  it('returns independent instances for different apps', () => {
+    const a = buildPerAppApis('app-a')
+    const b = buildPerAppApis('app-b')
+
+    expect(a.resource).not.toBe(b.resource)
+    expect(a.contextMenu).not.toBe(b.contextMenu)
+  })
+
+  it('registers context menu items under the calling app', () => {
+    const apis = buildPerAppApis('app-a')
+
+    const result = apis.contextMenu.addContextMenuItem({
+      label: 'Do a thing',
+      handler: () => {},
+    })
+    expect(result.success).toBe(true)
+
+    // A different app must not be able to remove it.
+    const other = buildPerAppApis('app-b')
+    const itemId = result.success ? result.data.itemId : ''
+    expect(other.contextMenu.removeContextMenuItem(itemId).success).toBe(false)
+
+    // The owner can.
+    expect(apis.contextMenu.removeContextMenuItem(itemId).success).toBe(true)
+  })
+})

--- a/src/app-api/core/perAppApis.test.ts
+++ b/src/app-api/core/perAppApis.test.ts
@@ -35,6 +35,7 @@ describe('buildPerAppApis', () => {
 
     expect(a.resource).not.toBe(b.resource)
     expect(a.contextMenu).not.toBe(b.contextMenu)
+    expect(a.nodeGraphics).not.toBe(b.nodeGraphics)
   })
 
   it('registers context menu items under the calling app', () => {

--- a/src/app-api/core/perAppApis.ts
+++ b/src/app-api/core/perAppApis.ts
@@ -12,6 +12,7 @@
 import type { AppContextApis } from '../types/AppContext'
 import { CyWebApi } from './index'
 import { createContextMenuApi } from './contextMenuApi'
+import { createNodeGraphicsApi } from './nodeGraphicsApi'
 import { createResourceApi } from './resourceApi'
 
 /**
@@ -27,5 +28,6 @@ export function buildPerAppApis(appId: string): AppContextApis {
     ...CyWebApi,
     resource: createResourceApi(appId),
     contextMenu: createContextMenuApi(appId),
+    nodeGraphics: createNodeGraphicsApi(appId),
   }
 }

--- a/src/app-api/core/perAppApis.ts
+++ b/src/app-api/core/perAppApis.ts
@@ -1,0 +1,31 @@
+// src/app-api/core/perAppApis.ts
+//
+// The single place a per-app API object is assembled.
+//
+// Three call sites need one — app mount, the side-panel tab host, and the apps
+// menu — and each previously spread `CyWebApi` and overrode the per-app
+// factories inline. Adding a per-app domain then meant editing three files, and
+// missing one produced an app that silently lacked that domain.
+//
+// React-free by construction: every factory it calls lives in core/.
+
+import type { AppContextApis } from '../types/AppContext'
+import { CyWebApi } from './index'
+import { createContextMenuApi } from './contextMenuApi'
+import { createResourceApi } from './resourceApi'
+
+/**
+ * Build the per-app `AppContextApis` for `appId`.
+ *
+ * Starts from the anonymous `CyWebApi` surface, then overrides every domain
+ * whose registrations must be attributed to an app and cleaned up when that app
+ * is disabled. Anything registered through these factories carries `appId` and
+ * is removed by `AppCleanupRegistry` on deactivation.
+ */
+export function buildPerAppApis(appId: string): AppContextApis {
+  return {
+    ...CyWebApi,
+    resource: createResourceApi(appId),
+    contextMenu: createContextMenuApi(appId),
+  }
+}

--- a/src/app-api/cywebapi-ready.test.ts
+++ b/src/app-api/cywebapi-ready.test.ts
@@ -24,6 +24,7 @@ const MOCK_API_DOMAINS = [
   'export',
   'workspace',
   'contextMenu',
+  'nodeGraphics',
 ] as const
 
 describe('cywebapi:ready smoke test', () => {
@@ -44,7 +45,7 @@ describe('cywebapi:ready smoke test', () => {
     expect((window as any).CyWebApi).toBeDefined()
   })
 
-  it('window.CyWebApi exposes all 10 required API domain keys', () => {
+  it('window.CyWebApi exposes all 11 required API domain keys', () => {
     ;(window as any).CyWebApi = mockCyWebApi
     for (const domain of MOCK_API_DOMAINS) {
       expect((window as any).CyWebApi).toHaveProperty(domain)

--- a/src/app-api/event-bus/initEventBus.ts
+++ b/src/app-api/event-bus/initEventBus.ts
@@ -9,6 +9,7 @@ import { useVisualStyleStore } from '../../data/hooks/stores/VisualStyleStore'
 import { useWorkspaceStore } from '../../data/hooks/stores/WorkspaceStore'
 import { IdType } from '../../models/IdType'
 import { Table } from '../../models/TableModel'
+import { detectChangedRowIds } from '../../models/TableModel/impl/tableDiff'
 import { VisualPropertyName } from '../../models/VisualStyleModel/VisualPropertyName'
 import { dispatchCyWebEvent } from './dispatchCyWebEvent'
 
@@ -33,21 +34,6 @@ function selectionEqual(
     if (a.selectedEdges[i] !== b.selectedEdges[i]) return false
   }
   return true
-}
-
-/**
- * Returns the IDs of rows that were added, deleted, or mutated between two
- * table snapshots. An empty array indicates a schema-only change.
- */
-function detectChangedRowIds(curr: Table, prev: Table): IdType[] {
-  const changed: IdType[] = []
-  for (const [id, row] of curr.rows) {
-    if (prev.rows.get(id) !== row) changed.push(id)
-  }
-  for (const id of prev.rows.keys()) {
-    if (!curr.rows.has(id)) changed.push(id)
-  }
-  return changed
 }
 
 /**

--- a/src/app-api/types/AppContext.ts
+++ b/src/app-api/types/AppContext.ts
@@ -3,6 +3,7 @@
 import { CyApp } from '../../models/AppModel/CyApp'
 import type { CyWebApiType } from '../core'
 import type { ContextMenuApi } from '../core/contextMenuApi'
+import type { NodeGraphicsApi } from '../core/nodeGraphicsApi'
 import type { ResourceApi, ResourceDeclaration } from './AppResourceTypes'
 
 /**
@@ -23,6 +24,12 @@ export interface AppContextApis extends CyWebApiType {
    * Overrides the anonymous contextMenu from CyWebApiType.
    */
   readonly contextMenu: ContextMenuApi
+  /**
+   * Per-app node-graphics render hook API (factory-bound to this app's ID).
+   * The hook and every image it produced are dropped when the app is disabled.
+   * Overrides the anonymous nodeGraphics from CyWebApiType.
+   */
+  readonly nodeGraphics: NodeGraphicsApi
 }
 
 /**

--- a/src/app-api/types/index.ts
+++ b/src/app-api/types/index.ts
@@ -79,6 +79,18 @@ export type {
   ContextMenuTarget,
 } from '../core/contextMenuApi'
 
+// ── Node Graphics API types ──────────────────────────────────────
+export type {
+  NodeGraphicsApi,
+  NodeGraphicsContainment,
+  NodeGraphicsCrossOrigin,
+  NodeGraphicsFit,
+  NodeGraphicsImage,
+  NodeGraphicsRenderHook,
+  NodeGraphicsRequest,
+  NodeGraphicsResult,
+} from '../core/nodeGraphicsApi'
+
 // ── App Resource registration types (Phase 2) ───────────────────
 export type {
   MenuItemHostProps,

--- a/src/data/hooks/stores/NodeGraphicsStore.spec.ts
+++ b/src/data/hooks/stores/NodeGraphicsStore.spec.ts
@@ -287,6 +287,97 @@ describe('NodeGraphicsStore', () => {
 
       expect(result.current.refreshRequests.net1).toBeUndefined()
     })
+
+    it('merges node ids from an unconsumed request', () => {
+      // Both calls land in one tick, so the renderer only ever reads the final
+      // entry. Replacing instead of merging would drop n1 entirely.
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n1'])
+        result.current.requestRefresh('net1', ['n2'])
+      })
+
+      expect(result.current.refreshRequests.net1.nodeIds).toEqual(['n1', 'n2'])
+      expect(result.current.refreshRequests.net1.token).toBe(2)
+    })
+
+    it('does not duplicate an id present in both requests', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n1', 'n2'])
+        result.current.requestRefresh('net1', ['n2', 'n3'])
+      })
+
+      expect(result.current.refreshRequests.net1.nodeIds).toEqual([
+        'n1',
+        'n2',
+        'n3',
+      ])
+    })
+
+    it('keeps a pending whole-network request when ids arrive after it', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1')
+        result.current.requestRefresh('net1', ['n1'])
+      })
+
+      expect(result.current.refreshRequests.net1.nodeIds).toBeUndefined()
+    })
+
+    it('copies the caller-supplied array', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+      const nodeIds = ['n1']
+
+      act(() => {
+        result.current.requestRefresh('net1', nodeIds)
+      })
+      nodeIds.push('n2')
+
+      expect(result.current.refreshRequests.net1.nodeIds).toEqual(['n1'])
+    })
+
+    it('starts a fresh request after the renderer consumes one', () => {
+      // The ack is what bounds the merge: without it, every later refresh would
+      // re-run every node ever refreshed for this network.
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n1'])
+      })
+      const token = result.current.refreshRequests.net1.token
+
+      act(() => {
+        result.current.consumeRefresh('net1', token)
+      })
+      expect(result.current.refreshRequests.net1).toBeUndefined()
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n2'])
+      })
+      expect(result.current.refreshRequests.net1.nodeIds).toEqual(['n2'])
+    })
+
+    it('ignores an ack for a superseded token', () => {
+      // A refresh that arrives after the renderer read the request must not be
+      // thrown away with it.
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n1'])
+      })
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n2'])
+        result.current.consumeRefresh('net1', 1)
+      })
+
+      expect(result.current.refreshRequests.net1.token).toBe(2)
+      expect(result.current.refreshRequests.net1.nodeIds).toEqual(['n1', 'n2'])
+    })
   })
 
   describe('app lifecycle integration', () => {

--- a/src/data/hooks/stores/NodeGraphicsStore.spec.ts
+++ b/src/data/hooks/stores/NodeGraphicsStore.spec.ts
@@ -29,6 +29,7 @@ describe('NodeGraphicsStore', () => {
         hooks: [],
         images: {},
         refreshRequests: {},
+        refreshSequence: {},
       })
     })
   })
@@ -359,6 +360,25 @@ describe('NodeGraphicsStore', () => {
         result.current.requestRefresh('net1', ['n2'])
       })
       expect(result.current.refreshRequests.net1.nodeIds).toEqual(['n2'])
+    })
+
+    it('never reissues a token the renderer already saw', () => {
+      // The renderer's effect keys off the token value. A token derived from the
+      // pending request would restart at 1 after the ack, and a refresh batched
+      // with that ack would look like no change at all.
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n1'])
+      })
+      expect(result.current.refreshRequests.net1.token).toBe(1)
+
+      act(() => {
+        result.current.consumeRefresh('net1', 1)
+        result.current.requestRefresh('net1', ['n2'])
+      })
+
+      expect(result.current.refreshRequests.net1.token).toBe(2)
     })
 
     it('ignores an ack for a superseded token', () => {

--- a/src/data/hooks/stores/NodeGraphicsStore.spec.ts
+++ b/src/data/hooks/stores/NodeGraphicsStore.spec.ts
@@ -1,0 +1,315 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  NodeGraphicsRenderHook,
+  ResolvedNodeGraphics,
+} from '../../../models/StoreModel/NodeGraphicsStoreModel'
+import { cleanupAllForApp } from './AppCleanupRegistry'
+import { useNodeGraphicsStore } from './NodeGraphicsStore'
+
+const noopHook: NodeGraphicsRenderHook = () => null
+
+const image = (
+  hookId: string,
+  url = 'https://example.com/a.png',
+): ResolvedNodeGraphics => ({
+  image: url,
+  fit: 'contain',
+  opacity: 1,
+  crossOrigin: 'null',
+  containment: 'inside',
+  hookId,
+})
+
+describe('NodeGraphicsStore', () => {
+  beforeEach(() => {
+    act(() => {
+      useNodeGraphicsStore.setState({
+        hooks: [],
+        images: {},
+        refreshRequests: {},
+      })
+    })
+  })
+
+  describe('setHook', () => {
+    it('registers a hook', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+      })
+
+      expect(result.current.hooks).toHaveLength(1)
+      expect(result.current.hooks[0].hookId).toBe('h1')
+    })
+
+    it('keeps the render function callable (immer must not freeze it away)', () => {
+      const render = vi.fn(() => 'https://example.com/x.png')
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render })
+      })
+
+      const stored = useNodeGraphicsStore.getState().hooks[0]
+      expect(typeof stored.render).toBe('function')
+      expect(
+        stored.render({ networkId: 'net1', nodeId: 'n1', attributes: {} }),
+      ).toBe('https://example.com/x.png')
+      expect(render).toHaveBeenCalledOnce()
+    })
+
+    it('replaces the same app’s previous hook rather than adding one', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setHook({ hookId: 'h2', appId: 'a', render: noopHook })
+      })
+
+      expect(result.current.hooks).toHaveLength(1)
+      expect(result.current.hooks[0].hookId).toBe('h2')
+    })
+
+    it('drops images produced by the replaced hook', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setImages('net1', [['n1', image('h1')]])
+      })
+      expect(result.current.images.net1.n1).toBeDefined()
+
+      act(() => {
+        result.current.setHook({ hookId: 'h2', appId: 'a', render: noopHook })
+      })
+
+      // Stale pictures from the old hook must not survive re-registration.
+      expect(result.current.images.net1?.n1).toBeUndefined()
+    })
+
+    it('keeps hooks from different apps side by side, in registration order', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setHook({ hookId: 'h2', appId: 'b', render: noopHook })
+      })
+
+      expect(result.current.hooks.map((h) => h.hookId)).toEqual(['h1', 'h2'])
+    })
+
+    it('treats the anonymous hook as its own owner', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setHook({ hookId: 'anon', render: noopHook })
+      })
+
+      expect(result.current.hooks).toHaveLength(2)
+    })
+  })
+
+  describe('removeAllByAppId', () => {
+    it('removes the app’s hook and its images', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setImages('net1', [['n1', image('h1')]])
+        result.current.removeAllByAppId('a')
+      })
+
+      expect(result.current.hooks).toHaveLength(0)
+      expect(result.current.images.net1?.n1).toBeUndefined()
+    })
+
+    it('leaves another app’s hook and images alone', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setHook({ hookId: 'h2', appId: 'b', render: noopHook })
+        result.current.setImages('net1', [
+          ['n1', image('h1')],
+          ['n2', image('h2')],
+        ])
+        result.current.removeAllByAppId('a')
+      })
+
+      expect(result.current.hooks.map((h) => h.hookId)).toEqual(['h2'])
+      expect(result.current.images.net1.n1).toBeUndefined()
+      expect(result.current.images.net1.n2).toBeDefined()
+    })
+
+    it('never removes the anonymous hook', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'anon', render: noopHook })
+        result.current.removeAllByAppId('a')
+      })
+
+      expect(result.current.hooks).toHaveLength(1)
+    })
+  })
+
+  describe('removeAnonymousHook', () => {
+    it('removes only the anonymous hook and its images', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({ hookId: 'anon', render: noopHook })
+        result.current.setHook({ hookId: 'h1', appId: 'a', render: noopHook })
+        result.current.setImages('net1', [
+          ['n1', image('anon')],
+          ['n2', image('h1')],
+        ])
+        result.current.removeAnonymousHook()
+      })
+
+      expect(result.current.hooks.map((h) => h.hookId)).toEqual(['h1'])
+      expect(result.current.images.net1.n1).toBeUndefined()
+      expect(result.current.images.net1.n2).toBeDefined()
+    })
+  })
+
+  describe('images', () => {
+    it('merges entries rather than replacing the network map', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setImages('net1', [['n1', image('h1', 'a.png')]])
+        result.current.setImages('net1', [['n2', image('h1', 'b.png')]])
+      })
+
+      expect(Object.keys(result.current.images.net1).sort()).toEqual([
+        'n1',
+        'n2',
+      ])
+    })
+
+    it('overwrites an existing node entry', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setImages('net1', [
+          ['n1', image('h1', 'https://example.com/old.png')],
+        ])
+        result.current.setImages('net1', [
+          ['n1', image('h1', 'https://example.com/new.png')],
+        ])
+      })
+
+      expect(result.current.images.net1.n1.image).toBe(
+        'https://example.com/new.png',
+      )
+    })
+
+    it('keeps networks independent', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setImages('net1', [['n1', image('h1')]])
+        result.current.setImages('net2', [['n1', image('h1')]])
+        result.current.clearNetwork('net1')
+      })
+
+      expect(result.current.images.net1).toBeUndefined()
+      expect(result.current.images.net2.n1).toBeDefined()
+    })
+
+    it('clearImages drops only the named nodes', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setImages('net1', [
+          ['n1', image('h1')],
+          ['n2', image('h1')],
+          ['n3', image('h1')],
+        ])
+        result.current.clearImages('net1', ['n1', 'n3'])
+      })
+
+      expect(Object.keys(result.current.images.net1)).toEqual(['n2'])
+    })
+
+    it('clearImages on an unknown network is a no-op', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      expect(() =>
+        act(() => {
+          result.current.clearImages('nope', ['n1'])
+        }),
+      ).not.toThrow()
+    })
+  })
+
+  describe('requestRefresh', () => {
+    it('starts at 1 and increments monotonically', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1')
+      })
+      expect(result.current.refreshRequests.net1.token).toBe(1)
+
+      act(() => {
+        result.current.requestRefresh('net1')
+      })
+      expect(result.current.refreshRequests.net1.token).toBe(2)
+    })
+
+    it('carries the requested node ids, or undefined for the whole network', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1', ['n1', 'n2'])
+      })
+      expect(result.current.refreshRequests.net1.nodeIds).toEqual(['n1', 'n2'])
+
+      act(() => {
+        result.current.requestRefresh('net1')
+      })
+      expect(result.current.refreshRequests.net1.nodeIds).toBeUndefined()
+    })
+
+    it('is cleared by clearNetwork', () => {
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.requestRefresh('net1')
+        result.current.clearNetwork('net1')
+      })
+
+      expect(result.current.refreshRequests.net1).toBeUndefined()
+    })
+  })
+
+  describe('app lifecycle integration', () => {
+    it('cleanupAllForApp removes the app’s hook via the cleanup registry', () => {
+      // The store registers its cleanup at module load, so appLifecycle.ts
+      // needs no changes to tear down node graphics.
+      const { result } = renderHook(() => useNodeGraphicsStore())
+
+      act(() => {
+        result.current.setHook({
+          hookId: 'h1',
+          appId: 'app-x',
+          render: noopHook,
+        })
+        result.current.setImages('net1', [['n1', image('h1')]])
+      })
+
+      act(() => {
+        cleanupAllForApp('app-x')
+      })
+
+      expect(result.current.hooks).toHaveLength(0)
+      expect(result.current.images.net1?.n1).toBeUndefined()
+    })
+  })
+})

--- a/src/data/hooks/stores/NodeGraphicsStore.ts
+++ b/src/data/hooks/stores/NodeGraphicsStore.ts
@@ -1,0 +1,150 @@
+// src/data/hooks/stores/NodeGraphicsStore.ts
+//
+// Registry for app-supplied node-graphics render hooks, plus the images they
+// have produced.
+//
+// NO PERSISTENCE, DELIBERATELY. Hook output is renderer-only: it must never
+// reach IndexedDB (it would bloat the DB and thrash cross-tab sync) and must
+// never reach CX2 (the export contract — see
+// docs/design/custom-graphics-image/node-graphics-render-hook.md). The CX2
+// exporter reads `CyNetwork` fields only, and this store is not one of them.
+//
+// Immer is safe here even though state holds functions. A bare function is not
+// `isDraftable`, so immer's deep freeze walks past it — `RendererFunctionStore`
+// stores raw functions under immer for the same reason. Do NOT "fix" this by
+// copying `AppResourceStore`'s no-immer setup: that carve-out exists because
+// `React.lazy()` returns a plain object whose mutable `_status` immer freezes.
+//
+// Registry and images share one store on purpose: unregistering a hook must
+// atomically drop its images, and splitting them would expose an intermediate
+// state to the renderer.
+
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+import { IdType } from '../../../models/IdType'
+import type {
+  NodeGraphicsStoreModel,
+  RegisteredNodeGraphicsHook,
+  ResolvedNodeGraphics,
+} from '../../../models/StoreModel/NodeGraphicsStoreModel'
+import { registerAppCleanup } from './AppCleanupRegistry'
+
+/** Drop every image produced by the given hook ids, across all networks. */
+const dropImagesByHookIds = (
+  images: Record<IdType, Record<IdType, ResolvedNodeGraphics>>,
+  hookIds: Set<string>,
+): void => {
+  if (hookIds.size === 0) return
+  for (const networkId of Object.keys(images)) {
+    const perNode = images[networkId]
+    for (const nodeId of Object.keys(perNode)) {
+      if (hookIds.has(perNode[nodeId].hookId)) {
+        delete perNode[nodeId]
+      }
+    }
+  }
+}
+
+export const useNodeGraphicsStore = create(
+  immer<NodeGraphicsStoreModel>((set) => ({
+    hooks: [],
+    images: {},
+    refreshRequests: {},
+
+    setHook(hook: RegisteredNodeGraphicsHook) {
+      set((state) => {
+        // One hook per app: replacing drops the previous hook's images so a
+        // re-registration cannot leave stale pictures on screen.
+        const existing = state.hooks.filter((h) => h.appId === hook.appId)
+        if (existing.length > 0) {
+          dropImagesByHookIds(
+            state.images,
+            new Set(existing.map((h) => h.hookId)),
+          )
+          state.hooks = state.hooks.filter((h) => h.appId !== hook.appId)
+        }
+        state.hooks.push(hook)
+        return state
+      })
+    },
+
+    removeAllByAppId(appId: string) {
+      set((state) => {
+        // Anonymous hooks (appId === undefined) are never removed here — they
+        // belong to window.CyWebApi and have no lifecycle to hook into.
+        const doomed = state.hooks.filter(
+          (h) => h.appId !== undefined && h.appId === appId,
+        )
+        if (doomed.length === 0) return state
+        dropImagesByHookIds(state.images, new Set(doomed.map((h) => h.hookId)))
+        state.hooks = state.hooks.filter(
+          (h) => h.appId === undefined || h.appId !== appId,
+        )
+        return state
+      })
+    },
+
+    removeAnonymousHook() {
+      set((state) => {
+        const doomed = state.hooks.filter((h) => h.appId === undefined)
+        if (doomed.length === 0) return state
+        dropImagesByHookIds(state.images, new Set(doomed.map((h) => h.hookId)))
+        state.hooks = state.hooks.filter((h) => h.appId !== undefined)
+        return state
+      })
+    },
+
+    setImages(
+      networkId: IdType,
+      entries: Array<[IdType, ResolvedNodeGraphics]>,
+    ) {
+      if (entries.length === 0) return
+      set((state) => {
+        const perNode = state.images[networkId] ?? {}
+        for (const [nodeId, resolved] of entries) {
+          perNode[nodeId] = resolved
+        }
+        state.images[networkId] = perNode
+        return state
+      })
+    },
+
+    clearImages(networkId: IdType, nodeIds: IdType[]) {
+      if (nodeIds.length === 0) return
+      set((state) => {
+        const perNode = state.images[networkId]
+        if (perNode === undefined) return state
+        for (const nodeId of nodeIds) {
+          delete perNode[nodeId]
+        }
+        return state
+      })
+    },
+
+    clearNetwork(networkId: IdType) {
+      set((state) => {
+        delete state.images[networkId]
+        delete state.refreshRequests[networkId]
+        return state
+      })
+    },
+
+    requestRefresh(networkId: IdType, nodeIds?: IdType[]) {
+      set((state) => {
+        const prev = state.refreshRequests[networkId]
+        state.refreshRequests[networkId] = {
+          token: (prev?.token ?? 0) + 1,
+          nodeIds,
+        }
+        return state
+      })
+    },
+  })),
+)
+
+// Lets appLifecycle.ts clean up an app's hook and images via
+// cleanupAllForApp(appId), with no changes needed there.
+registerAppCleanup((appId) =>
+  useNodeGraphicsStore.getState().removeAllByAppId(appId),
+)

--- a/src/data/hooks/stores/NodeGraphicsStore.ts
+++ b/src/data/hooks/stores/NodeGraphicsStore.ts
@@ -51,6 +51,7 @@ export const useNodeGraphicsStore = create(
     hooks: [],
     images: {},
     refreshRequests: {},
+    refreshSequence: {},
 
     setHook(hook: RegisteredNodeGraphicsHook) {
       set((state) => {
@@ -126,6 +127,8 @@ export const useNodeGraphicsStore = create(
       set((state) => {
         delete state.images[networkId]
         delete state.refreshRequests[networkId]
+        // refreshSequence survives on purpose: a renderer that comes back to
+        // this network must still see the next token as a change.
         return state
       })
     },
@@ -133,7 +136,11 @@ export const useNodeGraphicsStore = create(
     requestRefresh(networkId: IdType, nodeIds?: readonly IdType[]) {
       set((state) => {
         const prev = state.refreshRequests[networkId]
-        const token = (prev?.token ?? 0) + 1
+        // From the per-network sequence, not from the pending request: the
+        // request is deleted on consume, so deriving the token from it would
+        // reissue 1 and the renderer's selector would see no change.
+        const token = (state.refreshSequence[networkId] ?? 0) + 1
+        state.refreshSequence[networkId] = token
 
         // Copied, so a caller that mutates its array after the call cannot
         // change what the renderer runs.

--- a/src/data/hooks/stores/NodeGraphicsStore.ts
+++ b/src/data/hooks/stores/NodeGraphicsStore.ts
@@ -97,7 +97,7 @@ export const useNodeGraphicsStore = create(
 
     setImages(
       networkId: IdType,
-      entries: Array<[IdType, ResolvedNodeGraphics]>,
+      entries: ReadonlyArray<readonly [IdType, ResolvedNodeGraphics]>,
     ) {
       if (entries.length === 0) return
       set((state) => {
@@ -110,7 +110,7 @@ export const useNodeGraphicsStore = create(
       })
     },
 
-    clearImages(networkId: IdType, nodeIds: IdType[]) {
+    clearImages(networkId: IdType, nodeIds: readonly IdType[]) {
       if (nodeIds.length === 0) return
       set((state) => {
         const perNode = state.images[networkId]
@@ -130,13 +130,40 @@ export const useNodeGraphicsStore = create(
       })
     },
 
-    requestRefresh(networkId: IdType, nodeIds?: IdType[]) {
+    requestRefresh(networkId: IdType, nodeIds?: readonly IdType[]) {
       set((state) => {
         const prev = state.refreshRequests[networkId]
-        state.refreshRequests[networkId] = {
-          token: (prev?.token ?? 0) + 1,
-          nodeIds,
+        const token = (prev?.token ?? 0) + 1
+
+        // Copied, so a caller that mutates its array after the call cannot
+        // change what the renderer runs.
+        let nextIds = nodeIds === undefined ? undefined : [...nodeIds]
+
+        if (prev !== undefined) {
+          // Merge with the unconsumed request rather than replacing it. Two
+          // refresh() calls in one tick notify React once, so the renderer only
+          // ever reads the final entry — a replace would silently drop the first
+          // call's nodes. Either side asking for the whole network wins.
+          nextIds =
+            prev.nodeIds === undefined || nextIds === undefined
+              ? undefined
+              : [...new Set([...prev.nodeIds, ...nextIds])]
         }
+
+        state.refreshRequests[networkId] = { token, nodeIds: nextIds }
+        return state
+      })
+    },
+
+    consumeRefresh(networkId: IdType, token: number) {
+      set((state) => {
+        // Bounded accumulation depends on this: without an ack, merging would
+        // make every refresh re-run every node ever refreshed for this network.
+        //
+        // Token-checked so a request that arrived after the renderer read this
+        // one is not thrown away with it.
+        if (state.refreshRequests[networkId]?.token !== token) return state
+        delete state.refreshRequests[networkId]
         return state
       })
     },

--- a/src/data/hooks/stores/useAppManager.ts
+++ b/src/data/hooks/stores/useAppManager.ts
@@ -1,12 +1,8 @@
 import { useContext, useEffect, useRef, useState } from 'react'
 
-import { CyWebApi } from '../../../app-api/core'
-import { createContextMenuApi } from '../../../app-api/core/contextMenuApi'
+import { buildPerAppApis } from '../../../app-api/core/perAppApis'
 import { createResourceApi } from '../../../app-api/core/resourceApi'
-import type {
-  AppContextApis,
-  CyAppWithLifecycle,
-} from '../../../app-api/types/AppContext'
+import type { CyAppWithLifecycle } from '../../../app-api/types/AppContext'
 import type {
   RegisterMenuItemOptions,
   RegisterPanelOptions,
@@ -54,18 +50,6 @@ export interface AppManagerCommands {
     opts?: { activate?: boolean },
   ) => Promise<void>
   uninstallApp: (id: string) => Promise<void>
-}
-
-/**
- * Build a per-app AppContextApis object. Extends CyWebApi with
- * per-app resource and contextMenu factories bound to the given appId.
- */
-function buildPerAppApis(appId: string): AppContextApis {
-  return {
-    ...CyWebApi,
-    resource: createResourceApi(appId),
-    contextMenu: createContextMenuApi(appId),
-  }
 }
 
 /**

--- a/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -28,6 +28,7 @@ import { CX_ANNOTATIONS_KEY } from '../../../models/CxModel/impl/extractor'
 import { DisplayMode } from '../../../models/FilterModel/DisplayMode'
 import { IdType } from '../../../models/IdType'
 import { Network } from '../../../models/NetworkModel'
+import type { ResolvedNodeGraphics } from '../../../models/StoreModel/NodeGraphicsStoreModel'
 import { UndoCommandType } from '../../../models/StoreModel/UndoStoreModel'
 import { NetworkView, NodeView } from '../../../models/ViewModel'
 import VisualStyleFn, { VisualStyle } from '../../../models/VisualStyleModel'
@@ -48,7 +49,9 @@ import {
   resolveEdgeCreationTap,
 } from './edgeCreationMode'
 import { ContextMenuState, NetworkContextMenu } from './NetworkContextMenu'
+import { applyNodeGraphics, resetNodeGraphics } from './nodeGraphicsApply'
 import { registerCyExtensions } from './registerCyExtensions'
+import { useNodeGraphicsSync } from './useNodeGraphicsSync'
 import { isGraphVisible } from './viewportRecovery'
 
 registerCyExtensions()
@@ -292,6 +295,15 @@ const CyjsRenderer = ({
   const table = tables[id]
   const summary = summaries[id]
 
+  // App-supplied per-node images. Applied as Cytoscape.js element style
+  // bypasses, never as element data — see nodeGraphicsApply.ts for why, and for
+  // why they cannot reach CX2.
+  const nodeGraphics = useNodeGraphicsSync(id)
+  const nodeGraphicsRef = useRef<
+    Record<IdType, ResolvedNodeGraphics> | undefined
+  >(nodeGraphics)
+  nodeGraphicsRef.current = nodeGraphics
+
   /**
    * Renders the Cytoscape.js network visualization based on the current network data, view, and visual style.
    *
@@ -348,6 +360,10 @@ const CyjsRenderer = ({
     cy.removeAllListeners()
     cy.startBatch()
     cy.remove('*')
+
+    // The elements holding the node-graphics bypasses are gone, so the overlay
+    // must be re-applied in full below rather than diffed against a stale copy.
+    resetNodeGraphics(cy)
 
     // Prepare the data sources for visual style application
     const data: NetworkViewSources = {
@@ -844,6 +860,10 @@ const CyjsRenderer = ({
     // Apply the computed style to Cytoscape.js
     cy.style(newStyle)
 
+    // Must follow cy.style(): node.width()/height() feed the SVG size wrapper
+    // and only report correct values once the new stylesheet is installed.
+    applyNodeGraphics(cy, nodeGraphicsRef.current)
+
     // Restore saved viewport if available, otherwise fit the network if forceFit is true
     const savedViewport = getViewport('cyjs', id)
     if (savedViewport) {
@@ -950,11 +970,34 @@ const CyjsRenderer = ({
         cy.style(cyStyle)
       }
 
+      // Reapplying the stylesheet does not clear element bypasses, but it does
+      // reset node sizes, so re-run the apply to resize any SVG images.
+      applyNodeGraphics(cy, nodeGraphicsRef.current)
+
       // Store the key-value pair in the local IndexedDB
       setViewModel(id, updatedNetworkView)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- style/table triggers only; networkView is written here (loop)
     [vs, table, visualEditorProperties],
+  )
+
+  /**
+   * Effect: Paints app-supplied node images as they arrive.
+   *
+   * `useNodeGraphicsSync` runs render hooks in chunks across animation frames,
+   * so most images land after the render that triggered them. The two apply
+   * calls inside renderNetwork and onStyleModelUpdate only catch images that
+   * already existed; this effect catches the rest.
+   *
+   * Cheap to run: applyNodeGraphics diffs against the last applied overlay and
+   * returns immediately when nothing changed.
+   */
+  useEffect(
+    function onNodeGraphicsChange() {
+      if (cy === null) return
+      applyNodeGraphics(cy, nodeGraphics)
+    },
+    [nodeGraphics, cy],
   )
 
   /**

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.test.ts
@@ -192,6 +192,41 @@ describe('applyNodeGraphics', () => {
     resetNodeGraphics(cy)
   })
 
+  it('keeps applying later nodes after one node throws', () => {
+    // The guard is per node, so one malformed value costs one image — not every
+    // image queued behind it in the same pass.
+    const { cy, nodes } = stubCy()
+    nodes.get('n1')!.style.mockImplementation(() => {
+      throw new Error('bad value')
+    })
+
+    applyNodeGraphics(cy, {
+      n1: graphics('https://example.com/a.png'),
+      n2: graphics('https://example.com/b.png'),
+      n3: graphics('https://example.com/c.png'),
+    })
+
+    expect(nodes.get('n2')!.style).toHaveBeenCalledTimes(1)
+    expect(nodes.get('n3')!.style).toHaveBeenCalledTimes(1)
+    resetNodeGraphics(cy)
+  })
+
+  it('keeps clearing later nodes after one removeStyle throws', () => {
+    const { cy, nodes } = stubCy()
+    applyNodeGraphics(cy, {
+      n1: graphics('https://example.com/a.png'),
+      n2: graphics('https://example.com/b.png'),
+    })
+    nodes.get('n1')!.removeStyle.mockImplementation(() => {
+      throw new Error('cannot remove')
+    })
+
+    applyNodeGraphics(cy, {})
+
+    expect(nodes.get('n2')!.removeStyle).toHaveBeenCalledTimes(1)
+    resetNodeGraphics(cy)
+  })
+
   describe('SVG sizing', () => {
     it('wraps an SVG data URI to the node box', () => {
       const { cy, nodes } = stubCy()

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.test.ts
@@ -255,6 +255,56 @@ describe('applyNodeGraphics', () => {
       resetNodeGraphics(cy)
     })
 
+    it('rewraps the same graphics when the node box changes', () => {
+      // A stylesheet change resizes nodes without changing hook output. The SVG
+      // is wrapped to the node box, so the same graphics must be rewritten.
+      const svg = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
+      const same = graphics(svg)
+      let size = 40
+      const node = {
+        style: vi.fn(),
+        removeStyle: vi.fn(),
+        empty: () => false,
+        width: () => size,
+        height: () => size,
+      }
+      const cy = {
+        startBatch: vi.fn(),
+        endBatch: vi.fn(),
+        getElementById: () => node,
+      } as unknown as Core
+
+      applyNodeGraphics(cy, { n1: same })
+      size = 80
+      applyNodeGraphics(cy, { n1: same })
+
+      expect(node.style).toHaveBeenCalledTimes(2)
+      const second = node.style.mock.calls[1][0]['background-image'] as string
+      expect(
+        decodeURIComponent(second.substring('data:image/svg+xml,'.length)),
+      ).toContain('viewBox="0 0 80 80"')
+      resetNodeGraphics(cy)
+    })
+
+    it('applies the requested fit to the wrapped SVG', () => {
+      // Cytoscape's background-fit cannot act on an image already sized to the
+      // node, so cover has to be baked into the wrapper.
+      const { cy, nodes } = stubCy()
+      const svg =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg viewBox="0 0 200 50"/>')
+
+      applyNodeGraphics(cy, { n1: graphics(svg, { fit: 'cover' }) })
+
+      const applied = nodes.get('n1')!.style.mock.calls[0][0][
+        'background-image'
+      ] as string
+      expect(
+        decodeURIComponent(applied.substring('data:image/svg+xml,'.length)),
+      ).toContain('preserveAspectRatio="xMidYMid slice"')
+      resetNodeGraphics(cy)
+    })
+
     it('does not wrap when the node reports a zero size', () => {
       // Happens if this is called before cy.style() installs the stylesheet.
       const svg = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
@@ -276,6 +326,29 @@ describe('applyNodeGraphics', () => {
       applyNodeGraphics(cy, { n1: graphics(svg) })
 
       expect(node.style.mock.calls[0][0]['background-image']).toBe(svg)
+      resetNodeGraphics(cy)
+    })
+  })
+
+  describe('image cache cap', () => {
+    it('refuses a new URL past the cap and still admits a cached one', () => {
+      // Counted here, on the URL Cytoscape actually caches: SVG wrapping turns
+      // one hook image into a distinct URL per node size, so counting hook
+      // images instead would let the cache grow without bound.
+      const { cy, nodes } = stubCy(['n1'])
+      const node = nodes.get('n1')!
+
+      for (let i = 0; i < 2000; i++) {
+        applyNodeGraphics(cy, { n1: graphics(`https://example.com/${i}.png`) })
+      }
+      expect(node.style).toHaveBeenCalledTimes(2000)
+
+      applyNodeGraphics(cy, { n1: graphics('https://example.com/new.png') })
+      expect(node.style).toHaveBeenCalledTimes(2000)
+
+      // Already cached, so it costs no new Image and still goes through.
+      applyNodeGraphics(cy, { n1: graphics('https://example.com/0.png') })
+      expect(node.style).toHaveBeenCalledTimes(2001)
       resetNodeGraphics(cy)
     })
   })

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.test.ts
@@ -1,0 +1,287 @@
+import type { Core } from 'cytoscape'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ResolvedNodeGraphics } from '../../../models/StoreModel/NodeGraphicsStoreModel'
+import { applyNodeGraphics, resetNodeGraphics } from './nodeGraphicsApply'
+
+const graphics = (
+  image: string,
+  overrides: Partial<ResolvedNodeGraphics> = {},
+): ResolvedNodeGraphics => ({
+  image,
+  fit: 'contain',
+  opacity: 1,
+  crossOrigin: 'null',
+  containment: 'inside',
+  hookId: 'hook-1',
+  ...overrides,
+})
+
+/**
+ * Stub cy exposing one fake node per id in `nodeIds`. Ids outside that set
+ * return an empty collection, mimicking a node deleted between the hook running
+ * and this apply.
+ */
+const stubCy = (nodeIds: string[] = ['n1', 'n2', 'n3']) => {
+  const nodes = new Map<
+    string,
+    {
+      style: ReturnType<typeof vi.fn>
+      removeStyle: ReturnType<typeof vi.fn>
+      empty: () => boolean
+      width: () => number
+      height: () => number
+    }
+  >()
+  for (const id of nodeIds) {
+    nodes.set(id, {
+      style: vi.fn(),
+      removeStyle: vi.fn(),
+      empty: () => false,
+      width: () => 40,
+      height: () => 40,
+    })
+  }
+  const missing = {
+    style: vi.fn(),
+    removeStyle: vi.fn(),
+    empty: () => true,
+    width: () => 0,
+    height: () => 0,
+  }
+
+  const startBatch = vi.fn()
+  const endBatch = vi.fn()
+  const cy = {
+    startBatch,
+    endBatch,
+    getElementById: (id: string) => nodes.get(id) ?? missing,
+  } as unknown as Core
+
+  return { cy, nodes, missing, startBatch, endBatch }
+}
+
+describe('applyNodeGraphics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sets every background property on the target node', () => {
+    const { cy, nodes } = stubCy()
+
+    applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+
+    expect(nodes.get('n1')!.style).toHaveBeenCalledWith({
+      'background-image': 'https://example.com/a.png',
+      'background-fit': 'contain',
+      'background-image-opacity': 1,
+      'background-image-crossorigin': 'null',
+      'background-image-containment': 'inside',
+    })
+  })
+
+  it('never touches a node absent from both the previous and next overlay', () => {
+    // The load-bearing guarantee: Vizmapper-styled nodes must be left alone.
+    const { cy, nodes } = stubCy()
+
+    applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+
+    expect(nodes.get('n2')!.style).not.toHaveBeenCalled()
+    expect(nodes.get('n2')!.removeStyle).not.toHaveBeenCalled()
+    expect(nodes.get('n3')!.style).not.toHaveBeenCalled()
+    expect(nodes.get('n3')!.removeStyle).not.toHaveBeenCalled()
+  })
+
+  it('does nothing at all when both overlays are empty', () => {
+    const { cy, startBatch } = stubCy()
+
+    applyNodeGraphics(cy, {})
+
+    expect(startBatch).not.toHaveBeenCalled()
+  })
+
+  it('skips a node whose image is reference-identical to the last apply', () => {
+    const { cy, nodes } = stubCy()
+    const same = graphics('https://example.com/a.png')
+
+    applyNodeGraphics(cy, { n1: same })
+    expect(nodes.get('n1')!.style).toHaveBeenCalledTimes(1)
+
+    applyNodeGraphics(cy, { n1: same })
+    expect(nodes.get('n1')!.style).toHaveBeenCalledTimes(1)
+
+    resetNodeGraphics(cy)
+  })
+
+  it('reapplies when the image object changes', () => {
+    const { cy, nodes } = stubCy()
+
+    applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+    applyNodeGraphics(cy, { n1: graphics('https://example.com/b.png') })
+
+    expect(nodes.get('n1')!.style).toHaveBeenCalledTimes(2)
+    resetNodeGraphics(cy)
+  })
+
+  it('removes the bypass for a node dropped from the overlay', () => {
+    const { cy, nodes } = stubCy()
+
+    applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+    applyNodeGraphics(cy, {})
+
+    expect(nodes.get('n1')!.removeStyle).toHaveBeenCalledTimes(1)
+    // Every property this module sets must be named, or clearing leaves a
+    // partial bypass behind.
+    const propList = nodes.get('n1')!.removeStyle.mock.calls[0][0] as string
+    for (const prop of [
+      'background-image',
+      'background-fit',
+      'background-image-opacity',
+      'background-image-crossorigin',
+      'background-image-containment',
+    ]) {
+      expect(propList).toContain(prop)
+    }
+    resetNodeGraphics(cy)
+  })
+
+  it('does not call removeStyle for a node that never had an image', () => {
+    const { cy, nodes } = stubCy()
+
+    applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+    applyNodeGraphics(cy, { n2: graphics('https://example.com/b.png') })
+
+    expect(nodes.get('n1')!.removeStyle).toHaveBeenCalledTimes(1)
+    expect(nodes.get('n3')!.removeStyle).not.toHaveBeenCalled()
+    resetNodeGraphics(cy)
+  })
+
+  it('skips an id with no matching element', () => {
+    const { cy, missing } = stubCy(['n1'])
+
+    expect(() =>
+      applyNodeGraphics(cy, { gone: graphics('https://example.com/a.png') }),
+    ).not.toThrow()
+    expect(missing.style).not.toHaveBeenCalled()
+    resetNodeGraphics(cy)
+  })
+
+  it('batches the whole pass', () => {
+    const { cy, startBatch, endBatch } = stubCy()
+
+    applyNodeGraphics(cy, {
+      n1: graphics('https://example.com/a.png'),
+      n2: graphics('https://example.com/b.png'),
+    })
+
+    expect(startBatch).toHaveBeenCalledTimes(1)
+    expect(endBatch).toHaveBeenCalledTimes(1)
+    resetNodeGraphics(cy)
+  })
+
+  it('ends the batch even when a style write throws', () => {
+    const { cy, nodes, endBatch } = stubCy()
+    nodes.get('n1')!.style.mockImplementation(() => {
+      throw new Error('bad value')
+    })
+
+    expect(() =>
+      applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') }),
+    ).not.toThrow()
+    expect(endBatch).toHaveBeenCalledTimes(1)
+    resetNodeGraphics(cy)
+  })
+
+  describe('SVG sizing', () => {
+    it('wraps an SVG data URI to the node box', () => {
+      const { cy, nodes } = stubCy()
+      const svg = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
+
+      applyNodeGraphics(cy, { n1: graphics(svg) })
+
+      const applied = nodes.get('n1')!.style.mock.calls[0][0][
+        'background-image'
+      ] as string
+      const decoded = decodeURIComponent(
+        applied.substring('data:image/svg+xml,'.length),
+      )
+      expect(decoded).toContain('viewBox="0 0 40 40"')
+      resetNodeGraphics(cy)
+    })
+
+    it('leaves a raster URL unwrapped', () => {
+      const { cy, nodes } = stubCy()
+
+      applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+
+      expect(nodes.get('n1')!.style.mock.calls[0][0]['background-image']).toBe(
+        'https://example.com/a.png',
+      )
+      resetNodeGraphics(cy)
+    })
+
+    it('does not wrap when the node reports a zero size', () => {
+      // Happens if this is called before cy.style() installs the stylesheet.
+      const svg = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
+      const nodes = new Map()
+      const node = {
+        style: vi.fn(),
+        removeStyle: vi.fn(),
+        empty: () => false,
+        width: () => 0,
+        height: () => 0,
+      }
+      nodes.set('n1', node)
+      const cy = {
+        startBatch: vi.fn(),
+        endBatch: vi.fn(),
+        getElementById: (id: string) => nodes.get(id),
+      } as unknown as Core
+
+      applyNodeGraphics(cy, { n1: graphics(svg) })
+
+      expect(node.style.mock.calls[0][0]['background-image']).toBe(svg)
+      resetNodeGraphics(cy)
+    })
+  })
+
+  describe('resetNodeGraphics', () => {
+    it('forces the next apply to repaint rather than diff', () => {
+      const { cy, nodes } = stubCy()
+      const same = graphics('https://example.com/a.png')
+
+      applyNodeGraphics(cy, { n1: same })
+      resetNodeGraphics(cy)
+      applyNodeGraphics(cy, { n1: same })
+
+      // Without the reset, the second call would be skipped as unchanged — and
+      // after cy.remove('*') that would leave the node with no image.
+      expect(nodes.get('n1')!.style).toHaveBeenCalledTimes(2)
+      resetNodeGraphics(cy)
+    })
+
+    it('does not remove bypasses from nodes it forgets about', () => {
+      const { cy, nodes } = stubCy()
+
+      applyNodeGraphics(cy, { n1: graphics('https://example.com/a.png') })
+      resetNodeGraphics(cy)
+      applyNodeGraphics(cy, {})
+
+      expect(nodes.get('n1')!.removeStyle).not.toHaveBeenCalled()
+    })
+
+    it('keeps instances independent', () => {
+      const first = stubCy()
+      const second = stubCy()
+      const same = graphics('https://example.com/a.png')
+
+      applyNodeGraphics(first.cy, { n1: same })
+      applyNodeGraphics(second.cy, { n1: same })
+
+      expect(first.nodes.get('n1')!.style).toHaveBeenCalledTimes(1)
+      expect(second.nodes.get('n1')!.style).toHaveBeenCalledTimes(1)
+      resetNodeGraphics(first.cy)
+      resetNodeGraphics(second.cy)
+    })
+  })
+})

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
@@ -1,0 +1,148 @@
+// src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
+//
+// Writes app-supplied node images into Cytoscape.js as ELEMENT-LEVEL STYLE
+// BYPASSES (`node.style()`), not as element data.
+//
+// This is the only place in the repo that calls `ele.style()`, and that is
+// deliberate. The rest of the renderer drives every visual property through
+// `ele.data()` plus one shared stylesheet, but neither works here:
+//
+//   1. The `background-image` stylesheet mapper only exists when the visual
+//      style has a usable custom-graphics slot (`getFirstValidCustomGraphicVp`
+//      gate, cyjsRenderUtil.ts:291). A hook must work regardless of the user's
+//      Vizmapper setup, so it cannot depend on that mapper existing.
+//   2. `updateCyElements` removes stale custom-graphics keys on every pass
+//      (cyjsRenderUtil.ts:528-533), and `SpecialPropertyName.BackgroundImage` is
+//      in that list. A hook-written `data('backgroundImage', …)` would be wiped
+//      by the next `applyViewModel`.
+//
+// A bypass avoids both by not participating in either mechanism, and it survives
+// a stylesheet swap. Verified in node_modules/cytoscape/dist/cytoscape.cjs.js:
+//   - `corefn.style(newSheet)` → `setStyle` → `_Style.fromJson` installs a new
+//     Style object and never calls `cleanElements` (:19259-19278).
+//   - `cleanElements(eles, true)` is reached only from `styfn.clear` (:19140),
+//     which this app never calls, and it preserves bypass props anyway
+//     (:16547-16570).
+//   - Reapplying a stylesheet value over an existing bypass keeps the bypass and
+//     stores the stylesheet value underneath as `bypassed` (:16535-16538) — this
+//     is also why the hook wins over a Vizmapper image for free.
+//
+// It is also what keeps hook images out of CX2: the exporter reads `CyNetwork`
+// fields, and this never touches `VisualStyle`, `NetworkView`, or `ele.data()`.
+
+import { Core } from 'cytoscape'
+
+import { logUi } from '../../../debug'
+import type { IdType } from '../../../models/IdType'
+import type { ResolvedNodeGraphics } from '../../../models/StoreModel/NodeGraphicsStoreModel'
+import { wrapSvgDataUriForSize } from '../../../models/VisualStyleModel/impl/imageSourceImpl'
+
+/**
+ * Space-separated property list for `removeStyle`. Must cover every property
+ * `applyNodeGraphics` sets, or clearing a hook would leave a partial bypass.
+ */
+const HOOK_STYLE_PROPS = [
+  'background-image',
+  'background-fit',
+  'background-image-opacity',
+  'background-image-crossorigin',
+  'background-image-containment',
+].join(' ')
+
+/**
+ * Overlay last applied to each cy instance, so the next apply can be a diff.
+ *
+ * A WeakMap rather than store state: this is a fact about a specific
+ * Cytoscape.js instance, it must not survive that instance, and it must not be
+ * observable by anything that serializes.
+ */
+const applied = new WeakMap<Core, Record<IdType, ResolvedNodeGraphics>>()
+
+/**
+ * Forget what was applied to `cy`.
+ *
+ * Call after a full teardown (`cy.remove('*')`), where the elements holding the
+ * bypasses are gone. Without this the next apply would diff against a stale
+ * overlay and skip nodes it must repaint.
+ */
+export const resetNodeGraphics = (cy: Core): void => {
+  applied.delete(cy)
+}
+
+/** SVG data URIs get wrapped to the node's box; other URLs pass through. */
+const resolveImageForNode = (
+  image: string,
+  width: number,
+  height: number,
+): string => {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return image
+  if (width <= 0 || height <= 0) return image
+  return wrapSvgDataUriForSize(image, width, height)
+}
+
+/**
+ * Apply `next` as the complete set of hook images for `cy`.
+ *
+ * Diff-based and idempotent: only nodes whose image was added, changed, or
+ * removed are touched, so calling this on every restyle costs nothing when
+ * nothing changed. Nodes absent from both the previous and next overlay are
+ * never touched at all — this must not disturb Vizmapper-styled nodes.
+ *
+ * MUST be called after `cy.style(...)`, never before: `node.width()` and
+ * `node.height()` feed the SVG size wrapper and only report correct values once
+ * the new stylesheet is installed.
+ *
+ * @param cy - The Cytoscape.js instance
+ * @param next - nodeId → image. Omit or pass `{}` to clear every hook image.
+ */
+export const applyNodeGraphics = (
+  cy: Core,
+  next: Record<IdType, ResolvedNodeGraphics> = {},
+): void => {
+  const prev = applied.get(cy) ?? {}
+
+  const touched = new Set<IdType>([...Object.keys(prev), ...Object.keys(next)])
+  if (touched.size === 0) return
+
+  cy.startBatch()
+  try {
+    for (const nodeId of touched) {
+      const graphics = next[nodeId]
+
+      // A node can disappear between the hook running and this apply.
+      const node = cy.getElementById(nodeId)
+      if (node.empty()) continue
+
+      if (graphics === undefined) {
+        // Dropping the bypass lets the Vizmapper mapper (if any) reassert
+        // itself, leaving no residue in the user's saved style.
+        node.removeStyle(HOOK_STYLE_PROPS)
+        continue
+      }
+
+      // ResolvedNodeGraphics instances are immutable, so reference equality is
+      // a sound "nothing to do" test.
+      if (prev[nodeId] === graphics) continue
+
+      node.style({
+        'background-image': resolveImageForNode(
+          graphics.image,
+          node.width(),
+          node.height(),
+        ),
+        'background-fit': graphics.fit,
+        'background-image-opacity': graphics.opacity,
+        'background-image-crossorigin': graphics.crossOrigin,
+        'background-image-containment': graphics.containment,
+      })
+    }
+  } catch (e) {
+    // A malformed value must not break the frame. The overlay is still recorded
+    // below so the next apply does not retry the same failing write forever.
+    logUi.warn('[nodeGraphics]: failed to apply node graphics', e)
+  } finally {
+    cy.endBatch()
+  }
+
+  applied.set(cy, next)
+}

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
@@ -107,40 +107,48 @@ export const applyNodeGraphics = (
   cy.startBatch()
   try {
     for (const nodeId of touched) {
-      const graphics = next[nodeId]
+      // Scoped per node, not around the loop: one node's malformed value must
+      // not cost every later node in `touched` its image. The overlay is
+      // recorded below either way, so a failing write is not retried forever.
+      try {
+        const graphics = next[nodeId]
 
-      // A node can disappear between the hook running and this apply.
-      const node = cy.getElementById(nodeId)
-      if (node.empty()) continue
+        // A node can disappear between the hook running and this apply.
+        const node = cy.getElementById(nodeId)
+        if (node.empty()) continue
 
-      if (graphics === undefined) {
-        // Dropping the bypass lets the Vizmapper mapper (if any) reassert
-        // itself, leaving no residue in the user's saved style.
-        node.removeStyle(HOOK_STYLE_PROPS)
-        continue
+        if (graphics === undefined) {
+          // Dropping the bypass lets the Vizmapper mapper (if any) reassert
+          // itself, leaving no residue in the user's saved style.
+          node.removeStyle(HOOK_STYLE_PROPS)
+          continue
+        }
+
+        // ResolvedNodeGraphics instances are immutable, so reference equality is
+        // a sound "nothing to do" test.
+        if (prev[nodeId] === graphics) continue
+
+        node.style({
+          'background-image': resolveImageForNode(
+            graphics.image,
+            node.width(),
+            node.height(),
+          ),
+          'background-fit': graphics.fit,
+          'background-image-opacity': graphics.opacity,
+          'background-image-crossorigin': graphics.crossOrigin,
+          'background-image-containment': graphics.containment,
+        })
+      } catch (e) {
+        logUi.warn(
+          `[nodeGraphics]: failed to apply node graphics to ${nodeId}`,
+          e,
+        )
       }
-
-      // ResolvedNodeGraphics instances are immutable, so reference equality is
-      // a sound "nothing to do" test.
-      if (prev[nodeId] === graphics) continue
-
-      node.style({
-        'background-image': resolveImageForNode(
-          graphics.image,
-          node.width(),
-          node.height(),
-        ),
-        'background-fit': graphics.fit,
-        'background-image-opacity': graphics.opacity,
-        'background-image-crossorigin': graphics.crossOrigin,
-        'background-image-containment': graphics.containment,
-      })
     }
-  } catch (e) {
-    // A malformed value must not break the frame. The overlay is still recorded
-    // below so the next apply does not retry the same failing write forever.
-    logUi.warn('[nodeGraphics]: failed to apply node graphics', e)
   } finally {
+    // Must run even if something escapes the per-node guard, or the renderer
+    // stays batched and stops repainting.
     cy.endBatch()
   }
 

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsApply.ts
@@ -50,13 +50,41 @@ const HOOK_STYLE_PROPS = [
 ].join(' ')
 
 /**
+ * Distinct background-image URLs one cy instance accepts before new ones are
+ * refused.
+ *
+ * Cytoscape's `getCachedImage` retains one Image per distinct URL with no
+ * eviction, freed only by `cy.destroy()`. An app generating a fresh data URI per
+ * update would grow that cache without bound. Counted here rather than in
+ * useNodeGraphicsSync because SVG wrapping below makes one hook image into a
+ * different URL per node size — the URL is the cache key, so it is what counts.
+ */
+const MAX_DISTINCT_IMAGES = 2000
+
+/** What was last written to one node, and the node box it was written for. */
+interface AppliedEntry {
+  readonly graphics: ResolvedNodeGraphics
+  readonly width: number
+  readonly height: number
+}
+
+/**
  * Overlay last applied to each cy instance, so the next apply can be a diff.
  *
  * A WeakMap rather than store state: this is a fact about a specific
  * Cytoscape.js instance, it must not survive that instance, and it must not be
  * observable by anything that serializes.
  */
-const applied = new WeakMap<Core, Record<IdType, ResolvedNodeGraphics>>()
+const applied = new WeakMap<Core, Record<IdType, AppliedEntry>>()
+
+/**
+ * Distinct URLs handed to each cy instance, mirroring its image cache.
+ *
+ * Not cleared by `resetNodeGraphics`: removing elements does not empty the
+ * renderer's image cache, so what was cached is still cached.
+ */
+const cachedUrls = new WeakMap<Core, Set<string>>()
+const capReported = new WeakSet<Core>()
 
 /**
  * Forget what was applied to `cy`.
@@ -69,15 +97,42 @@ export const resetNodeGraphics = (cy: Core): void => {
   applied.delete(cy)
 }
 
+/**
+ * True when `url` may be handed to Cytoscape, counting it if it is new.
+ *
+ * A URL already in the cache always passes: it costs no new Image.
+ */
+const admitUrl = (cy: Core, url: string): boolean => {
+  let urls = cachedUrls.get(cy)
+  if (urls === undefined) {
+    urls = new Set<string>()
+    cachedUrls.set(cy, urls)
+  }
+  if (urls.has(url)) return true
+  if (urls.size >= MAX_DISTINCT_IMAGES) {
+    if (!capReported.has(cy)) {
+      capReported.add(cy)
+      logUi.warn(
+        `[nodeGraphics]: reached ${MAX_DISTINCT_IMAGES} distinct images on this renderer; ` +
+          'refusing new ones. Prefer stable URLs over freshly generated data URIs.',
+      )
+    }
+    return false
+  }
+  urls.add(url)
+  return true
+}
+
 /** SVG data URIs get wrapped to the node's box; other URLs pass through. */
 const resolveImageForNode = (
-  image: string,
+  graphics: ResolvedNodeGraphics,
   width: number,
   height: number,
 ): string => {
+  const image = graphics.image
   if (!Number.isFinite(width) || !Number.isFinite(height)) return image
   if (width <= 0 || height <= 0) return image
-  return wrapSvgDataUriForSize(image, width, height)
+  return wrapSvgDataUriForSize(image, width, height, graphics.fit)
 }
 
 /**
@@ -104,12 +159,14 @@ export const applyNodeGraphics = (
   const touched = new Set<IdType>([...Object.keys(prev), ...Object.keys(next)])
   if (touched.size === 0) return
 
+  const nextApplied: Record<IdType, AppliedEntry> = {}
+
   cy.startBatch()
   try {
     for (const nodeId of touched) {
       // Scoped per node, not around the loop: one node's malformed value must
-      // not cost every later node in `touched` its image. The overlay is
-      // recorded below either way, so a failing write is not retried forever.
+      // not cost every later node in `touched` its image. The entry is recorded
+      // before the write, so a failing write is not retried forever.
       try {
         const graphics = next[nodeId]
 
@@ -124,16 +181,32 @@ export const applyNodeGraphics = (
           continue
         }
 
+        const width = node.width()
+        const height = node.height()
+
         // ResolvedNodeGraphics instances are immutable, so reference equality is
-        // a sound "nothing to do" test.
-        if (prev[nodeId] === graphics) continue
+        // a sound "nothing to do" test — but only for the same node box. An SVG
+        // is wrapped to that box, so a node resized by a stylesheet change needs
+        // the same graphics rewritten at the new size.
+        const before = prev[nodeId]
+        if (
+          before !== undefined &&
+          before.graphics === graphics &&
+          before.width === width &&
+          before.height === height
+        ) {
+          nextApplied[nodeId] = before
+          continue
+        }
+
+        const url = resolveImageForNode(graphics, width, height)
+        // Recorded before the write, so neither a refused URL nor a throwing
+        // write is retried on every restyle for the rest of the session.
+        nextApplied[nodeId] = { graphics, width, height }
+        if (!admitUrl(cy, url)) continue
 
         node.style({
-          'background-image': resolveImageForNode(
-            graphics.image,
-            node.width(),
-            node.height(),
-          ),
+          'background-image': url,
           'background-fit': graphics.fit,
           'background-image-opacity': graphics.opacity,
           'background-image-crossorigin': graphics.crossOrigin,
@@ -152,5 +225,5 @@ export const applyNodeGraphics = (
     cy.endBatch()
   }
 
-  applied.set(cy, next)
+  applied.set(cy, nextApplied)
 }

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveNodeGraphics } from './nodeGraphicsResolve'
+
+const HOOK_ID = 'hook-1'
+const URL = 'https://example.com/a.png'
+
+describe('resolveNodeGraphics', () => {
+  describe('declining', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['an empty string', ''],
+    ])('returns null for %s', (_label, value) => {
+      expect(resolveNodeGraphics(value as any, HOOK_ID)).toBeNull()
+    })
+
+    it.each([
+      ['blob:', 'blob:http://localhost/x'],
+      ['file:', 'file:///tmp/x.png'],
+      ['an unrecognized scheme', 'ftp://example.com/x.png'],
+      ['a bare filename', 'x.png'],
+    ])('returns null for %s', (_label, value) => {
+      expect(resolveNodeGraphics(value, HOOK_ID)).toBeNull()
+    })
+
+    it.each([
+      ['a number', 42],
+      ['a boolean', true],
+    ])('returns null for %s rather than throwing', (_label, value) => {
+      expect(resolveNodeGraphics(value as any, HOOK_ID)).toBeNull()
+    })
+
+    it('returns null for a JSON chart object, which is not an image', () => {
+      expect(
+        resolveNodeGraphics('{"cy_dataColumns":["a"]}', HOOK_ID),
+      ).toBeNull()
+    })
+
+    it('returns null when the object carries no usable image', () => {
+      expect(resolveNodeGraphics({ image: 'blob:x' }, HOOK_ID)).toBeNull()
+    })
+  })
+
+  describe('string shorthand', () => {
+    it('accepts a bare URL and applies every default', () => {
+      expect(resolveNodeGraphics(URL, HOOK_ID)).toEqual({
+        image: URL,
+        fit: 'contain',
+        opacity: 1,
+        crossOrigin: 'null',
+        containment: 'inside',
+        hookId: HOOK_ID,
+      })
+    })
+
+    it('promotes raw <svg> markup to a data URI', () => {
+      const svg =
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+
+      const resolved = resolveNodeGraphics(svg, HOOK_ID)
+
+      expect(resolved?.image).toBe(
+        'data:image/svg+xml,' + encodeURIComponent(svg),
+      )
+    })
+  })
+
+  describe('full form', () => {
+    it('passes through valid values', () => {
+      const resolved = resolveNodeGraphics(
+        {
+          image: URL,
+          fit: 'cover',
+          opacity: 0.5,
+          crossOrigin: 'anonymous',
+          containment: 'over',
+        },
+        HOOK_ID,
+      )
+
+      expect(resolved).toEqual({
+        image: URL,
+        fit: 'cover',
+        opacity: 0.5,
+        crossOrigin: 'anonymous',
+        containment: 'over',
+        hookId: HOOK_ID,
+      })
+    })
+
+    it('stamps the hookId so removing a hook can drop only its images', () => {
+      expect(resolveNodeGraphics(URL, 'other-hook')?.hookId).toBe('other-hook')
+    })
+  })
+
+  describe('rejecting invalid enum values', () => {
+    // Passing these through would make Cytoscape.js warn on every restyle.
+    it('falls back to the default fit', () => {
+      expect(
+        resolveNodeGraphics({ image: URL, fit: 'squish' as any }, HOOK_ID)?.fit,
+      ).toBe('contain')
+    })
+
+    it('falls back to the default crossOrigin', () => {
+      expect(
+        resolveNodeGraphics(
+          { image: URL, crossOrigin: 'yes-please' as any },
+          HOOK_ID,
+        )?.crossOrigin,
+      ).toBe('null')
+    })
+
+    it('falls back to the default containment', () => {
+      expect(
+        resolveNodeGraphics(
+          { image: URL, containment: 'behind' as any },
+          HOOK_ID,
+        )?.containment,
+      ).toBe('inside')
+    })
+  })
+
+  describe('opacity', () => {
+    it.each([
+      ['above 1', 5, 1],
+      ['below 0', -3, 0],
+      ['exactly 0', 0, 0],
+      ['exactly 1', 1, 1],
+      ['a fraction', 0.25, 0.25],
+    ])('clamps %s to %s', (_label, input, expected) => {
+      expect(
+        resolveNodeGraphics({ image: URL, opacity: input }, HOOK_ID)?.opacity,
+      ).toBe(expected)
+    })
+
+    it.each([
+      ['NaN', NaN],
+      ['Infinity', Infinity],
+      ['a string', '0.5'],
+      ['undefined', undefined],
+    ])('defaults to 1 for %s', (_label, input) => {
+      expect(
+        resolveNodeGraphics({ image: URL, opacity: input as any }, HOOK_ID)
+          ?.opacity,
+      ).toBe(1)
+    })
+  })
+})

--- a/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.ts
@@ -1,0 +1,112 @@
+// src/features/NetworkPanel/CyjsRenderer/nodeGraphicsResolve.ts
+//
+// Turns whatever an app's render hook returned into a validated, fully
+// defaulted `ResolvedNodeGraphics` — or null.
+//
+// Everything here is defensive. The input crossed the app boundary, is typed
+// only by a contract the app may ignore, and reaches this code from inside the
+// render path, where there is no ApiResult channel to report a failure on. So a
+// bad value degrades to "no image for this node" and a log line, never a throw.
+
+import { logApp } from '../../../debug'
+import {
+  describeImageSourceRejection,
+  normalizeImageSource,
+} from '../../../models/VisualStyleModel/impl/imageSourceImpl'
+import type {
+  NodeGraphicsContainment,
+  NodeGraphicsCrossOrigin,
+  NodeGraphicsFit,
+  NodeGraphicsImage,
+  NodeGraphicsResult,
+  ResolvedNodeGraphics,
+} from '../../../models/StoreModel/NodeGraphicsStoreModel'
+
+const FITS = new Set<NodeGraphicsFit>(['contain', 'cover', 'none'])
+const CROSS_ORIGINS = new Set<NodeGraphicsCrossOrigin>([
+  'anonymous',
+  'use-credentials',
+  'null',
+])
+const CONTAINMENTS = new Set<NodeGraphicsContainment>(['inside', 'over'])
+
+const DEFAULT_FIT: NodeGraphicsFit = 'contain'
+// Matches computeImageProperties: load from servers without CORS headers at the
+// cost of tainting the canvas (which excludes the image from PNG export).
+const DEFAULT_CROSS_ORIGIN: NodeGraphicsCrossOrigin = 'null'
+// 'inside' matches Vizmapper image slots, so a pie chart on the same node still
+// draws on top — consistent with how two Vizmapper slots already behave.
+const DEFAULT_CONTAINMENT: NodeGraphicsContainment = 'inside'
+
+const clampOpacity = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 1
+  return Math.min(Math.max(value, 0), 1)
+}
+
+/**
+ * Normalize a hook result. Returns null when the hook declined (`null`) or
+ * returned something unusable.
+ *
+ * @param result - Whatever the hook returned, untrusted
+ * @param hookId - Attribution, so removing a hook can drop only its images
+ */
+export const resolveNodeGraphics = (
+  result: NodeGraphicsResult,
+  hookId: string,
+): ResolvedNodeGraphics | null => {
+  if (result === null || result === undefined) return null
+
+  let raw: NodeGraphicsImage
+  if (typeof result === 'string') {
+    raw = { image: result }
+  } else if (typeof result === 'object') {
+    raw = result
+  } else {
+    logApp.warn(
+      `[nodeGraphics]: hook returned ${typeof result}; expected a string, an object, or null`,
+    )
+    return null
+  }
+
+  const source = normalizeImageSource(raw.image)
+  if (source.kind !== 'url') {
+    // 'empty' is how an app says "nothing here" via a blank string — as routine
+    // as returning null, so it stays quiet. The rest are mistakes worth naming.
+    if (source.kind === 'rejected' && source.reason !== 'empty') {
+      logApp.warn(
+        `[nodeGraphics]: ${describeImageSourceRejection(source.reason)}:`,
+        source.raw.substring(0, 80),
+      )
+    } else if (source.kind === 'json') {
+      logApp.warn(
+        '[nodeGraphics]: hook returned a JSON object string; only images are supported',
+      )
+    }
+    return null
+  }
+
+  // Unknown enum values would make Cytoscape.js warn on every restyle, so fall
+  // back to the default rather than passing them through.
+  const fit = FITS.has(raw.fit as NodeGraphicsFit)
+    ? (raw.fit as NodeGraphicsFit)
+    : DEFAULT_FIT
+  const crossOrigin = CROSS_ORIGINS.has(
+    raw.crossOrigin as NodeGraphicsCrossOrigin,
+  )
+    ? (raw.crossOrigin as NodeGraphicsCrossOrigin)
+    : DEFAULT_CROSS_ORIGIN
+  const containment = CONTAINMENTS.has(
+    raw.containment as NodeGraphicsContainment,
+  )
+    ? (raw.containment as NodeGraphicsContainment)
+    : DEFAULT_CONTAINMENT
+
+  return {
+    image: source.url,
+    fit,
+    opacity: clampOpacity(raw.opacity),
+    crossOrigin,
+    containment,
+    hookId,
+  }
+}

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
@@ -331,6 +331,30 @@ describe('useNodeGraphicsSync', () => {
       // cache is not re-entered for nothing.
       expect(imagesFor('net1').n1).toBe(first)
     })
+
+    it('records a re-run that changes only a non-image field', async () => {
+      // The skip must compare every resolved field. Keying it on the image
+      // string alone swallowed a hook that dimmed a node without changing the
+      // URL, so the renderer never saw the new opacity.
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      let opacity = 1
+      registerHook(() => ({ image: 'https://example.com/a.png', opacity }))
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect((imagesFor('net1').n1 as any).opacity).toBe(1)
+
+      opacity = 0.25
+      act(() => {
+        useNodeGraphicsStore.getState().requestRefresh('net1')
+      })
+      await drain()
+
+      expect((imagesFor('net1').n1 as any).opacity).toBe(0.25)
+      expect((imagesFor('net1').n1 as any).image).toBe(
+        'https://example.com/a.png',
+      )
+    })
   })
 
   describe('hook lifecycle', () => {
@@ -459,6 +483,9 @@ describe('useNodeGraphicsSync', () => {
       renderHook(() => useNodeGraphicsSync('net1'))
       await drain()
 
+      // Bounded above by the budget, and above zero — a hook that was never
+      // called at all would otherwise satisfy this assertion.
+      expect(render.mock.calls.length).toBeGreaterThan(0)
       expect(render.mock.calls.length).toBeLessThanOrEqual(20)
       render.mockClear()
 

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
@@ -104,6 +104,7 @@ describe('useNodeGraphicsSync', () => {
       hooks: [],
       images: {},
       refreshRequests: {},
+      refreshSequence: {},
     })
   })
 
@@ -152,6 +153,22 @@ describe('useNodeGraphicsSync', () => {
     await drain()
 
     expect(row.score).toBe(1)
+  })
+
+  it('copies list attributes, so a hook cannot reach the host array', async () => {
+    // A spread shares every array value with the host table. Immer freezes
+    // those, so a hook writing to one either corrupts host data or throws.
+    const row = { tags: ['a', 'b'] }
+    await setNodeTable('net1', tableOf([['n1', row]]))
+    registerHook((req: any) => {
+      req.attributes.tags.push('c')
+      return 'https://example.com/a.png'
+    })
+
+    renderHook(() => useNodeGraphicsSync('net1'))
+    await drain()
+
+    expect(row.tags).toEqual(['a', 'b'])
   })
 
   it('skips a node when the hook returns null', async () => {
@@ -499,6 +516,111 @@ describe('useNodeGraphicsSync', () => {
       await drain()
 
       expect(render).not.toHaveBeenCalled()
+    })
+
+    it('keeps the images a hook produced before it was disabled', async () => {
+      // A tripped circuit breaker is not a decline. Clearing here would erase
+      // every image the hook drew while it was healthy.
+      const rows: Array<[string, Record<string, ValueType>]> = Array.from(
+        { length: 25 },
+        (_, i) => [`n${i}`, { score: i }],
+      )
+      await setNodeTable('net1', tableOf(rows))
+      let throwing = false
+      registerHook(() => {
+        if (throwing) throw new Error('boom')
+        return 'https://example.com/a.png'
+      })
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect(Object.keys(imagesFor('net1'))).toHaveLength(25)
+
+      throwing = true
+      await act(async () => {
+        await setNodeTable(
+          'net1',
+          tableOf(rows.map(([id, r]) => [id, { ...r, again: true }])),
+        )
+      })
+      await drain()
+
+      expect(Object.keys(imagesFor('net1'))).toHaveLength(25)
+    })
+
+    it('leaves a disabled hook disabled when another app registers one', async () => {
+      // The hook list changes whenever any app registers, so resetting the
+      // circuit breaker there would revive every hook it had disabled.
+      const rows: Array<[string, Record<string, ValueType>]> = Array.from(
+        { length: 25 },
+        (_, i) => [`n${i}`, { score: i }],
+      )
+      await setNodeTable('net1', tableOf(rows))
+      const bad = vi.fn(() => {
+        throw new Error('boom')
+      })
+      registerHook(bad, 'app-a')
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect(bad.mock.calls.length).toBeGreaterThan(0)
+      bad.mockClear()
+
+      registerHook(() => null, 'app-b')
+      await drain()
+
+      expect(bad).not.toHaveBeenCalled()
+    })
+
+    it('keeps rendering later nodes when a returned value cannot be read', async () => {
+      // Normalization reads the value's properties, so a throwing getter throws
+      // outside the hook call. Unguarded, it kills the rest of the chunk.
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', { bad: true }],
+          ['n2', { bad: false }],
+        ]),
+      )
+      registerHook((req) => {
+        if (req.attributes.bad !== true) return 'https://example.com/a.png'
+        return {
+          get image(): string {
+            throw new Error('hostile getter')
+          },
+        }
+      })
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+
+      expect(Object.keys(imagesFor('net1'))).toEqual(['n2'])
+    })
+
+    it('does not resurrect a node deleted after the flush began', async () => {
+      // `targets` is a snapshot. Rows must be read from the live table, or a
+      // chunk running after the deletion writes the image back.
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', { score: 1 }],
+          ['n2', { score: 2 }],
+        ]),
+      )
+      registerHook(() => 'https://example.com/a.png')
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      // Runs the coalescing timer only: the flush queues its first chunk for
+      // the next frame.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COALESCE_MS + 1)
+      })
+      await act(async () => {
+        await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      })
+      await drain()
+
+      expect(Object.keys(imagesFor('net1'))).toEqual(['n1'])
     })
   })
 

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
@@ -1,0 +1,559 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useNodeGraphicsStore } from '../../../data/hooks/stores/NodeGraphicsStore'
+import type { IdType } from '../../../models/IdType'
+import type { NodeGraphicsRenderHook } from '../../../models/StoreModel/NodeGraphicsStoreModel'
+import type { Table } from '../../../models/TableModel'
+import type { ValueType } from '../../../models/TableModel'
+import { useNodeGraphicsSync } from './useNodeGraphicsSync'
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+// A real (minimal) zustand store for tables, so the hook's selector subscription
+// re-renders exactly as it does in the app. ViewModelStore and hydrationContext
+// only need getState-level stubs.
+
+vi.mock('../../../data/hooks/stores/TableStore', async () => {
+  const { create } = await import('zustand')
+  return {
+    useTableStore: create<{ tables: Record<string, { nodeTable: Table }> }>(
+      () => ({ tables: {} }),
+    ),
+  }
+})
+
+const mockGetViewModel = vi.fn(() => undefined)
+vi.mock('../../../data/hooks/stores/ViewModelStore', () => ({
+  useViewModelStore: {
+    getState: () => ({ getViewModel: mockGetViewModel }),
+  },
+}))
+
+const mockIsHydrating = vi.fn(() => false)
+vi.mock('../../../data/hooks/stores/hydrationContext', () => ({
+  isHydrating: () => mockIsHydrating(),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const COALESCE_MS = 50
+
+const tableOf = (rows: Array<[IdType, Record<string, ValueType>]>): Table =>
+  ({ id: 't', columns: [], rows: new Map(rows) }) as unknown as Table
+
+/** Replace a network's node table, mimicking a TableStore write. */
+const setNodeTable = async (networkId: string, table: Table): Promise<void> => {
+  const { useTableStore } = await import(
+    '../../../data/hooks/stores/TableStore'
+  )
+  ;(useTableStore as any).setState({
+    tables: {
+      ...(useTableStore as any).getState().tables,
+      [networkId]: { nodeTable: table },
+    },
+  })
+}
+
+/** Run the coalescing timer plus enough animation frames to drain all chunks. */
+const drain = async (frames = 5): Promise<void> => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(COALESCE_MS + 1)
+  })
+  for (let i = 0; i < frames; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20)
+    })
+  }
+}
+
+const registerHook = (
+  render: NodeGraphicsRenderHook,
+  appId = 'app-a',
+): void => {
+  act(() => {
+    useNodeGraphicsStore
+      .getState()
+      .setHook({ hookId: `hook-${appId}`, appId, render })
+  })
+}
+
+const imagesFor = (networkId: string): Record<string, unknown> =>
+  useNodeGraphicsStore.getState().images[networkId] ?? {}
+
+describe('useNodeGraphicsSync', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers({
+      toFake: [
+        'setTimeout',
+        'clearTimeout',
+        'requestAnimationFrame',
+        'cancelAnimationFrame',
+        'performance',
+      ],
+    })
+    vi.clearAllMocks()
+    mockIsHydrating.mockReturnValue(false)
+    const { useTableStore } = await import(
+      '../../../data/hooks/stores/TableStore'
+    )
+    ;(useTableStore as any).setState({ tables: {} })
+    useNodeGraphicsStore.setState({
+      hooks: [],
+      images: {},
+      refreshRequests: {},
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns undefined and runs nothing when no hook is registered', async () => {
+    await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+
+    const { result } = renderHook(() => useNodeGraphicsSync('net1'))
+    await drain()
+
+    expect(result.current).toBeUndefined()
+    expect(imagesFor('net1')).toEqual({})
+  })
+
+  it('runs the hook for every node on mount', async () => {
+    await setNodeTable(
+      'net1',
+      tableOf([
+        ['n1', { score: 1 }],
+        ['n2', { score: 2 }],
+      ]),
+    )
+    const render = vi.fn(() => 'https://example.com/a.png')
+    registerHook(render)
+
+    renderHook(() => useNodeGraphicsSync('net1'))
+    await drain()
+
+    expect(render).toHaveBeenCalledTimes(2)
+    expect(Object.keys(imagesFor('net1')).sort()).toEqual(['n1', 'n2'])
+  })
+
+  it('passes a copy of the row, so a hook cannot mutate host state', async () => {
+    const row = { score: 1 }
+    await setNodeTable('net1', tableOf([['n1', row]]))
+    const render = vi.fn((req: any) => {
+      req.attributes.score = 999
+      return 'https://example.com/a.png'
+    })
+    registerHook(render)
+
+    renderHook(() => useNodeGraphicsSync('net1'))
+    await drain()
+
+    expect(row.score).toBe(1)
+  })
+
+  it('skips a node when the hook returns null', async () => {
+    await setNodeTable(
+      'net1',
+      tableOf([
+        ['n1', { keep: true }],
+        ['n2', { keep: false }],
+      ]),
+    )
+    registerHook((req) =>
+      req.attributes.keep === true ? 'https://example.com/a.png' : null,
+    )
+
+    renderHook(() => useNodeGraphicsSync('net1'))
+    await drain()
+
+    expect(Object.keys(imagesFor('net1'))).toEqual(['n1'])
+  })
+
+  describe('invalidation', () => {
+    it('re-runs only the rows a table edit touched', async () => {
+      const untouched = { score: 1 }
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', untouched],
+          ['n2', { score: 2 }],
+        ]),
+      )
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect(render).toHaveBeenCalledTimes(2)
+      render.mockClear()
+
+      // Only n2's row object changes.
+      await act(async () => {
+        await setNodeTable(
+          'net1',
+          tableOf([
+            ['n1', untouched],
+            ['n2', { score: 99 }],
+          ]),
+        )
+      })
+      await drain()
+
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render.mock.calls[0][0].nodeId).toBe('n2')
+    })
+
+    it('coalesces a burst of writes into one flush', async () => {
+      const rows: Array<[string, Record<string, ValueType>]> = Array.from(
+        { length: 5 },
+        (_, i) => [`n${i}`, { score: i }],
+      )
+      await setNodeTable('net1', tableOf(rows))
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      render.mockClear()
+
+      // Three writes inside the coalescing window, each rebuilding every row —
+      // as a column rename does.
+      await act(async () => {
+        for (let pass = 1; pass <= 3; pass++) {
+          await setNodeTable(
+            'net1',
+            tableOf(rows.map(([id, r]) => [id, { ...r, pass }])),
+          )
+        }
+      })
+      await drain()
+
+      // One flush over 5 nodes, not three.
+      expect(render).toHaveBeenCalledTimes(5)
+    })
+
+    it('drops a deleted node’s image without calling the hook', async () => {
+      const keep = { score: 1 }
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', keep],
+          ['n2', { score: 2 }],
+        ]),
+      )
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      render.mockClear()
+
+      await act(async () => {
+        await setNodeTable('net1', tableOf([['n1', keep]]))
+      })
+      await drain()
+
+      expect(imagesFor('net1').n2).toBeUndefined()
+      expect(render).not.toHaveBeenCalled()
+    })
+
+    it('re-runs everything when an app calls refresh', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      let url = 'https://example.com/a.png'
+      const render = vi.fn(() => url)
+      registerHook(render)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      render.mockClear()
+
+      url = 'https://example.com/b.png'
+      act(() => {
+        useNodeGraphicsStore.getState().requestRefresh('net1')
+      })
+      await drain()
+
+      expect(render).toHaveBeenCalledTimes(1)
+      expect((imagesFor('net1').n1 as any).image).toBe(
+        'https://example.com/b.png',
+      )
+    })
+
+    it('re-runs only the nodes named in a scoped refresh', async () => {
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', { score: 1 }],
+          ['n2', { score: 2 }],
+        ]),
+      )
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      render.mockClear()
+
+      act(() => {
+        useNodeGraphicsStore.getState().requestRefresh('net1', ['n2'])
+      })
+      await drain()
+
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render.mock.calls[0][0].nodeId).toBe('n2')
+    })
+
+    it('skips a re-run whose image is unchanged', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      registerHook(() => 'https://example.com/a.png')
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      const first = imagesFor('net1').n1
+
+      await act(async () => {
+        await setNodeTable('net1', tableOf([['n1', { score: 2 }]]))
+      })
+      await drain()
+
+      // Identical image string → no new entry, so Cytoscape's unbounded image
+      // cache is not re-entered for nothing.
+      expect(imagesFor('net1').n1).toBe(first)
+    })
+  })
+
+  describe('hook lifecycle', () => {
+    it('drops every image when the last hook is removed', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      registerHook(() => 'https://example.com/a.png')
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect(imagesFor('net1').n1).toBeDefined()
+
+      act(() => {
+        useNodeGraphicsStore.getState().removeAllByAppId('app-a')
+      })
+      await drain()
+
+      expect(imagesFor('net1')).toEqual({})
+    })
+
+    it('re-runs every node when a hook is registered after mount', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect(imagesFor('net1')).toEqual({})
+
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+      await drain()
+
+      expect(render).toHaveBeenCalledTimes(1)
+    })
+
+    it('lets a second hook serve nodes the first declines', async () => {
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', { owner: 'a' }],
+          ['n2', { owner: 'b' }],
+        ]),
+      )
+      registerHook(
+        (req) =>
+          req.attributes.owner === 'a' ? 'https://a.example/x.png' : null,
+        'app-a',
+      )
+      registerHook(
+        (req) =>
+          req.attributes.owner === 'b' ? 'https://b.example/x.png' : null,
+        'app-b',
+      )
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+
+      expect((imagesFor('net1').n1 as any).image).toBe(
+        'https://a.example/x.png',
+      )
+      expect((imagesFor('net1').n2 as any).image).toBe(
+        'https://b.example/x.png',
+      )
+    })
+
+    it('clears the network on unmount', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      registerHook(() => 'https://example.com/a.png')
+
+      const { unmount } = renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+      expect(imagesFor('net1').n1).toBeDefined()
+
+      act(() => {
+        unmount()
+      })
+
+      expect(imagesFor('net1')).toEqual({})
+    })
+  })
+
+  describe('failure containment', () => {
+    it('yields no image for a node whose hook throws', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      registerHook(() => {
+        throw new Error('boom')
+      })
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+
+      expect(imagesFor('net1')).toEqual({})
+    })
+
+    it('keeps rendering other nodes when one call throws', async () => {
+      await setNodeTable(
+        'net1',
+        tableOf([
+          ['n1', { bad: true }],
+          ['n2', { bad: false }],
+        ]),
+      )
+      registerHook((req) => {
+        if (req.attributes.bad === true) throw new Error('boom')
+        return 'https://example.com/a.png'
+      })
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+
+      expect(Object.keys(imagesFor('net1'))).toEqual(['n2'])
+    })
+
+    it('stops calling a hook that exhausts its failure budget', async () => {
+      // 25 nodes, all throwing, against a budget of 20.
+      const rows: Array<[string, Record<string, ValueType>]> = Array.from(
+        { length: 25 },
+        (_, i) => [`n${i}`, { score: i }],
+      )
+      await setNodeTable('net1', tableOf(rows))
+      const render = vi.fn(() => {
+        throw new Error('boom')
+      })
+      registerHook(render)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+
+      expect(render.mock.calls.length).toBeLessThanOrEqual(20)
+      render.mockClear()
+
+      // A later edit must not revive it.
+      await act(async () => {
+        await setNodeTable(
+          'net1',
+          tableOf(rows.map(([id, r]) => [id, { ...r, again: true }])),
+        )
+      })
+      await drain()
+
+      expect(render).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cross-tab hydration', () => {
+    it('defers the flush while hydrating, then runs it', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+      mockIsHydrating.mockReturnValue(true)
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      await drain()
+
+      // A peer tab's write replaces the whole table, so every row looks changed.
+      // Running then would re-derive the entire network for nothing.
+      expect(render).not.toHaveBeenCalled()
+
+      mockIsHydrating.mockReturnValue(false)
+      await drain()
+
+      expect(render).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('network switching', () => {
+    it('runs against the new network after a switch', async () => {
+      await setNodeTable('net1', tableOf([['n1', { score: 1 }]]))
+      await setNodeTable('net2', tableOf([['n9', { score: 9 }]]))
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        () => 'https://example.com/a.png',
+      )
+      registerHook(render)
+
+      const { rerender } = renderHook(
+        ({ id }: { id: string }) => useNodeGraphicsSync(id),
+        { initialProps: { id: 'net1' } },
+      )
+      await drain()
+      render.mockClear()
+
+      act(() => {
+        rerender({ id: 'net2' })
+      })
+      await drain()
+
+      expect(render.mock.calls.every((c) => c[0].networkId === 'net2')).toBe(
+        true,
+      )
+      expect(imagesFor('net2').n9).toBeDefined()
+    })
+
+    it('does not write images for the old network after switching', async () => {
+      // 500 nodes span multiple chunks, so a switch lands mid-flush.
+      const rows: Array<[string, Record<string, ValueType>]> = Array.from(
+        { length: 500 },
+        (_, i) => [`n${i}`, { score: i }],
+      )
+      await setNodeTable('net1', tableOf(rows))
+      await setNodeTable('net2', tableOf([['z1', { score: 0 }]]))
+      registerHook(() => 'https://example.com/a.png')
+
+      const { rerender } = renderHook(
+        ({ id }: { id: string }) => useNodeGraphicsSync(id),
+        { initialProps: { id: 'net1' } },
+      )
+
+      // Fire the coalescing timer and exactly one frame, leaving chunks queued.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COALESCE_MS + 1)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20)
+      })
+
+      act(() => {
+        rerender({ id: 'net2' })
+      })
+      await drain(10)
+
+      // The generation bump must have dropped the queued chunks; net1 was
+      // cleared and nothing may have refilled it.
+      expect(imagesFor('net1')).toEqual({})
+      expect(imagesFor('net2').z1).toBeDefined()
+    })
+  })
+})

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
@@ -622,6 +622,47 @@ describe('useNodeGraphicsSync', () => {
 
       expect(Object.keys(imagesFor('net1'))).toEqual(['n1'])
     })
+
+    it('finishes the nodes left over when the table vanishes mid-flush', async () => {
+      // A peer-tab replace clears the table before setting the new one. A chunk
+      // landing in that gap must put its unprocessed nodes back, or they keep
+      // stale images: the replacement carries the same rows, so the table-diff
+      // effect finds nothing changed and never re-queues them.
+      const rows: Array<[string, Record<string, ValueType>]> = Array.from(
+        { length: 500 },
+        (_, i) => [`n${i}`, { score: i }],
+      )
+      await setNodeTable('net1', tableOf(rows))
+      registerHook(() => 'https://example.com/a.png')
+
+      renderHook(() => useNodeGraphicsSync('net1'))
+      // Coalescing timer plus one frame: 200 of 500 nodes done, the rest queued.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(COALESCE_MS + 1)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20)
+      })
+      expect(Object.keys(imagesFor('net1'))).toHaveLength(200)
+
+      const { useTableStore } = await import(
+        '../../../data/hooks/stores/TableStore'
+      )
+      await act(async () => {
+        ;(useTableStore as any).setState({ tables: {} })
+      })
+      // The frame that finds no table.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20)
+      })
+      // Same rows, new object — the diff sees no change and queues nothing.
+      await act(async () => {
+        await setNodeTable('net1', tableOf(rows))
+      })
+      await drain(10)
+
+      expect(Object.keys(imagesFor('net1'))).toHaveLength(500)
+    })
   })
 
   describe('cross-tab hydration', () => {

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.test.ts
@@ -1,4 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
+import type { Core } from 'cytoscape'
+import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useNodeGraphicsStore } from '../../../data/hooks/stores/NodeGraphicsStore'
@@ -6,6 +8,7 @@ import type { IdType } from '../../../models/IdType'
 import type { NodeGraphicsRenderHook } from '../../../models/StoreModel/NodeGraphicsStoreModel'
 import type { Table } from '../../../models/TableModel'
 import type { ValueType } from '../../../models/TableModel'
+import { applyNodeGraphics, resetNodeGraphics } from './nodeGraphicsApply'
 import { useNodeGraphicsSync } from './useNodeGraphicsSync'
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
@@ -554,6 +557,202 @@ describe('useNodeGraphicsSync', () => {
       // cleared and nothing may have refilled it.
       expect(imagesFor('net1')).toEqual({})
       expect(imagesFor('net2').z1).toBeDefined()
+    })
+  })
+
+  // ── Sync + apply, composed ─────────────────────────────────────────────────
+  //
+  // The tests above count hook invocations. These count the cy writes that
+  // result, because "only that node re-renders" is a claim about BOTH: the hook
+  // must run once, and exactly one element must be restyled. The two are
+  // separate mechanisms (row diffing vs the apply layer's overlay diff), so a
+  // regression in either would leave the other's test passing.
+  //
+  // Wires the real store, the real sync hook, and the real apply layer, with a
+  // stub cy that records writes — mirroring CyjsRenderer's onNodeGraphicsChange
+  // effect.
+  describe('scoping of cy writes', () => {
+    const NODE_IDS = ['n0', 'n1', 'n2', 'n3', 'n4']
+
+    const stubCy = () => {
+      const styleCalls: string[] = []
+      const removeCalls: string[] = []
+      const nodes = new Map(
+        NODE_IDS.map((id) => [
+          id,
+          {
+            style: vi.fn(() => styleCalls.push(id)),
+            removeStyle: vi.fn(() => removeCalls.push(id)),
+            empty: () => false,
+            width: () => 40,
+            height: () => 40,
+          },
+        ]),
+      )
+      const missing = {
+        style: vi.fn(),
+        removeStyle: vi.fn(),
+        empty: () => true,
+        width: () => 0,
+        height: () => 0,
+      }
+      const cy = {
+        startBatch: vi.fn(),
+        endBatch: vi.fn(),
+        getElementById: (id: string) => nodes.get(id) ?? missing,
+      } as unknown as Core
+      return { cy, styleCalls, removeCalls }
+    }
+
+    /** Mirrors CyjsRenderer: run the sync hook, apply whatever it returns. */
+    const renderRenderer = (cy: Core, networkId: string) =>
+      renderHook(() => {
+        const graphics = useNodeGraphicsSync(networkId)
+        useEffect(() => {
+          applyNodeGraphics(cy, graphics)
+        }, [graphics])
+        return graphics
+      })
+
+    type Rows = Array<[string, Record<string, ValueType>]>
+
+    /**
+     * Row set whose objects keep their identity across calls, so a "single cell
+     * edit" can be modelled faithfully: `InMemoryTable.setValue` clones the rows
+     * Map but replaces only the one target row object. Building fresh objects
+     * for every row would instead model a column operation.
+     */
+    const makeRows = (): {
+      rows: Rows
+      editOne: (id: string, score: number) => Rows
+      rebuildAll: (extra: Record<string, ValueType>) => Rows
+    } => {
+      const rows: Rows = NODE_IDS.map((id, i) => [id, { score: i }])
+      return {
+        rows,
+        editOne: (target, score) =>
+          rows.map(([id, r]) => (id === target ? [id, { score }] : [id, r])),
+        rebuildAll: (extra) => rows.map(([id, r]) => [id, { ...r, ...extra }]),
+      }
+    }
+
+    it('writes to exactly one node when one row changes', async () => {
+      const { cy, styleCalls, removeCalls } = stubCy()
+      const table = makeRows()
+      await setNodeTable('net1', tableOf(table.rows))
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        ({ attributes }) => `https://example.com/${attributes.score}.png`,
+      )
+      registerHook(render)
+
+      const view = renderRenderer(cy, 'net1')
+      await drain()
+
+      // All five painted on mount.
+      expect(styleCalls.sort()).toEqual([...NODE_IDS].sort())
+      styleCalls.length = 0
+      removeCalls.length = 0
+      render.mockClear()
+
+      // Change n2's row only; every other row keeps its object identity.
+      await act(async () => {
+        await setNodeTable('net1', tableOf(table.editOne('n2', 99)))
+      })
+      await drain()
+
+      // The hook ran once, for n2.
+      expect(render).toHaveBeenCalledTimes(1)
+      expect(render.mock.calls[0][0].nodeId).toBe('n2')
+
+      // And exactly one element was restyled — not the whole network.
+      expect(styleCalls).toEqual(['n2'])
+      expect(removeCalls).toEqual([])
+
+      view.unmount()
+      resetNodeGraphics(cy)
+    })
+
+    it('writes nothing when a row changes but its image does not', async () => {
+      const { cy, styleCalls } = stubCy()
+      const table = makeRows()
+      await setNodeTable('net1', tableOf(table.rows))
+      // Image ignores the data, so an edit cannot change it.
+      registerHook(() => 'https://example.com/constant.png')
+
+      const view = renderRenderer(cy, 'net1')
+      await drain()
+      styleCalls.length = 0
+
+      await act(async () => {
+        await setNodeTable('net1', tableOf(table.editOne('n2', 99)))
+      })
+      await drain()
+
+      // The de-dupe skips the store write, so no cy write either.
+      expect(styleCalls).toEqual([])
+
+      view.unmount()
+      resetNodeGraphics(cy)
+    })
+
+    it('writes to every node when a column operation rebuilds every row', async () => {
+      const { cy, styleCalls } = stubCy()
+      const table = makeRows()
+      await setNodeTable('net1', tableOf(table.rows))
+      const render = vi.fn<NodeGraphicsRenderHook>(
+        ({ attributes }) =>
+          `https://example.com/${attributes.score}-${attributes.tag ?? ''}.png`,
+      )
+      registerHook(render)
+
+      const view = renderRenderer(cy, 'net1')
+      await drain()
+      styleCalls.length = 0
+      render.mockClear()
+
+      // What createColumn / setColumnName / applyValueToElements actually do:
+      // clone every row object. This is the case the coalescing window exists
+      // for, and it legitimately restyles everything.
+      await act(async () => {
+        await setNodeTable('net1', tableOf(table.rebuildAll({ tag: 'x' })))
+      })
+      await drain()
+
+      expect(render).toHaveBeenCalledTimes(NODE_IDS.length)
+      expect(styleCalls.sort()).toEqual([...NODE_IDS].sort())
+
+      view.unmount()
+      resetNodeGraphics(cy)
+    })
+
+    it('removes the bypass from only the node whose hook stops returning one', async () => {
+      const { cy, styleCalls, removeCalls } = stubCy()
+      const table = makeRows()
+      await setNodeTable('net1', tableOf(table.rows))
+      // n2 drops out once its score passes 50.
+      registerHook(({ attributes }) =>
+        Number(attributes.score) > 50
+          ? null
+          : `https://example.com/${attributes.score}.png`,
+      )
+
+      const view = renderRenderer(cy, 'net1')
+      await drain()
+      styleCalls.length = 0
+      removeCalls.length = 0
+
+      await act(async () => {
+        await setNodeTable('net1', tableOf(table.editOne('n2', 99)))
+      })
+      await drain()
+
+      // A declined node has its image dropped from the store, which the apply
+      // layer turns into one removeStyle — leaving the other four untouched.
+      expect(removeCalls).toEqual(['n2'])
+      expect(styleCalls).toEqual([])
+
+      view.unmount()
+      resetNodeGraphics(cy)
     })
   })
 })

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
@@ -159,6 +159,8 @@ export const useNodeGraphicsSync = (
       if (generation !== generationRef.current) return
 
       const entries: Array<[IdType, ResolvedNodeGraphics]> = []
+      /** Nodes the hook used to serve and now declines. */
+      const declined: IdType[] = []
       const end = Math.min(index + CHUNK_SIZE, targets.length)
       const existing = useNodeGraphicsStore.getState().images[networkId] ?? {}
 
@@ -184,7 +186,13 @@ export const useNodeGraphicsSync = (
         }
 
         const resolved = runHooks(activeHooks, request)
-        if (resolved === null) continue
+        if (resolved === null) {
+          // Declining is a real answer, not a no-op: a node whose data no longer
+          // qualifies must lose the image it had, or a stale picture survives
+          // until the next refresh or network switch.
+          if (existing[nodeId] !== undefined) declined.push(nodeId)
+          continue
+        }
 
         // Reference-new but string-identical images would re-enter Cytoscape's
         // unbounded image cache for nothing.
@@ -212,6 +220,9 @@ export const useNodeGraphicsSync = (
       // stalling once at the end.
       if (entries.length > 0) {
         useNodeGraphicsStore.getState().setImages(networkId, entries)
+      }
+      if (declined.length > 0) {
+        useNodeGraphicsStore.getState().clearImages(networkId, declined)
       }
 
       if (index < targets.length) {

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
@@ -47,6 +47,24 @@ const FAILURE_BUDGET = 20
 const MAX_DISTINCT_IMAGES = 2000
 
 /**
+ * True when a freshly resolved result is indistinguishable from the stored one.
+ *
+ * Compares every field, `hookId` included: a node now served by a different hook
+ * must be re-attributed, or removing that hook would leave its image behind.
+ */
+const isSameGraphics = (
+  existing: ResolvedNodeGraphics | undefined,
+  next: ResolvedNodeGraphics,
+): boolean =>
+  existing !== undefined &&
+  existing.image === next.image &&
+  existing.fit === next.fit &&
+  existing.opacity === next.opacity &&
+  existing.crossOrigin === next.crossOrigin &&
+  existing.containment === next.containment &&
+  existing.hookId === next.hookId
+
+/**
  * Run the registered hooks for one network and return the resulting images.
  *
  * @param networkId - Network this renderer is showing
@@ -194,9 +212,11 @@ export const useNodeGraphicsSync = (
           continue
         }
 
-        // Reference-new but string-identical images would re-enter Cytoscape's
-        // unbounded image cache for nothing.
-        if (existing[nodeId]?.image === resolved.image) continue
+        // A reference-new but field-identical result would re-enter Cytoscape's
+        // unbounded image cache for nothing. Every field is compared, not just
+        // the image: a hook that keeps the same URL and changes only `opacity`
+        // or `fit` is making a real change and must not be skipped.
+        if (isSameGraphics(existing[nodeId], resolved)) continue
 
         if (
           !distinctImagesRef.current.has(resolved.image) &&
@@ -365,6 +385,9 @@ export const useNodeGraphicsSync = (
           pendingRef.current.add(nodeId)
         }
       }
+      // The work now lives in the pending set, so release the request. This is
+      // what stops requestRefresh's merge from accumulating node ids forever.
+      useNodeGraphicsStore.getState().consumeRefresh(networkId, request.token)
       // An app that recomputed its images expects them to replace the old ones,
       // so the dedupe cache must not veto a repeat of an earlier image.
       distinctImagesRef.current.clear()

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
@@ -24,7 +24,7 @@ import type {
   RegisteredNodeGraphicsHook,
   ResolvedNodeGraphics,
 } from '../../../models/StoreModel/NodeGraphicsStoreModel'
-import type { Table } from '../../../models/TableModel'
+import type { AttributeName, Table, ValueType } from '../../../models/TableModel'
 import { detectRowDelta } from '../../../models/TableModel/impl/tableDiff'
 import { NodeVisualPropertyName } from '../../../models/VisualStyleModel/VisualPropertyName'
 import { resolveNodeGraphics } from './nodeGraphicsResolve'
@@ -33,18 +33,18 @@ import { resolveNodeGraphics } from './nodeGraphicsResolve'
 const COALESCE_MS = 50
 /** Nodes processed per animation frame, so a large batch never blocks one. */
 const CHUNK_SIZE = 200
+/**
+ * Wall-clock a chunk may spend before yielding the frame.
+ *
+ * A node count alone does not bound a frame: a hook taking 12ms per node stays
+ * under `SLOW_CALL_MS` yet CHUNK_SIZE of them blocks for seconds. At least one
+ * node still runs per frame, so progress never stalls.
+ */
+const CHUNK_BUDGET_MS = 8
 /** A synchronous hook call slower than this counts against the failure budget. */
 const SLOW_CALL_MS = 16
 /** Throws plus slow calls before a hook is disabled for the session. */
 const FAILURE_BUDGET = 20
-/**
- * Distinct image strings per network before new ones are refused.
- *
- * Cytoscape's `getCachedImage` retains one Image per distinct URL with no
- * eviction, freed only by `cy.destroy()`. An app generating a fresh data URI per
- * update would grow that cache without bound.
- */
-const MAX_DISTINCT_IMAGES = 2000
 
 /**
  * True when a freshly resolved result is indistinguishable from the stored one.
@@ -63,6 +63,32 @@ const isSameGraphics = (
   existing.crossOrigin === next.crossOrigin &&
   existing.containment === next.containment &&
   existing.hookId === next.hookId
+
+/**
+ * Copy a table row for the hook, list values included.
+ *
+ * A spread alone shares every list-valued attribute with the host table, so a
+ * hook could edit host data through it — or throw, because immer froze it.
+ */
+const copyRow = (
+  row: Record<AttributeName, ValueType>,
+): Record<AttributeName, ValueType> => {
+  const copy: Record<AttributeName, ValueType> = { ...row }
+  for (const key of Object.keys(copy)) {
+    const value = copy[key]
+    if (Array.isArray(value)) copy[key] = [...value] as ValueType
+  }
+  return copy
+}
+
+/**
+ * What the hook chain answered for one node.
+ *
+ * `'declined'` and `'noop'` must stay distinct: declining is an answer that
+ * clears the node's image, while `'noop'` — every hook threw or is disabled —
+ * must leave the image a working hook already produced.
+ */
+type HookOutcome = ResolvedNodeGraphics | 'declined' | 'noop'
 
 /**
  * Run the registered hooks for one network and return the resulting images.
@@ -95,8 +121,6 @@ export const useNodeGraphicsSync = (
   /** hookId → throws + slow calls so far. */
   const failuresRef = useRef<Map<string, number>>(new Map())
   const degradedRef = useRef<Set<string>>(new Set())
-  const distinctImagesRef = useRef<Set<string>>(new Set())
-  const imageCapReportedRef = useRef<boolean>(false)
 
   // Read in the flush without making it an effect dependency.
   const hooksRef = useRef<RegisteredNodeGraphicsHook[]>(hooks)
@@ -181,10 +205,25 @@ export const useNodeGraphicsSync = (
       const declined: IdType[] = []
       const end = Math.min(index + CHUNK_SIZE, targets.length)
       const existing = useNodeGraphicsStore.getState().images[networkId] ?? {}
+      // The live table, not the snapshot `targets` came from: a node deleted
+      // mid-flush was already cleared by the table-diff effect, and writing it
+      // back from a stale snapshot would resurrect its image.
+      const currentTable = nodeTableRef.current
+      if (currentTable === undefined) return
+
+      const chunkStart = index
+      const chunkStartedAt = performance.now()
 
       for (; index < end; index++) {
+        if (
+          index > chunkStart &&
+          performance.now() - chunkStartedAt > CHUNK_BUDGET_MS
+        ) {
+          break
+        }
+
         const nodeId = targets[index]
-        const row = table.rows.get(nodeId)
+        const row = currentTable.rows.get(nodeId)
         // Deleted between queueing and now; the table-diff effect already
         // dropped its image.
         if (row === undefined) continue
@@ -194,7 +233,7 @@ export const useNodeGraphicsSync = (
           networkId,
           nodeId,
           // A copy: an app must not be able to mutate host table state.
-          attributes: { ...row },
+          attributes: copyRow(row),
           width: nodeView?.values.get(NodeVisualPropertyName.NodeWidth) as
             | number
             | undefined,
@@ -203,8 +242,11 @@ export const useNodeGraphicsSync = (
             | undefined,
         }
 
-        const resolved = runHooks(activeHooks, request)
-        if (resolved === null) {
+        const outcome = runHooks(activeHooks, request)
+        // No hook answered — every one threw or is disabled. Leave whatever a
+        // working hook produced earlier in place.
+        if (outcome === 'noop') continue
+        if (outcome === 'declined') {
           // Declining is a real answer, not a no-op: a node whose data no longer
           // qualifies must lose the image it had, or a stale picture survives
           // until the next refresh or network switch.
@@ -216,24 +258,9 @@ export const useNodeGraphicsSync = (
         // unbounded image cache for nothing. Every field is compared, not just
         // the image: a hook that keeps the same URL and changes only `opacity`
         // or `fit` is making a real change and must not be skipped.
-        if (isSameGraphics(existing[nodeId], resolved)) continue
+        if (isSameGraphics(existing[nodeId], outcome)) continue
 
-        if (
-          !distinctImagesRef.current.has(resolved.image) &&
-          distinctImagesRef.current.size >= MAX_DISTINCT_IMAGES
-        ) {
-          if (!imageCapReportedRef.current) {
-            imageCapReportedRef.current = true
-            logApp.warn(
-              `[nodeGraphics]: reached ${MAX_DISTINCT_IMAGES} distinct images for network ${networkId}; ` +
-                'refusing new ones. Prefer stable URLs over freshly generated data URIs.',
-            )
-          }
-          continue
-        }
-        distinctImagesRef.current.add(resolved.image)
-
-        entries.push([nodeId, resolved])
+        entries.push([nodeId, outcome])
       }
 
       // One write per chunk, so a large batch repaints progressively instead of
@@ -257,11 +284,16 @@ export const useNodeGraphicsSync = (
    * Call hooks in registration order; the first non-null result wins. A hook
    * returning null yields to the next one, which is what makes multiple apps
    * compose.
+   *
+   * Returns `'declined'` only when a hook actually ran and answered "no image".
+   * A chain where every hook threw or is disabled returns `'noop'`, so a
+   * tripped circuit breaker never erases images the hook produced while healthy.
    */
   const runHooks = (
     activeHooks: RegisteredNodeGraphicsHook[],
     request: NodeGraphicsRequest,
-  ): ResolvedNodeGraphics | null => {
+  ): HookOutcome => {
+    let declined = false
     for (const hook of activeHooks) {
       // Re-checked per call, not just per flush: a hook that starts failing on
       // node 1 of 100000 must stop being called on node 21, not at the next
@@ -281,10 +313,20 @@ export const useNodeGraphicsSync = (
         noteFailure(hook.hookId, `took ${elapsed.toFixed(0)}ms`)
       }
 
-      const resolved = resolveNodeGraphics(result, hook.hookId)
+      let resolved
+      try {
+        resolved = resolveNodeGraphics(result, hook.hookId)
+      } catch (e) {
+        // Normalization reads properties off an untrusted object, so a throwing
+        // getter lands here rather than in the call above. Same treatment: a
+        // failure, never an answer, and never an escape from the frame.
+        noteFailure(hook.hookId, `returned an unreadable value: ${String(e)}`)
+        continue
+      }
       if (resolved !== null) return resolved
+      declined = true
     }
-    return null
+    return declined ? 'declined' : 'noop'
   }
 
   /**
@@ -312,8 +354,6 @@ export const useNodeGraphicsSync = (
       prevNodeTableRef.current = undefined
       pendingRef.current.clear()
       pendingAllRef.current = true
-      distinctImagesRef.current.clear()
-      imageCapReportedRef.current = false
       schedule()
       // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule/invalidateQueuedWork are stable closures over refs
     },
@@ -333,8 +373,17 @@ export const useNodeGraphicsSync = (
         return
       }
 
-      failuresRef.current.clear()
-      degradedRef.current.clear()
+      // Prune rather than clear. The hook list changes whenever any app
+      // registers, and clearing here would revive a hook the circuit breaker
+      // disabled. A re-registered hook gets a fresh hookId, so dropping only
+      // ids that are gone still gives it a clean slate.
+      const registered = new Set(hooks.map((h) => h.hookId))
+      for (const hookId of Array.from(failuresRef.current.keys())) {
+        if (!registered.has(hookId)) failuresRef.current.delete(hookId)
+      }
+      for (const hookId of Array.from(degradedRef.current)) {
+        if (!registered.has(hookId)) degradedRef.current.delete(hookId)
+      }
       pendingAllRef.current = true
       schedule()
       // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule/invalidateQueuedWork are stable closures over refs
@@ -388,10 +437,6 @@ export const useNodeGraphicsSync = (
       // The work now lives in the pending set, so release the request. This is
       // what stops requestRefresh's merge from accumulating node ids forever.
       useNodeGraphicsStore.getState().consumeRefresh(networkId, request.token)
-      // An app that recomputed its images expects them to replace the old ones,
-      // so the dedupe cache must not veto a repeat of an earlier image.
-      distinctImagesRef.current.clear()
-      imageCapReportedRef.current = false
       schedule()
       // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule is a stable closure over refs
     },

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
@@ -209,7 +209,16 @@ export const useNodeGraphicsSync = (
       // mid-flush was already cleared by the table-diff effect, and writing it
       // back from a stale snapshot would resurrect its image.
       const currentTable = nodeTableRef.current
-      if (currentTable === undefined) return
+      if (currentTable === undefined) {
+        // The table is momentarily absent, not gone: a peer-tab replace clears
+        // it before setting the new one. Returning alone would drop every node
+        // this flush had not reached yet, so put them back and retry.
+        for (let i = index; i < targets.length; i++) {
+          pendingRef.current.add(targets[i])
+        }
+        schedule()
+        return
+      }
 
       const chunkStart = index
       const chunkStartedAt = performance.now()

--- a/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
@@ -1,0 +1,381 @@
+// src/features/NetworkPanel/CyjsRenderer/useNodeGraphicsSync.ts
+//
+// Decides WHEN to run app render hooks, and for which nodes.
+//
+// Renderer-scoped on purpose: called from CyjsRenderer, so no hook work happens
+// for background networks, and mounting is the natural first-run trigger.
+//
+// The hard part is not calling the hook — it is not calling it a hundred
+// thousand times. `InMemoryTable` rebuilds EVERY row object on a column
+// operation (createColumn, deleteColumn, setColumnName, duplicateColumn,
+// applyValueToElements, setTable, add), so a single column rename reports every
+// node as changed. Hence the coalescing window and the chunked flush below.
+
+import { useEffect, useRef } from 'react'
+
+import { logApp } from '../../../debug'
+import { useNodeGraphicsStore } from '../../../data/hooks/stores/NodeGraphicsStore'
+import { useTableStore } from '../../../data/hooks/stores/TableStore'
+import { useViewModelStore } from '../../../data/hooks/stores/ViewModelStore'
+import { isHydrating } from '../../../data/hooks/stores/hydrationContext'
+import type { IdType } from '../../../models/IdType'
+import type {
+  NodeGraphicsRequest,
+  RegisteredNodeGraphicsHook,
+  ResolvedNodeGraphics,
+} from '../../../models/StoreModel/NodeGraphicsStoreModel'
+import type { Table } from '../../../models/TableModel'
+import { detectRowDelta } from '../../../models/TableModel/impl/tableDiff'
+import { NodeVisualPropertyName } from '../../../models/VisualStyleModel/VisualPropertyName'
+import { resolveNodeGraphics } from './nodeGraphicsResolve'
+
+/** Writes inside this window merge into one flush. */
+const COALESCE_MS = 50
+/** Nodes processed per animation frame, so a large batch never blocks one. */
+const CHUNK_SIZE = 200
+/** A synchronous hook call slower than this counts against the failure budget. */
+const SLOW_CALL_MS = 16
+/** Throws plus slow calls before a hook is disabled for the session. */
+const FAILURE_BUDGET = 20
+/**
+ * Distinct image strings per network before new ones are refused.
+ *
+ * Cytoscape's `getCachedImage` retains one Image per distinct URL with no
+ * eviction, freed only by `cy.destroy()`. An app generating a fresh data URI per
+ * update would grow that cache without bound.
+ */
+const MAX_DISTINCT_IMAGES = 2000
+
+/**
+ * Run the registered hooks for one network and return the resulting images.
+ *
+ * @param networkId - Network this renderer is showing
+ * @returns nodeId → image, or undefined when no hook is registered
+ */
+export const useNodeGraphicsSync = (
+  networkId: IdType,
+): Record<IdType, ResolvedNodeGraphics> | undefined => {
+  const hooks = useNodeGraphicsStore((state) => state.hooks)
+  const images = useNodeGraphicsStore((state) => state.images[networkId])
+  const refreshToken = useNodeGraphicsStore(
+    (state) => state.refreshRequests[networkId]?.token,
+  )
+  const nodeTable = useTableStore((state) => state.tables[networkId]?.nodeTable)
+
+  /** Nodes awaiting a hook run. */
+  const pendingRef = useRef<Set<IdType>>(new Set())
+  /** Set when every node needs a run (mount, hook change, whole-network refresh). */
+  const pendingAllRef = useRef<boolean>(true)
+  const prevNodeTableRef = useRef<Table | undefined>(undefined)
+  /**
+   * Bumped whenever queued work becomes invalid (network switch, hook change,
+   * unmount). A chunk from an older generation is dropped rather than applied.
+   */
+  const generationRef = useRef<number>(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const rafRef = useRef<number | undefined>(undefined)
+  /** hookId → throws + slow calls so far. */
+  const failuresRef = useRef<Map<string, number>>(new Map())
+  const degradedRef = useRef<Set<string>>(new Set())
+  const distinctImagesRef = useRef<Set<string>>(new Set())
+  const imageCapReportedRef = useRef<boolean>(false)
+
+  // Read in the flush without making it an effect dependency.
+  const hooksRef = useRef<RegisteredNodeGraphicsHook[]>(hooks)
+  hooksRef.current = hooks
+  const nodeTableRef = useRef<Table | undefined>(nodeTable)
+  nodeTableRef.current = nodeTable
+
+  // ── The flush ──────────────────────────────────────────────────────────────
+
+  const cancelScheduled = (): void => {
+    if (timerRef.current !== undefined) {
+      clearTimeout(timerRef.current)
+      timerRef.current = undefined
+    }
+    if (rafRef.current !== undefined) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = undefined
+    }
+  }
+
+  /**
+   * Discard queued work: cancel the timer and any in-flight chunk loop, and bump
+   * the generation so a chunk that already escaped cancellation drops its
+   * results instead of applying them to the wrong network.
+   */
+  const invalidateQueuedWork = (): void => {
+    generationRef.current++
+    cancelScheduled()
+  }
+
+  const flushRef = useRef<() => void>(() => {})
+
+  const schedule = (): void => {
+    if (timerRef.current !== undefined) return
+    timerRef.current = setTimeout(() => {
+      timerRef.current = undefined
+      flushRef.current()
+    }, COALESCE_MS)
+  }
+
+  flushRef.current = function flush(): void {
+    const activeHooks = hooksRef.current.filter(
+      (h) => !degradedRef.current.has(h.hookId),
+    )
+    const table = nodeTableRef.current
+
+    if (activeHooks.length === 0 || table === undefined) {
+      pendingRef.current.clear()
+      pendingAllRef.current = false
+      return
+    }
+
+    // A peer tab's edit arrives as a full-table replace, so every row looks
+    // changed. Wait it out rather than re-running the hook for the whole
+    // network; the pending set is preserved, so nothing is lost.
+    if (isHydrating()) {
+      schedule()
+      return
+    }
+
+    const targets = pendingAllRef.current
+      ? Array.from(table.rows.keys())
+      : Array.from(pendingRef.current)
+
+    pendingRef.current.clear()
+    pendingAllRef.current = false
+
+    if (targets.length === 0) return
+
+    const generation = generationRef.current
+    const viewModel = useViewModelStore.getState().getViewModel(networkId)
+
+    let index = 0
+
+    const processChunk = (): void => {
+      rafRef.current = undefined
+      // Network switched, hook changed, or unmounted while chunks were queued.
+      if (generation !== generationRef.current) return
+
+      const entries: Array<[IdType, ResolvedNodeGraphics]> = []
+      const end = Math.min(index + CHUNK_SIZE, targets.length)
+      const existing = useNodeGraphicsStore.getState().images[networkId] ?? {}
+
+      for (; index < end; index++) {
+        const nodeId = targets[index]
+        const row = table.rows.get(nodeId)
+        // Deleted between queueing and now; the table-diff effect already
+        // dropped its image.
+        if (row === undefined) continue
+
+        const nodeView = viewModel?.nodeViews[nodeId]
+        const request: NodeGraphicsRequest = {
+          networkId,
+          nodeId,
+          // A copy: an app must not be able to mutate host table state.
+          attributes: { ...row },
+          width: nodeView?.values.get(NodeVisualPropertyName.NodeWidth) as
+            | number
+            | undefined,
+          height: nodeView?.values.get(NodeVisualPropertyName.NodeHeight) as
+            | number
+            | undefined,
+        }
+
+        const resolved = runHooks(activeHooks, request)
+        if (resolved === null) continue
+
+        // Reference-new but string-identical images would re-enter Cytoscape's
+        // unbounded image cache for nothing.
+        if (existing[nodeId]?.image === resolved.image) continue
+
+        if (
+          !distinctImagesRef.current.has(resolved.image) &&
+          distinctImagesRef.current.size >= MAX_DISTINCT_IMAGES
+        ) {
+          if (!imageCapReportedRef.current) {
+            imageCapReportedRef.current = true
+            logApp.warn(
+              `[nodeGraphics]: reached ${MAX_DISTINCT_IMAGES} distinct images for network ${networkId}; ` +
+                'refusing new ones. Prefer stable URLs over freshly generated data URIs.',
+            )
+          }
+          continue
+        }
+        distinctImagesRef.current.add(resolved.image)
+
+        entries.push([nodeId, resolved])
+      }
+
+      // One write per chunk, so a large batch repaints progressively instead of
+      // stalling once at the end.
+      if (entries.length > 0) {
+        useNodeGraphicsStore.getState().setImages(networkId, entries)
+      }
+
+      if (index < targets.length) {
+        rafRef.current = requestAnimationFrame(processChunk)
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(processChunk)
+  }
+
+  /**
+   * Call hooks in registration order; the first non-null result wins. A hook
+   * returning null yields to the next one, which is what makes multiple apps
+   * compose.
+   */
+  const runHooks = (
+    activeHooks: RegisteredNodeGraphicsHook[],
+    request: NodeGraphicsRequest,
+  ): ResolvedNodeGraphics | null => {
+    for (const hook of activeHooks) {
+      // Re-checked per call, not just per flush: a hook that starts failing on
+      // node 1 of 100000 must stop being called on node 21, not at the next
+      // flush.
+      if (degradedRef.current.has(hook.hookId)) continue
+
+      let result
+      const startedAt = performance.now()
+      try {
+        result = hook.render(request)
+      } catch (e) {
+        noteFailure(hook.hookId, `threw: ${String(e)}`)
+        continue
+      }
+      const elapsed = performance.now() - startedAt
+      if (elapsed > SLOW_CALL_MS) {
+        noteFailure(hook.hookId, `took ${elapsed.toFixed(0)}ms`)
+      }
+
+      const resolved = resolveNodeGraphics(result, hook.hookId)
+      if (resolved !== null) return resolved
+    }
+    return null
+  }
+
+  /**
+   * Count a throw or a slow call, and disable the hook once it exhausts its
+   * budget. Without this, a broken hook burns time on every table edit for the
+   * rest of the session. Images it already produced are left alone.
+   */
+  const noteFailure = (hookId: string, detail: string): void => {
+    const count = (failuresRef.current.get(hookId) ?? 0) + 1
+    failuresRef.current.set(hookId, count)
+    if (count >= FAILURE_BUDGET && !degradedRef.current.has(hookId)) {
+      degradedRef.current.add(hookId)
+      logApp.warn(
+        `[nodeGraphics]: disabling render hook ${hookId} after ${count} failures (last: ${detail})`,
+      )
+    }
+  }
+
+  // ── Triggers ───────────────────────────────────────────────────────────────
+
+  // Network switch: nothing queued for the old network is valid.
+  useEffect(
+    function onNetworkChange() {
+      invalidateQueuedWork()
+      prevNodeTableRef.current = undefined
+      pendingRef.current.clear()
+      pendingAllRef.current = true
+      distinctImagesRef.current.clear()
+      imageCapReportedRef.current = false
+      schedule()
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule/invalidateQueuedWork are stable closures over refs
+    },
+    [networkId],
+  )
+
+  // Hook registered, replaced, or cleared.
+  useEffect(
+    function onHooksChange() {
+      invalidateQueuedWork()
+
+      if (hooks.length === 0) {
+        // Drop every image so nodes fall back to their Vizmapper graphics.
+        pendingRef.current.clear()
+        pendingAllRef.current = false
+        useNodeGraphicsStore.getState().clearNetwork(networkId)
+        return
+      }
+
+      failuresRef.current.clear()
+      degradedRef.current.clear()
+      pendingAllRef.current = true
+      schedule()
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule/invalidateQueuedWork are stable closures over refs
+    },
+    [hooks, networkId],
+  )
+
+  // Table edit. Also covers node creation (a new node is a new row).
+  useEffect(
+    function onNodeTableChange() {
+      if (nodeTable === undefined) return
+
+      const prev = prevNodeTableRef.current
+      prevNodeTableRef.current = nodeTable
+
+      // First sighting: the mount effect already queued every node.
+      if (prev === undefined || prev === nodeTable) return
+
+      const { changed, removed } = detectRowDelta(nodeTable, prev)
+
+      if (removed.length > 0) {
+        // Deleted nodes need their image dropped, never a hook call.
+        useNodeGraphicsStore.getState().clearImages(networkId, removed)
+      }
+      if (changed.length === 0) return
+
+      for (const nodeId of changed) {
+        pendingRef.current.add(nodeId)
+      }
+      schedule()
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule is a stable closure over refs
+    },
+    [nodeTable, networkId],
+  )
+
+  // App-driven refresh, for images that depend on the app's own state.
+  useEffect(
+    function onRefreshRequest() {
+      if (refreshToken === undefined) return
+
+      const request = useNodeGraphicsStore.getState().refreshRequests[networkId]
+      if (request === undefined) return
+
+      if (request.nodeIds === undefined) {
+        pendingAllRef.current = true
+      } else {
+        for (const nodeId of request.nodeIds) {
+          pendingRef.current.add(nodeId)
+        }
+      }
+      // An app that recomputed its images expects them to replace the old ones,
+      // so the dedupe cache must not veto a repeat of an earlier image.
+      distinctImagesRef.current.clear()
+      imageCapReportedRef.current = false
+      schedule()
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- schedule is a stable closure over refs
+    },
+    [refreshToken, networkId],
+  )
+
+  // Unmount: cancel queued work and drop this network's images, since nothing
+  // is left to display them.
+  useEffect(
+    function onUnmount() {
+      return () => {
+        invalidateQueuedWork()
+        useNodeGraphicsStore.getState().clearNetwork(networkId)
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- invalidateQueuedWork is a stable closure over refs
+    },
+    [networkId],
+  )
+
+  return images
+}

--- a/src/features/ToolBar/AppMenu/index.tsx
+++ b/src/features/ToolBar/AppMenu/index.tsx
@@ -3,9 +3,7 @@ import { ToolbarMenuItem as MenuItem } from '@/features/ToolBar/menuItemModel'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { AppIdProvider } from '../../../app-api/AppIdContext'
-import { CyWebApi } from '../../../app-api/core'
-import { createContextMenuApi } from '../../../app-api/core/contextMenuApi'
-import { createResourceApi } from '../../../app-api/core/resourceApi'
+import { buildPerAppApis } from '../../../app-api/core/perAppApis'
 import { useAppResourceStore } from '../../../data/hooks/stores/AppResourceStore'
 import { useAppStore } from '../../../data/hooks/stores/AppStore'
 import { appRegistry } from '../../../data/hooks/stores/useAppManager'
@@ -96,11 +94,7 @@ export const AppMenu = () => {
       })
       .map((r: RegisteredAppResource) => {
         const MenuComponent = r.component as React.ComponentType<any>
-        const perAppApis = {
-          ...CyWebApi,
-          resource: createResourceApi(r.appId),
-          contextMenu: createContextMenuApi(r.appId),
-        }
+        const perAppApis = buildPerAppApis(r.appId)
 
         const wrapped = r.closeOnAction ? (
           <div

--- a/src/features/Workspace/SidePanel/TabContents.tsx
+++ b/src/features/Workspace/SidePanel/TabContents.tsx
@@ -12,9 +12,7 @@ import { AppStatus } from '../../../models/AppModel/AppStatus'
 import { ComponentMetadata } from '../../../models/AppModel/ComponentMetadata'
 import type { RegisteredAppResource } from '../../../models/AppModel/RegisteredAppResource'
 import { AppIdProvider } from '../.././../app-api/AppIdContext'
-import { CyWebApi } from '../../../app-api/core'
-import { createContextMenuApi } from '../../../app-api/core/contextMenuApi'
-import { createResourceApi } from '../../../app-api/core/resourceApi'
+import { buildPerAppApis } from '../../../app-api/core/perAppApis'
 import ExternalComponent from '../../AppManager/ExternalComponent'
 import { PluginErrorBoundary } from '../../AppManager/PluginErrorBoundary'
 // Lazy, directly from MainPanel (not the barrel): the hierarchy viewer pulls
@@ -139,17 +137,6 @@ export function usePanelEntries(): PanelEntry[] {
 }
 
 /**
- * Build per-app APIs map for AppIdProvider.
- */
-function getPerAppApis(appId: string) {
-  return {
-    ...CyWebApi,
-    resource: createResourceApi(appId),
-    contextMenu: createContextMenuApi(appId),
-  }
-}
-
-/**
  * Render the panel entries as TabPanel elements.
  */
 export function renderPanelContents(
@@ -159,7 +146,7 @@ export function renderPanelContents(
   return entries.map((entry, index) => {
     const PanelComponent = entry.component
     const content = entry.appId ? (
-      <AppIdProvider value={{ appId: entry.appId, apis: getPerAppApis(entry.appId) }}>
+      <AppIdProvider value={{ appId: entry.appId, apis: buildPerAppApis(entry.appId) }}>
         <PluginErrorBoundary
           appId={entry.appId}
           slot="right-panel"

--- a/src/models/CxModel/impl/exporter.nodeGraphics.test.ts
+++ b/src/models/CxModel/impl/exporter.nodeGraphics.test.ts
@@ -1,0 +1,189 @@
+// src/models/CxModel/impl/exporter.nodeGraphics.test.ts
+//
+// Guards the export contract for app-supplied node graphics: a render hook's
+// images are renderer-only and must NEVER appear in exported CX2, while
+// Vizmapper custom graphics must continue to export exactly as before.
+//
+// This is the regression test for the feature's hard constraint. If it fails,
+// something wired NodeGraphicsStore into the export path — do not "fix" it by
+// updating the expectation.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useNodeGraphicsStore } from '../../../data/hooks/stores/NodeGraphicsStore'
+import { CyNetwork } from '../../CyNetworkModel'
+import NetworkFn, { Network, NetworkAttributes } from '../../NetworkModel'
+import type { ResolvedNodeGraphics } from '../../StoreModel/NodeGraphicsStoreModel'
+import { createTable } from '../../TableModel/impl/inMemoryTable'
+import { NetworkView } from '../../ViewModel'
+import { createViewModel } from '../../ViewModel/impl/viewModelImpl'
+import VisualStyleFn, { VisualStyle } from '../../VisualStyleModel'
+import { getCustomGraphicsPropertyKeys } from '../../VisualStyleModel/impl/customGraphicsImpl'
+import { setBypass } from '../../VisualStyleModel/impl/visualStyleImpl'
+import { CustomGraphicsType } from '../../VisualStyleModel/VisualPropertyValue'
+import { exportCyNetworkToCx2 } from './exporter'
+
+/** Distinctive enough that a substring search over the whole export is sound. */
+const SENTINEL_MARKER = 'CYWEB_HOOK_SENTINEL'
+const SENTINEL_IMAGE = `https://example.com/${SENTINEL_MARKER}.png`
+
+const hookImage = (image = SENTINEL_IMAGE): ResolvedNodeGraphics => ({
+  image,
+  fit: 'contain',
+  opacity: 1,
+  crossOrigin: 'null',
+  containment: 'inside',
+  hookId: 'sentinel-hook',
+})
+
+interface Fixture {
+  cyNetwork: CyNetwork
+  networkId: string
+  visualStyle: VisualStyle
+  networkView: NetworkView
+}
+
+const buildFixture = (networkId = 'net-node-graphics'): Fixture => {
+  const network: Network = NetworkFn.createNetwork(networkId)
+  NetworkFn.addNode(network, 'n1')
+  NetworkFn.addNode(network, 'n2')
+
+  const nodeTable = createTable(`${networkId}-nodes`)
+  const edgeTable = createTable(`${networkId}-edges`)
+  const visualStyle: VisualStyle = VisualStyleFn.createVisualStyle()
+  const networkView: NetworkView = createViewModel(network)
+  const networkAttributes: NetworkAttributes = { id: networkId, attributes: {} }
+
+  return {
+    networkId,
+    visualStyle,
+    networkView,
+    cyNetwork: {
+      network,
+      nodeTable,
+      edgeTable,
+      visualStyle,
+      networkViews: [networkView],
+      networkAttributes,
+      undoRedoStack: { undoStack: [], redoStack: [] },
+    },
+  }
+}
+
+const exportToJson = (cyNetwork: CyNetwork): string =>
+  JSON.stringify(exportCyNetworkToCx2(cyNetwork))
+
+describe('CX2 export and node-graphics render hooks', () => {
+  beforeEach(() => {
+    useNodeGraphicsStore.setState({
+      hooks: [],
+      images: {},
+      refreshRequests: {},
+    })
+  })
+
+  it('produces byte-identical CX2 with and without hook images', () => {
+    const { cyNetwork, networkId } = buildFixture()
+
+    const before = exportToJson(cyNetwork)
+
+    useNodeGraphicsStore.getState().setHook({
+      hookId: 'sentinel-hook',
+      appId: 'sentinel-app',
+      render: () => SENTINEL_IMAGE,
+    })
+    useNodeGraphicsStore.getState().setImages(networkId, [
+      ['n1', hookImage()],
+      ['n2', hookImage()],
+    ])
+    // Populated, so a leak would be visible.
+    expect(
+      Object.keys(useNodeGraphicsStore.getState().images[networkId]),
+    ).toHaveLength(2)
+
+    const after = exportToJson(cyNetwork)
+
+    expect(after).toBe(before)
+    expect(after).not.toContain(SENTINEL_MARKER)
+  })
+
+  it('leaks nothing even when images exist for every node id in the export', () => {
+    const { cyNetwork, networkId } = buildFixture()
+    useNodeGraphicsStore.getState().setHook({
+      hookId: 'sentinel-hook',
+      render: () => SENTINEL_IMAGE,
+    })
+    useNodeGraphicsStore.getState().setImages(networkId, [
+      [
+        'n1',
+        hookImage(
+          'data:image/svg+xml,%3Csvg%20id%3D%22CYWEB_HOOK_SENTINEL%22%2F%3E',
+        ),
+      ],
+      ['n2', hookImage()],
+    ])
+
+    const cx2 = exportToJson(cyNetwork)
+
+    expect(cx2).not.toContain(SENTINEL_MARKER)
+    expect(cx2).not.toContain('data:image/svg+xml')
+  })
+
+  it('does not mutate the visual style or the view model', () => {
+    // Reference identity is a stronger claim than "no serialized difference":
+    // it proves the hook path never wrote to the exportable stores at all.
+    const { cyNetwork, networkId, visualStyle, networkView } = buildFixture()
+
+    useNodeGraphicsStore.getState().setHook({
+      hookId: 'sentinel-hook',
+      render: () => SENTINEL_IMAGE,
+    })
+    useNodeGraphicsStore.getState().setImages(networkId, [['n1', hookImage()]])
+    exportToJson(cyNetwork)
+
+    expect(cyNetwork.visualStyle).toBe(visualStyle)
+    expect(cyNetwork.networkViews?.[0]).toBe(networkView)
+  })
+
+  it('still exports a Vizmapper image custom graphic', () => {
+    // The other half of the contract: suppressing hook images must not suppress
+    // the user's own custom graphics.
+    const { cyNetwork, networkId } = buildFixture()
+    const vizmapperImage = 'https://example.com/vizmapper-owned.png'
+    const customGraphic: CustomGraphicsType = {
+      type: 'image',
+      name: 'org.cytoscape.ding.customgraphics.bitmap.URLImageCustomGraphics',
+      properties: { url: vizmapperImage },
+    } as unknown as CustomGraphicsType
+
+    const styled = setBypass(
+      cyNetwork.visualStyle,
+      'nodeImageChart1' as any,
+      ['n1'],
+      customGraphic as any,
+    )
+
+    useNodeGraphicsStore.getState().setHook({
+      hookId: 'sentinel-hook',
+      render: () => SENTINEL_IMAGE,
+    })
+    useNodeGraphicsStore.getState().setImages(networkId, [['n1', hookImage()]])
+
+    const cx2 = exportToJson({ ...cyNetwork, visualStyle: styled })
+
+    expect(cx2).toContain(vizmapperImage)
+    expect(cx2).not.toContain(SENTINEL_MARKER)
+  })
+
+  it('keeps the hook’s cy property names out of the custom-graphics key list', () => {
+    // Structural guard. The apply layer uses element style bypasses, not element
+    // data — but if anyone reimplements it with data keys, those keys must not
+    // join this list, or applyViewModel's stale-key sweep would fight them and
+    // serialization paths could pick them up.
+    const keys = getCustomGraphicsPropertyKeys()
+
+    expect(keys).not.toContain('background-image-containment')
+    expect(keys).not.toContain('background-image-opacity')
+    expect(keys).not.toContain('appNodeImage')
+  })
+})

--- a/src/models/StoreModel/NodeGraphicsStoreModel.ts
+++ b/src/models/StoreModel/NodeGraphicsStoreModel.ts
@@ -126,40 +126,57 @@ export interface NodeGraphicsRefreshRequest {
   /** Monotonic; the renderer reacts to changes, not to the value. */
   readonly token: number
   /** Undefined means the whole network. */
-  readonly nodeIds?: IdType[]
+  readonly nodeIds?: readonly IdType[]
 }
 
 export interface NodeGraphicsState {
   /** Registration order. First non-null result wins. */
-  hooks: RegisteredNodeGraphicsHook[]
+  readonly hooks: RegisteredNodeGraphicsHook[]
   /**
    * networkId → nodeId → resolved image.
    *
    * Ephemeral. Never persisted and never read by the CX2 exporter, which is
    * what keeps hook images out of exported files.
    */
-  images: Record<IdType, Record<IdType, ResolvedNodeGraphics>>
-  refreshRequests: Record<IdType, NodeGraphicsRefreshRequest>
+  readonly images: Record<IdType, Record<IdType, ResolvedNodeGraphics>>
+  readonly refreshRequests: Record<IdType, NodeGraphicsRefreshRequest>
 }
 
 export interface NodeGraphicsActions {
   /** Register or replace the hook owned by `hook.appId`. */
-  setHook: (hook: RegisteredNodeGraphicsHook) => void
+  readonly setHook: (hook: RegisteredNodeGraphicsHook) => void
   /** Remove an app's hook and every image it produced. */
-  removeAllByAppId: (appId: string) => void
+  readonly removeAllByAppId: (appId: string) => void
   /** Remove the anonymous (`window.CyWebApi`) hook and its images. */
-  removeAnonymousHook: () => void
+  readonly removeAnonymousHook: () => void
   /** Merge resolved images for a network. */
-  setImages: (
+  readonly setImages: (
     networkId: IdType,
-    entries: Array<[IdType, ResolvedNodeGraphics]>,
+    entries: ReadonlyArray<readonly [IdType, ResolvedNodeGraphics]>,
   ) => void
   /** Drop images for specific nodes, e.g. after they are deleted. */
-  clearImages: (networkId: IdType, nodeIds: IdType[]) => void
+  readonly clearImages: (networkId: IdType, nodeIds: readonly IdType[]) => void
   /** Drop every image and pending refresh for a network. */
-  clearNetwork: (networkId: IdType) => void
-  /** Ask the renderer to re-run the hook. */
-  requestRefresh: (networkId: IdType, nodeIds?: IdType[]) => void
+  readonly clearNetwork: (networkId: IdType) => void
+  /**
+   * Ask the renderer to re-run the hook.
+   *
+   * Coalesces with a request the renderer has not consumed yet: node ids merge,
+   * and a whole-network request (`nodeIds` omitted) absorbs any pending ids.
+   */
+  readonly requestRefresh: (
+    networkId: IdType,
+    nodeIds?: readonly IdType[],
+  ) => void
+  /**
+   * Renderer-only: acknowledge a refresh request once its nodes are queued.
+   *
+   * Ignored unless `token` still matches the stored request, so a refresh that
+   * landed after the renderer read the request survives. Without this ack the
+   * merge in `requestRefresh` would accumulate node ids for the network's whole
+   * lifetime.
+   */
+  readonly consumeRefresh: (networkId: IdType, token: number) => void
 }
 
 export type NodeGraphicsStoreModel = NodeGraphicsState & NodeGraphicsActions

--- a/src/models/StoreModel/NodeGraphicsStoreModel.ts
+++ b/src/models/StoreModel/NodeGraphicsStoreModel.ts
@@ -140,6 +140,13 @@ export interface NodeGraphicsState {
    */
   readonly images: Record<IdType, Record<IdType, ResolvedNodeGraphics>>
   readonly refreshRequests: Record<IdType, NodeGraphicsRefreshRequest>
+  /**
+   * networkId → last token issued. Kept separately from `refreshRequests` and
+   * never reset, because deriving the next token from the pending request would
+   * restart at 1 after the renderer consumes one — and a request the renderer
+   * never saw at a lower value would then not look like a change at all.
+   */
+  readonly refreshSequence: Record<IdType, number>
 }
 
 export interface NodeGraphicsActions {

--- a/src/models/StoreModel/NodeGraphicsStoreModel.ts
+++ b/src/models/StoreModel/NodeGraphicsStoreModel.ts
@@ -1,0 +1,155 @@
+// src/models/StoreModel/NodeGraphicsStoreModel.ts
+//
+// Types for the node-graphics render hook: a function an external app registers
+// that the host calls with each changed node, returning an image to draw as that
+// node's Cytoscape.js background-image.
+//
+// Deliberately separate from the VisualStyle model. Hook output is renderer-only
+// and must never be exported to CX2 — see
+// docs/design/custom-graphics-image/node-graphics-render-hook.md.
+
+import { IdType } from '../IdType'
+import { AttributeName, ValueType } from '../TableModel'
+
+/** How the image is fitted to the node box. Mirrors Cytoscape.js `background-fit`. */
+export type NodeGraphicsFit = 'contain' | 'cover' | 'none'
+
+/**
+ * Whether the image draws under or over Cytoscape.js pie/ring charts.
+ *
+ * Cytoscape's node draw order is: shape → images(inside) → border → pie →
+ * stripe → images(over). So `'inside'` (the default, matching Vizmapper image
+ * slots) means an active pie chart covers this image. Use `'over'` to own the
+ * node face.
+ */
+export type NodeGraphicsContainment = 'inside' | 'over'
+
+/**
+ * How the browser requests the image.
+ *
+ * `'null'` is a valid Cytoscape.js value meaning "do not set the crossOrigin
+ * attribute" — it loads from servers without CORS headers, at the cost of
+ * tainting the canvas, which excludes the image from PNG export. Use
+ * `'anonymous'` when export fidelity matters more than reach.
+ */
+export type NodeGraphicsCrossOrigin = 'anonymous' | 'use-credentials' | 'null'
+
+/** What the host tells the hook about the node it is asking about. */
+export interface NodeGraphicsRequest {
+  readonly networkId: IdType
+  readonly nodeId: IdType
+  /**
+   * Shallow copy of the node's table row. A copy rather than the live row so an
+   * app cannot mutate host state; writes to it are ignored.
+   */
+  readonly attributes: Record<AttributeName, ValueType>
+  /** Current node width in model units, when the view model has it. */
+  readonly width?: number
+  readonly height?: number
+}
+
+/** A hook's full-form answer. */
+export interface NodeGraphicsImage {
+  /**
+   * An `http(s)://` URL, a `data:` URI, or raw `<svg>` markup. `blob:` and
+   * `file:` are rejected — blob URLs are dead by the time a style reapplies.
+   */
+  readonly image: string
+  /** Default `'contain'`. */
+  readonly fit?: NodeGraphicsFit
+  /** 0..1. Default 1. */
+  readonly opacity?: number
+  /** Default `'null'`. */
+  readonly crossOrigin?: NodeGraphicsCrossOrigin
+  /** Default `'inside'`. */
+  readonly containment?: NodeGraphicsContainment
+}
+
+/**
+ * What a hook may return. A bare string is shorthand for `{ image }`.
+ * `null` or `undefined` means "no image for this node" — the node falls back to
+ * its Vizmapper custom graphic, if any.
+ */
+export type NodeGraphicsResult = string | NodeGraphicsImage | null | undefined
+
+/**
+ * The function an app registers.
+ *
+ * Synchronous by contract. An app whose image needs async work (a fetch, an
+ * offscreen render) should compute and cache it in its own code, then call
+ * `nodeGraphics.refresh()` so this hook can return the cached value.
+ *
+ * Must not throw. A throwing hook yields no image for that node, and repeated
+ * throws trip a circuit breaker that stops the host calling it.
+ */
+export type NodeGraphicsRenderHook = (
+  request: NodeGraphicsRequest,
+) => NodeGraphicsResult
+
+/** A hook plus the app that owns it. */
+export interface RegisteredNodeGraphicsHook {
+  readonly hookId: string
+  /** `undefined` for anonymous registrations via `window.CyWebApi`. */
+  readonly appId?: string
+  readonly render: NodeGraphicsRenderHook
+}
+
+/**
+ * A validated, fully defaulted image ready for the renderer.
+ *
+ * `image` has passed `normalizeImageSource`, so it is a URL or data URI — never
+ * raw markup. Instances are treated as immutable and compared by reference by
+ * the apply layer, so never mutate one in place.
+ */
+export interface ResolvedNodeGraphics {
+  readonly image: string
+  readonly fit: NodeGraphicsFit
+  readonly opacity: number
+  readonly crossOrigin: NodeGraphicsCrossOrigin
+  readonly containment: NodeGraphicsContainment
+  /** Hook that produced this, for attribution on hook removal. */
+  readonly hookId: string
+}
+
+/** An app's request that the host re-run the hook. */
+export interface NodeGraphicsRefreshRequest {
+  /** Monotonic; the renderer reacts to changes, not to the value. */
+  readonly token: number
+  /** Undefined means the whole network. */
+  readonly nodeIds?: IdType[]
+}
+
+export interface NodeGraphicsState {
+  /** Registration order. First non-null result wins. */
+  hooks: RegisteredNodeGraphicsHook[]
+  /**
+   * networkId → nodeId → resolved image.
+   *
+   * Ephemeral. Never persisted and never read by the CX2 exporter, which is
+   * what keeps hook images out of exported files.
+   */
+  images: Record<IdType, Record<IdType, ResolvedNodeGraphics>>
+  refreshRequests: Record<IdType, NodeGraphicsRefreshRequest>
+}
+
+export interface NodeGraphicsActions {
+  /** Register or replace the hook owned by `hook.appId`. */
+  setHook: (hook: RegisteredNodeGraphicsHook) => void
+  /** Remove an app's hook and every image it produced. */
+  removeAllByAppId: (appId: string) => void
+  /** Remove the anonymous (`window.CyWebApi`) hook and its images. */
+  removeAnonymousHook: () => void
+  /** Merge resolved images for a network. */
+  setImages: (
+    networkId: IdType,
+    entries: Array<[IdType, ResolvedNodeGraphics]>,
+  ) => void
+  /** Drop images for specific nodes, e.g. after they are deleted. */
+  clearImages: (networkId: IdType, nodeIds: IdType[]) => void
+  /** Drop every image and pending refresh for a network. */
+  clearNetwork: (networkId: IdType) => void
+  /** Ask the renderer to re-run the hook. */
+  requestRefresh: (networkId: IdType, nodeIds?: IdType[]) => void
+}
+
+export type NodeGraphicsStoreModel = NodeGraphicsState & NodeGraphicsActions

--- a/src/models/StoreModel/NodeGraphicsStoreModel.ts
+++ b/src/models/StoreModel/NodeGraphicsStoreModel.ts
@@ -53,13 +53,23 @@ export interface NodeGraphicsImage {
   /**
    * An `http(s)://` URL, a `data:` URI, or raw `<svg>` markup. `blob:` and
    * `file:` are rejected — blob URLs are dead by the time a style reapplies.
+   *
+   * Must be the bare URI. Values copied out of another tool's column may carry a
+   * namespace prefix — STRING's `stringdb::STRING style` is
+   * `string:data:image/png;base64,…` — which reads as an unrecognised scheme and
+   * is discarded. Strip the prefix before returning.
    */
   readonly image: string
   /** Default `'contain'`. */
   readonly fit?: NodeGraphicsFit
   /** 0..1. Default 1. */
   readonly opacity?: number
-  /** Default `'null'`. */
+  /**
+   * Default `'null'`, which loads from hosts that send no CORS header at the cost
+   * of tainting the canvas — Cytoscape then omits the image from PNG export.
+   * `'anonymous'` keeps export working but fails outright on such a host, so
+   * preflight a new remote source under both modes.
+   */
   readonly crossOrigin?: NodeGraphicsCrossOrigin
   /** Default `'inside'`. */
   readonly containment?: NodeGraphicsContainment

--- a/src/models/TableModel/impl/tableDiff.test.ts
+++ b/src/models/TableModel/impl/tableDiff.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import { IdType } from '../../IdType'
+import { Table } from '../Table'
+import { ValueType } from '../ValueType'
+import { detectChangedRowIds, detectRowDelta } from './tableDiff'
+
+/**
+ * Minimal Table stand-in. Only `rows` participates in row diffing, so the
+ * column metadata is left empty on purpose — building real tables here would
+ * couple these tests to InMemoryTable's construction rules for no benefit.
+ */
+const tableOf = (rows: Array<[IdType, Record<string, ValueType>]>): Table =>
+  ({
+    id: 'test-table',
+    columns: [],
+    rows: new Map(rows),
+  }) as unknown as Table
+
+describe('detectRowDelta', () => {
+  it('reports nothing when both snapshots share every row object', () => {
+    const shared = { name: 'a' }
+    const prev = tableOf([['n1', shared]])
+    const curr = tableOf([['n1', shared]])
+
+    expect(detectRowDelta(curr, prev)).toEqual({ changed: [], removed: [] })
+  })
+
+  it('reports a mutated row as changed, not removed', () => {
+    const prev = tableOf([['n1', { score: 1.2 }]])
+    const curr = tableOf([['n1', { score: 3.4 }]])
+
+    expect(detectRowDelta(curr, prev)).toEqual({
+      changed: ['n1'],
+      removed: [],
+    })
+  })
+
+  it('reports an added row as changed', () => {
+    const shared = { score: 1 }
+    const prev = tableOf([['n1', shared]])
+    const curr = tableOf([
+      ['n1', shared],
+      ['n2', { score: 2 }],
+    ])
+
+    expect(detectRowDelta(curr, prev)).toEqual({
+      changed: ['n2'],
+      removed: [],
+    })
+  })
+
+  it('separates a removed row from mutated ones', () => {
+    const untouched = { score: 1 }
+    const prev = tableOf([
+      ['n1', untouched],
+      ['n2', { score: 2 }],
+      ['n3', { score: 3 }],
+    ])
+    const curr = tableOf([
+      ['n1', untouched],
+      ['n2', { score: 99 }],
+    ])
+
+    expect(detectRowDelta(curr, prev)).toEqual({
+      changed: ['n2'],
+      removed: ['n3'],
+    })
+  })
+
+  it('treats an equal-by-value but distinct row object as changed', () => {
+    // This is the whole reason column operations fan out to every row:
+    // InMemoryTable clones each row, so identity changes even when values do not.
+    const prev = tableOf([['n1', { score: 1 }]])
+    const curr = tableOf([['n1', { score: 1 }]])
+
+    expect(detectRowDelta(curr, prev).changed).toEqual(['n1'])
+  })
+
+  it('reports every row as changed when all row objects are rebuilt', () => {
+    const prev = tableOf([
+      ['n1', { score: 1 }],
+      ['n2', { score: 2 }],
+      ['n3', { score: 3 }],
+    ])
+    const curr = tableOf([
+      ['n1', { score: 1, extra: '' }],
+      ['n2', { score: 2, extra: '' }],
+      ['n3', { score: 3, extra: '' }],
+    ])
+
+    expect(detectRowDelta(curr, prev)).toEqual({
+      changed: ['n1', 'n2', 'n3'],
+      removed: [],
+    })
+  })
+
+  it('handles an emptied table', () => {
+    const prev = tableOf([
+      ['n1', { score: 1 }],
+      ['n2', { score: 2 }],
+    ])
+
+    expect(detectRowDelta(tableOf([]), prev)).toEqual({
+      changed: [],
+      removed: ['n1', 'n2'],
+    })
+  })
+
+  it('handles a table populated from empty', () => {
+    const curr = tableOf([['n1', { score: 1 }]])
+
+    expect(detectRowDelta(curr, tableOf([]))).toEqual({
+      changed: ['n1'],
+      removed: [],
+    })
+  })
+})
+
+describe('detectChangedRowIds', () => {
+  it('concatenates changed then removed, preserving the legacy order', () => {
+    const untouched = { score: 1 }
+    const prev = tableOf([
+      ['n1', untouched],
+      ['n2', { score: 2 }],
+      ['n3', { score: 3 }],
+    ])
+    const curr = tableOf([
+      ['n1', untouched],
+      ['n2', { score: 99 }],
+    ])
+
+    expect(detectChangedRowIds(curr, prev)).toEqual(['n2', 'n3'])
+  })
+
+  it('returns an empty array for a schema-only change', () => {
+    const shared = { score: 1 }
+    const prev = tableOf([['n1', shared]])
+    const curr = tableOf([['n1', shared]])
+
+    expect(detectChangedRowIds(curr, prev)).toEqual([])
+  })
+})

--- a/src/models/TableModel/impl/tableDiff.ts
+++ b/src/models/TableModel/impl/tableDiff.ts
@@ -1,0 +1,60 @@
+// src/models/TableModel/impl/tableDiff.ts
+//
+// Row-level diffing between two table snapshots.
+//
+// Extracted from the app-api event bus so the renderer can share it. Two
+// consumers with different needs:
+//   - `initEventBus` wants one flat list of touched row ids (`data:changed`).
+//   - The node-graphics render hook must tell mutated rows from deleted ones:
+//     a mutated row needs the hook re-run, a deleted row needs its image
+//     dropped without calling the hook at all.
+//
+// Diffing is by row-object reference, not by value. `InMemoryTable` clones a
+// row object on every write, so reference inequality is an exact "this row was
+// written" signal — but note that the column-level operations (createColumn,
+// deleteColumn, setColumnName, duplicateColumn, applyValueToElements) rebuild
+// EVERY row object. Callers must expect an N-sized `changed` set from a single
+// column rename and coalesce accordingly.
+
+import { IdType } from '../../IdType'
+import { Table } from '../Table'
+
+export interface RowDelta {
+  /** Rows present in `curr` whose object identity differs from `prev`. */
+  changed: IdType[]
+  /** Rows present in `prev` and absent from `curr`. */
+  removed: IdType[]
+}
+
+/**
+ * Split the difference between two table snapshots into mutated-or-added rows
+ * and removed rows.
+ *
+ * Added rows appear in `changed`: they are present in `curr` and their identity
+ * cannot match a `prev` entry that does not exist.
+ */
+export function detectRowDelta(curr: Table, prev: Table): RowDelta {
+  const changed: IdType[] = []
+  const removed: IdType[] = []
+
+  for (const [id, row] of curr.rows) {
+    if (prev.rows.get(id) !== row) changed.push(id)
+  }
+  for (const id of prev.rows.keys()) {
+    if (!curr.rows.has(id)) removed.push(id)
+  }
+
+  return { changed, removed }
+}
+
+/**
+ * Returns the IDs of rows that were added, deleted, or mutated between two
+ * table snapshots. An empty array indicates a schema-only change.
+ *
+ * Order is significant to existing callers: mutated and added rows first (in
+ * `curr` iteration order), then removed rows.
+ */
+export function detectChangedRowIds(curr: Table, prev: Table): IdType[] {
+  const { changed, removed } = detectRowDelta(curr, prev)
+  return [...changed, ...removed]
+}

--- a/src/models/TableModel/impl/tableDiff.ts
+++ b/src/models/TableModel/impl/tableDiff.ts
@@ -21,9 +21,9 @@ import { Table } from '../Table'
 
 export interface RowDelta {
   /** Rows present in `curr` whose object identity differs from `prev`. */
-  changed: IdType[]
+  readonly changed: readonly IdType[]
   /** Rows present in `prev` and absent from `curr`. */
-  removed: IdType[]
+  readonly removed: readonly IdType[]
 }
 
 /**

--- a/src/models/VisualStyleModel/impl/customGraphicsImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/customGraphicsImpl.test.ts
@@ -1051,9 +1051,16 @@ describe('CustomGraphicsImpl', () => {
         '<circle cx="50" cy="50" r="40" fill="red" /></svg>'
 
       const expectWrapped = (decoded: string) => {
+        // Outer box matches the slot, which keeps Cytoscape's image offset at
+        // zero (no zoom drift).
         expect(decoded).toContain('viewBox="0 0 120 80"')
         expect(decoded).toContain('width="120" height="80"')
-        expect(decoded).toContain('x="20" y="0" width="80" height="80"')
+        // The source scales to fit that box while keeping its own aspect ratio.
+        // It used to be dropped into a min(width, height) square at natural
+        // size, which cropped this 100x100 source inside an 80x80 viewport.
+        expect(decoded).toContain('viewBox="0 0 100 100"')
+        expect(decoded).toContain('width="100%" height="100%"')
+        expect(decoded).toContain('preserveAspectRatio="xMidYMid meet"')
         expect(decoded).toContain(
           '<circle cx="50" cy="50" r="40" fill="red" />',
         )

--- a/src/models/VisualStyleModel/impl/customGraphicsImpl.ts
+++ b/src/models/VisualStyleModel/impl/customGraphicsImpl.ts
@@ -19,6 +19,7 @@ import {
   RingChartPropertiesType,
 } from '../VisualPropertyValue/CustomGraphicsType'
 import { SpecialPropertyName } from './CyjsProperties/CyjsStyleModels/directMappingSelector'
+import { normalizeImageSource, wrapSvgDataUriForSize } from './imageSourceImpl'
 
 export const getCustomGraphicNodeVps = (
   vps: VisualProperty<VisualPropertyValueType>[],
@@ -395,43 +396,16 @@ export const computeImageProperties = (
 
   // A custom graphic can carry raw `<svg>` markup rather than a URL (Desktop-authored
   // values and hand-edited CX2 both do this). Cytoscape.js only accepts a URL for
-  // background-image, so promote the markup to the data URI form the wrapping branch
-  // below already handles.
-  let finalUrl = imageProps.url
-  if (finalUrl.trimStart().startsWith('<svg')) {
-    finalUrl = 'data:image/svg+xml,' + encodeURIComponent(finalUrl.trimStart())
-  }
+  // background-image, so promote the markup to a data URI.
+  //
+  // Stored values are deliberately NOT held to the scheme policy that gates new
+  // input (blob:/file: rejection). Applying it here would silently drop images
+  // from existing networks — a product decision, not a refactor. A non-'url'
+  // classification therefore falls through with the value untouched.
+  const source = normalizeImageSource(imageProps.url)
+  const promotedUrl = source.kind === 'url' ? source.url : imageProps.url
 
-  // For SVG data URIs we wrap the source SVG in an outer SVG sized to the slot's
-  // width/height and centered inside it. This pins the rendered aspect ratio and
-  // works around a Cytoscape.js bug where data-URI background images pick up a zoom
-  // offset. See docs/design/custom-graphics-image/zoom-bug-demo.html for a repro.
-  if (finalUrl.startsWith('data:image/svg+xml')) {
-    try {
-      const commaIdx = finalUrl.indexOf(',')
-      if (commaIdx !== -1) {
-        const metadata = finalUrl.substring(0, commaIdx)
-        const data = finalUrl.substring(commaIdx + 1)
-
-        let rawSvg = ''
-        if (metadata.includes('base64')) {
-          rawSvg = atob(data)
-        } else {
-          rawSvg = decodeURIComponent(data)
-        }
-
-        const size = Math.min(width, height)
-        const offsetX = (width - size) / 2
-        const offsetY = (height - size) / 2
-
-        const wrapperSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"><svg x="${offsetX}" y="${offsetY}" width="${size}" height="${size}">${rawSvg}</svg></svg>`
-
-        finalUrl = 'data:image/svg+xml,' + encodeURIComponent(wrapperSvg)
-      }
-    } catch (e) {
-      logModel.warn('Failed to wrap SVG custom graphic', e)
-    }
-  }
+  const finalUrl = wrapSvgDataUriForSize(promotedUrl, width, height)
 
   pairs.push([SpecialPropertyName.BackgroundImage, finalUrl])
   pairs.push([SpecialPropertyName.BackgroundFit, 'contain'])

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
@@ -107,6 +107,52 @@ describe('normalizeImageSource', () => {
     })
   })
 
+  describe('values that cannot be coerced to a string', () => {
+    // String(value) itself throws for these. The function is documented as
+    // never throwing and runs in the render path, so each must come back as a
+    // rejection instead of breaking the frame. `raw` is empty because there is
+    // no string to report.
+    it.each([
+      ['a null-prototype object', () => Object.create(null) as unknown],
+      [
+        'an object whose toString throws',
+        () =>
+          ({
+            toString() {
+              throw new Error('toString exploded')
+            },
+          }) as unknown,
+      ],
+      [
+        'an object whose Symbol.toPrimitive throws',
+        () =>
+          ({
+            [Symbol.toPrimitive]() {
+              throw new Error('toPrimitive exploded')
+            },
+          }) as unknown,
+      ],
+    ])('rejects %s without throwing', (_label, make) => {
+      const value = make()
+
+      expect(() => normalizeImageSource(value)).not.toThrow()
+      expect(normalizeImageSource(value)).toEqual({
+        kind: 'rejected',
+        reason: 'unrecognized',
+        raw: '',
+      })
+    })
+
+    it('rejects a symbol through the normal unrecognized path', () => {
+      // String(symbol) does not throw — the spec special-cases the explicit
+      // call — so this one reaches the scheme check like any other string.
+      const result = normalizeImageSource(Symbol('nope'))
+
+      expect(result.kind).toBe('rejected')
+      expect(result.kind === 'rejected' && result.reason).toBe('unrecognized')
+    })
+  })
+
   it('never throws on hostile input', () => {
     const hostile = [
       Symbol.iterator.toString(),
@@ -210,6 +256,22 @@ describe('wrapSvgDataUriForSize', () => {
       expect(wrapped).toContain('width="100%" height="100%"')
     })
 
+    it('handles single-quoted dimensions', () => {
+      // Single quotes are legal in SVG. Missing them would leave the source
+      // width in place beside the wrapper's, and two width attributes make the
+      // data URI invalid XML — the image then fails to load entirely.
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent("<svg width='200' height='50'><rect/></svg>")
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 60, 30))
+
+      expect(wrapped).toContain('viewBox="0 0 200 50"')
+      expect(wrapped).not.toContain("width='200'")
+      expect(wrapped).not.toContain("height='50'")
+      expect(wrapped.match(/\swidth=/g)).toHaveLength(2) // wrapper + source root
+    })
+
     it('keeps an existing viewBox rather than deriving one', () => {
       const url =
         'data:image/svg+xml,' +
@@ -233,9 +295,7 @@ describe('wrapSvgDataUriForSize', () => {
       const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 40, 40))
 
       expect(wrapped).not.toContain('preserveAspectRatio="none"')
-      expect(
-        wrapped.match(/preserveAspectRatio=/g),
-      ).toHaveLength(1)
+      expect(wrapped.match(/preserveAspectRatio=/g)).toHaveLength(1)
     })
 
     it('does not corrupt a self-closing source tag', () => {

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  describeImageSourceRejection,
+  normalizeImageSource,
+  wrapSvgDataUriForSize,
+} from './imageSourceImpl'
+
+describe('normalizeImageSource', () => {
+  describe('rejected schemes', () => {
+    it('rejects blob: URLs because they are ephemeral', () => {
+      const result = normalizeImageSource('blob:http://localhost/abc-123')
+
+      expect(result).toEqual({
+        kind: 'rejected',
+        reason: 'blob',
+        raw: 'blob:http://localhost/abc-123',
+      })
+    })
+
+    it('rejects file: URLs', () => {
+      const result = normalizeImageSource('file:///Users/me/pic.png')
+
+      expect(result.kind).toBe('rejected')
+      expect(result.kind === 'rejected' && result.reason).toBe('file')
+    })
+
+    it('rejects a scheme it does not recognize', () => {
+      const result = normalizeImageSource('ftp://example.com/pic.png')
+
+      expect(result.kind).toBe('rejected')
+      expect(result.kind === 'rejected' && result.reason).toBe('unrecognized')
+    })
+
+    it('rejects a bare filename', () => {
+      const result = normalizeImageSource('pic.png')
+
+      expect(result.kind === 'rejected' && result.reason).toBe('unrecognized')
+    })
+  })
+
+  describe('empty input', () => {
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['whitespace only', '   \n\t  '],
+    ])('rejects %s as empty', (_label, value) => {
+      const result = normalizeImageSource(value)
+
+      expect(result).toEqual({ kind: 'rejected', reason: 'empty', raw: '' })
+    })
+  })
+
+  describe('accepted URLs', () => {
+    it.each([
+      ['http', 'http://example.com/pic.png'],
+      ['https', 'https://example.com/pic.png'],
+      ['data URI', 'data:image/png;base64,iVBORw0KGgo='],
+      ['svg data URI', 'data:image/svg+xml,%3Csvg%2F%3E'],
+    ])('accepts a %s URL unchanged', (_label, url) => {
+      expect(normalizeImageSource(url)).toEqual({ kind: 'url', url })
+    })
+
+    it('trims surrounding whitespace', () => {
+      expect(normalizeImageSource('  https://example.com/a.png \n')).toEqual({
+        kind: 'url',
+        url: 'https://example.com/a.png',
+      })
+    })
+  })
+
+  describe('raw SVG markup', () => {
+    it('promotes raw markup to a percent-encoded data URI', () => {
+      const svg =
+        '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>'
+
+      const result = normalizeImageSource(svg)
+
+      expect(result.kind).toBe('url')
+      expect(result.kind === 'url' && result.url).toBe(
+        'data:image/svg+xml,' + encodeURIComponent(svg),
+      )
+    })
+
+    it('promotes markup that has leading whitespace', () => {
+      const result = normalizeImageSource('   <svg><rect/></svg>')
+
+      expect(result.kind === 'url' && result.url).toBe(
+        'data:image/svg+xml,' + encodeURIComponent('<svg><rect/></svg>'),
+      )
+    })
+  })
+
+  describe('JSON objects', () => {
+    it('classifies an object-looking string as json without parsing it', () => {
+      const raw = '{"cy_dataColumns":["a"],"cy_colors":["#f00"]}'
+
+      expect(normalizeImageSource(raw)).toEqual({ kind: 'json', raw })
+    })
+
+    it('classifies malformed JSON as json and leaves parsing to the caller', () => {
+      expect(normalizeImageSource('{not valid json')).toEqual({
+        kind: 'json',
+        raw: '{not valid json',
+      })
+    })
+  })
+
+  it('never throws on hostile input', () => {
+    const hostile = [
+      Symbol.iterator.toString(),
+      '{'.repeat(10000),
+      '<svg'.repeat(1000),
+      42,
+      true,
+      [],
+      {},
+    ]
+
+    for (const value of hostile) {
+      expect(() => normalizeImageSource(value)).not.toThrow()
+    }
+  })
+})
+
+describe('describeImageSourceRejection', () => {
+  it.each(['blob', 'file', 'empty', 'unrecognized'] as const)(
+    'returns a non-empty message for %s',
+    (reason) => {
+      expect(describeImageSourceRejection(reason).length).toBeGreaterThan(0)
+    },
+  )
+})
+
+describe('wrapSvgDataUriForSize', () => {
+  const decodeWrapper = (url: string): string =>
+    decodeURIComponent(url.substring('data:image/svg+xml,'.length))
+
+  it('leaves a non-SVG URL untouched', () => {
+    const url = 'https://example.com/pic.png'
+
+    expect(wrapSvgDataUriForSize(url, 40, 40)).toBe(url)
+  })
+
+  it('leaves a raster data URI untouched', () => {
+    const url = 'data:image/png;base64,iVBORw0KGgo='
+
+    expect(wrapSvgDataUriForSize(url, 40, 40)).toBe(url)
+  })
+
+  it('wraps a percent-encoded SVG in an outer SVG at the given size', () => {
+    const inner = '<svg><circle r="5"/></svg>'
+    const url = 'data:image/svg+xml,' + encodeURIComponent(inner)
+
+    const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 60, 40))
+
+    expect(wrapped).toContain('viewBox="0 0 60 40"')
+    expect(wrapped).toContain('width="60" height="40"')
+    expect(wrapped).toContain(inner)
+  })
+
+  it('unwraps a base64 SVG data URI before wrapping', () => {
+    const inner = '<svg><rect width="1" height="1"/></svg>'
+    const url = 'data:image/svg+xml;base64,' + btoa(inner)
+
+    const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 30, 30))
+
+    expect(wrapped).toContain(inner)
+  })
+
+  it('centers the inner SVG on the shorter axis', () => {
+    const url = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
+
+    // size = min(100, 40) = 40; offsetX = (100-40)/2 = 30; offsetY = 0
+    const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40))
+
+    expect(wrapped).toContain('x="30" y="0" width="40" height="40"')
+  })
+
+  it('returns the input unchanged when the data URI has no comma', () => {
+    const url = 'data:image/svg+xml'
+
+    expect(wrapSvgDataUriForSize(url, 40, 40)).toBe(url)
+  })
+
+  it('returns the input unchanged when base64 decoding fails', () => {
+    const url = 'data:image/svg+xml;base64,!!!not-base64!!!'
+
+    expect(wrapSvgDataUriForSize(url, 40, 40)).toBe(url)
+  })
+
+  it('returns the input unchanged when percent-decoding fails', () => {
+    const url = 'data:image/svg+xml,%E0%A4%A'
+
+    expect(wrapSvgDataUriForSize(url, 40, 40)).toBe(url)
+  })
+})

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
@@ -272,6 +272,26 @@ describe('wrapSvgDataUriForSize', () => {
       expect(wrapped.match(/\swidth=/g)).toHaveLength(2) // wrapper + source root
     })
 
+    it('keeps a quoted ">" inside a root attribute intact', () => {
+      // `>` is legal inside a quoted attribute value. A matcher that stops at
+      // the first `>` ends the opening tag mid-value, so the wrapper's own
+      // width/height land inside the label and the source dimensions survive
+      // beside them — two width attributes, invalid XML, no image at all.
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent(
+          '<svg aria-label="a > b" width="200" height="50"><rect/></svg>',
+        )
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 60, 30))
+
+      expect(wrapped).toContain('aria-label="a > b"')
+      expect(wrapped).toContain('viewBox="0 0 200 50"')
+      expect(wrapped).not.toContain('width="200"')
+      expect(wrapped).not.toContain('height="50"')
+      expect(wrapped.match(/\swidth=/g)).toHaveLength(2) // wrapper + source root
+    })
+
     it('keeps an existing viewBox rather than deriving one', () => {
       const url =
         'data:image/svg+xml,' +

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
@@ -149,15 +149,25 @@ describe('wrapSvgDataUriForSize', () => {
     expect(wrapSvgDataUriForSize(url, 40, 40)).toBe(url)
   })
 
-  it('wraps a percent-encoded SVG in an outer SVG at the given size', () => {
-    const inner = '<svg><circle r="5"/></svg>'
-    const url = 'data:image/svg+xml,' + encodeURIComponent(inner)
+  it('wraps in an outer SVG matching the node box', () => {
+    // The outer box must equal the node box, or Cytoscape's image offset stops
+    // being zero and the graphic drifts as the canvas zooms.
+    const url =
+      'data:image/svg+xml,' + encodeURIComponent('<svg><circle r="5"/></svg>')
 
     const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 60, 40))
 
     expect(wrapped).toContain('viewBox="0 0 60 40"')
     expect(wrapped).toContain('width="60" height="40"')
-    expect(wrapped).toContain(inner)
+  })
+
+  it('keeps the source content', () => {
+    const url =
+      'data:image/svg+xml,' + encodeURIComponent('<svg><circle r="5"/></svg>')
+
+    expect(decodeWrapper(wrapSvgDataUriForSize(url, 60, 40))).toContain(
+      '<circle r="5"/>',
+    )
   })
 
   it('unwraps a base64 SVG data URI before wrapping', () => {
@@ -166,16 +176,76 @@ describe('wrapSvgDataUriForSize', () => {
 
     const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 30, 30))
 
-    expect(wrapped).toContain(inner)
+    expect(wrapped).toContain('<rect width="1" height="1"/>')
   })
 
-  it('centers the inner SVG on the shorter axis', () => {
-    const url = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
+  describe('aspect ratio', () => {
+    // Verified in real Cytoscape: the previous min(width, height) square inner
+    // viewport confined a wide graphic to the short axis, and rendered a source
+    // with intrinsic dimensions at natural size — which cropped it and left the
+    // visible remnant drifting off-centre as the canvas zoomed.
+    it('lets the source fill the box while preserving its own ratio', () => {
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg viewBox="0 0 200 50"><rect/></svg>')
 
-    // size = min(100, 40) = 40; offsetX = (100-40)/2 = 30; offsetY = 0
-    const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40))
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40))
 
-    expect(wrapped).toContain('x="30" y="0" width="40" height="40"')
+      expect(wrapped).toContain('width="100%" height="100%"')
+      expect(wrapped).toContain('preserveAspectRatio="xMidYMid meet"')
+      // No min(width, height) square viewport any more.
+      expect(wrapped).not.toContain('width="40" height="40"')
+    })
+
+    it('derives a viewBox for a source that has dimensions but none', () => {
+      // Stripping width/height without adding a viewBox would leave the source
+      // with no scalable coordinate system, so it would render at 1:1 and crop.
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg width="100" height="100"><rect/></svg>')
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 60, 30))
+
+      expect(wrapped).toContain('viewBox="0 0 100 100"')
+      expect(wrapped).toContain('width="100%" height="100%"')
+    })
+
+    it('keeps an existing viewBox rather than deriving one', () => {
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent(
+          '<svg width="200" height="50" viewBox="0 0 400 100"><rect/></svg>',
+        )
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 60, 30))
+
+      expect(wrapped).toContain('viewBox="0 0 400 100"')
+      expect(wrapped).not.toContain('viewBox="0 0 200 50"')
+    })
+
+    it('replaces a source preserveAspectRatio rather than duplicating it', () => {
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent(
+          '<svg viewBox="0 0 10 10" preserveAspectRatio="none"><rect/></svg>',
+        )
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 40, 40))
+
+      expect(wrapped).not.toContain('preserveAspectRatio="none"')
+      expect(
+        wrapped.match(/preserveAspectRatio=/g),
+      ).toHaveLength(1)
+    })
+
+    it('does not corrupt a self-closing source tag', () => {
+      const url = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40))
+
+      expect(wrapped).toContain('preserveAspectRatio="xMidYMid meet"/>')
+      expect(wrapped).not.toContain('/ width')
+    })
   })
 
   it('returns the input unchanged when the data URI has no comma', () => {

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.test.ts
@@ -298,6 +298,63 @@ describe('wrapSvgDataUriForSize', () => {
       expect(wrapped.match(/preserveAspectRatio=/g)).toHaveLength(1)
     })
 
+    it('slices the source to fill the box for fit cover', () => {
+      // The wrapper hands Cytoscape a node-sized image, so background-fit has
+      // nothing left to do — cover has to happen here or not at all.
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg viewBox="0 0 200 50"><rect/></svg>')
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40, 'cover'))
+
+      expect(wrapped).toContain('preserveAspectRatio="xMidYMid slice"')
+      expect(wrapped).toContain('width="100%" height="100%"')
+    })
+
+    it('centres the source at its natural size for fit none', () => {
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg width="20" height="10"><rect/></svg>')
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40, 'none'))
+
+      expect(wrapped).toContain('x="40" y="15" width="20" height="10"')
+      expect(wrapped).not.toContain('width="100%"')
+    })
+
+    it('falls back to meet for fit none when the source has no size', () => {
+      // A viewBox alone gives no natural size to honour.
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg viewBox="0 0 20 10"><rect/></svg>')
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40, 'none'))
+
+      expect(wrapped).toContain('width="100%" height="100%"')
+      expect(wrapped).toContain('preserveAspectRatio="xMidYMid meet"')
+    })
+
+    it('does not duplicate a source x or y attribute', () => {
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg x="5" y="5" width="20" height="10"/>')
+
+      const wrapped = decodeWrapper(wrapSvgDataUriForSize(url, 100, 40, 'none'))
+
+      expect(wrapped.match(/\sx=/g)).toHaveLength(1)
+      expect(wrapped.match(/\sy=/g)).toHaveLength(1)
+    })
+
+    it('defaults to contain when no fit is given', () => {
+      const url =
+        'data:image/svg+xml,' +
+        encodeURIComponent('<svg viewBox="0 0 200 50"><rect/></svg>')
+
+      expect(decodeWrapper(wrapSvgDataUriForSize(url, 100, 40))).toContain(
+        'preserveAspectRatio="xMidYMid meet"',
+      )
+    })
+
     it('does not corrupt a self-closing source tag', () => {
       const url = 'data:image/svg+xml,' + encodeURIComponent('<svg/>')
 

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.ts
@@ -165,7 +165,10 @@ const fitSourceToViewport = (
   fit: ImageFit,
 ): string =>
   rawSvg.replace(
-    /<svg\b([^>]*?)(\/?)>/,
+    // Quote-aware: a `>` inside a quoted attribute value (`aria-label="a > b"`)
+    // is legal SVG, and `[^>]*` would end the opening tag there — the wrapper
+    // would then inject its attributes into the middle of the value.
+    /<svg\b((?:"[^"]*"|'[^']*'|[^>"'])*?)(\/?)>/,
     (whole: string, attrs: string, selfClose: string) => {
       const width = readLength(readRootAttr(attrs, 'width'))
       const height = readLength(readRootAttr(attrs, 'height'))

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.ts
@@ -1,0 +1,141 @@
+// src/models/VisualStyleModel/impl/imageSourceImpl.ts
+//
+// One image-source policy, shared by every path that turns an external string
+// into a Cytoscape.js `background-image` value.
+//
+// Three callers, historically with three copies of this logic:
+//   1. `customGraphicPassthroughFn` (mapperFactory.ts) — a table column value
+//      passed through to a custom-graphics slot.
+//   2. `computeImageProperties` (customGraphicsImpl.ts) — a stored
+//      `ImagePropertiesType.url` on its way to the renderer.
+//   3. `nodeGraphicsApi` — an app render hook's return value.
+//
+// Keeping the policy here means an app hook cannot smuggle in a scheme the
+// Vizmapper path rejects, and a fix to the SVG wrapping benefits all three.
+
+import { logModel } from '../../../debug'
+
+/** Why an image source was refused. Callers decide how loudly to report it. */
+export type ImageSourceRejection = 'empty' | 'blob' | 'file' | 'unrecognized'
+
+export type ImageSourceResult =
+  /** Usable directly as a Cytoscape.js `background-image` value. */
+  | { readonly kind: 'url'; readonly url: string }
+  /** Looks like a JSON object. Only the chart callers care; others reject it. */
+  | { readonly kind: 'json'; readonly raw: string }
+  | {
+      readonly kind: 'rejected'
+      readonly reason: ImageSourceRejection
+      /** Trimmed input, for log messages. Empty when the input was blank. */
+      readonly raw: string
+    }
+
+/**
+ * Classify an external image source string against the shared policy.
+ *
+ * Accepts `http(s)://` URLs, `data:` URIs, and raw `<svg>` markup (promoted to
+ * a `data:image/svg+xml` URI, because Cytoscape.js only takes a URL).
+ *
+ * Rejects `blob:` (ephemeral — dead by the time the style reapplies) and
+ * `file:` (unreadable from the page). Anything else is `unrecognized`.
+ *
+ * Pure: never logs, never throws. Callers own the reporting.
+ */
+export const normalizeImageSource = (value: unknown): ImageSourceResult => {
+  if (value == null || value === '') {
+    return { kind: 'rejected', reason: 'empty', raw: '' }
+  }
+
+  const raw = String(value).trim()
+  if (raw === '') {
+    return { kind: 'rejected', reason: 'empty', raw: '' }
+  }
+
+  if (raw.startsWith('blob:')) {
+    return { kind: 'rejected', reason: 'blob', raw }
+  }
+  if (raw.startsWith('file:')) {
+    return { kind: 'rejected', reason: 'file', raw }
+  }
+
+  // Raw markup → the data URI form that wrapSvgDataUriForSize can size.
+  if (raw.startsWith('<svg')) {
+    return { kind: 'url', url: 'data:image/svg+xml,' + encodeURIComponent(raw) }
+  }
+
+  if (
+    raw.startsWith('http://') ||
+    raw.startsWith('https://') ||
+    raw.startsWith('data:')
+  ) {
+    return { kind: 'url', url: raw }
+  }
+
+  if (raw.startsWith('{')) {
+    return { kind: 'json', raw }
+  }
+
+  return { kind: 'rejected', reason: 'unrecognized', raw }
+}
+
+/** Human-readable reason, for a caller's warn message. */
+export const describeImageSourceRejection = (
+  reason: ImageSourceRejection,
+): string => {
+  switch (reason) {
+    case 'blob':
+      return 'Blob URLs are ephemeral and cannot be used for custom graphics'
+    case 'file':
+      return 'Local file URLs are not supported for custom graphics'
+    case 'empty':
+      return 'Image source is empty'
+    default:
+      return 'Unrecognized image source'
+  }
+}
+
+/**
+ * Wrap an SVG data URI in an outer SVG sized to `width` x `height`, with the
+ * source SVG centered inside it.
+ *
+ * This pins the rendered aspect ratio and works around a Cytoscape.js bug where
+ * data-URI background images pick up a zoom offset. See
+ * docs/design/custom-graphics-image/zoom-bug-demo.html for a repro.
+ *
+ * Non-SVG URLs pass through untouched. On any decode failure the input is
+ * returned unchanged, so a malformed URI degrades to "unsized" rather than
+ * "no image".
+ */
+export const wrapSvgDataUriForSize = (
+  url: string,
+  width: number,
+  height: number,
+): string => {
+  if (!url.startsWith('data:image/svg+xml')) {
+    return url
+  }
+
+  try {
+    const commaIdx = url.indexOf(',')
+    if (commaIdx === -1) {
+      return url
+    }
+
+    const metadata = url.substring(0, commaIdx)
+    const data = url.substring(commaIdx + 1)
+    const rawSvg = metadata.includes('base64')
+      ? atob(data)
+      : decodeURIComponent(data)
+
+    const size = Math.min(width, height)
+    const offsetX = (width - size) / 2
+    const offsetY = (height - size) / 2
+
+    const wrapperSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"><svg x="${offsetX}" y="${offsetY}" width="${size}" height="${size}">${rawSvg}</svg></svg>`
+
+    return 'data:image/svg+xml,' + encodeURIComponent(wrapperSvg)
+  } catch (e) {
+    logModel.warn('Failed to wrap SVG custom graphic', e)
+    return url
+  }
+}

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.ts
@@ -94,13 +94,61 @@ export const describeImageSourceRejection = (
   }
 }
 
+/** Leading number of an SVG length attribute (`"100"`, `"100px"`). */
+const readLength = (value: string | undefined): number | undefined => {
+  if (value === undefined) return undefined
+  const match = /^\s*([\d.]+)/.exec(value)
+  if (match === null) return undefined
+  const parsed = parseFloat(match[1])
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+/**
+ * Rewrite the source root `<svg>` so it fills its parent viewport while keeping
+ * its own aspect ratio.
+ *
+ * Without this the source renders at its natural size inside the wrapper, which
+ * crops anything larger than the node — measurably so: a 100x100 source in a
+ * 140x60 node lost its centre entirely, and the visible remnant drifted further
+ * off-centre the more the canvas was zoomed.
+ *
+ * A source carrying `width`/`height` but no `viewBox` has no scalable coordinate
+ * system, so one is derived from those dimensions before they are replaced.
+ */
+const fitSourceToViewport = (rawSvg: string): string =>
+  rawSvg.replace(
+    /<svg\b([^>]*?)(\/?)>/,
+    (whole: string, attrs: string, selfClose: string) => {
+      const width = readLength(/\bwidth="([^"]*)"/.exec(attrs)?.[1])
+      const height = readLength(/\bheight="([^"]*)"/.exec(attrs)?.[1])
+
+      let next = attrs
+      if (
+        !/\bviewBox=/.test(next) &&
+        width !== undefined &&
+        height !== undefined
+      ) {
+        next += ` viewBox="0 0 ${width} ${height}"`
+      }
+      next = next.replace(
+        /\s(width|height|preserveAspectRatio)="[^"]*"/g,
+        '',
+      )
+
+      return `<svg${next} width="100%" height="100%" preserveAspectRatio="xMidYMid meet"${selfClose}>`
+    },
+  )
+
 /**
  * Wrap an SVG data URI in an outer SVG sized to `width` x `height`, with the
- * source SVG centered inside it.
+ * source scaled to fit inside it and centered.
  *
- * This pins the rendered aspect ratio and works around a Cytoscape.js bug where
- * data-URI background images pick up a zoom offset. See
- * docs/design/custom-graphics-image/zoom-bug-demo.html for a repro.
+ * The outer box must match the node box: that is what keeps Cytoscape's image
+ * offset at zero and avoids a canvas bug where a background image whose bounding
+ * box is smaller than the node drifts off its anchor as the view zooms. See
+ * docs/design/custom-graphics-image/zoom-bug-demo.html for a repro. Within that
+ * box the source keeps its own aspect ratio, so a wide graphic uses the node's
+ * full width instead of being confined to a min(width, height) square.
  *
  * Non-SVG URLs pass through untouched. On any decode failure the input is
  * returned unchanged, so a malformed URI degrades to "unsized" rather than
@@ -127,11 +175,7 @@ export const wrapSvgDataUriForSize = (
       ? atob(data)
       : decodeURIComponent(data)
 
-    const size = Math.min(width, height)
-    const offsetX = (width - size) / 2
-    const offsetY = (height - size) / 2
-
-    const wrapperSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"><svg x="${offsetX}" y="${offsetY}" width="${size}" height="${size}">${rawSvg}</svg></svg>`
+    const wrapperSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">${fitSourceToViewport(rawSvg)}</svg>`
 
     return 'data:image/svg+xml,' + encodeURIComponent(wrapperSvg)
   } catch (e) {

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.ts
@@ -131,21 +131,39 @@ const readRootAttr = (attrs: string, name: string): string | undefined => {
 
 /** The attributes the wrapper reasserts, in either quote style. */
 const ROOT_ATTRS_TO_REPLACE =
-  /\s(?:width|height|preserveAspectRatio)\s*=\s*(?:"[^"]*"|'[^']*')/g
+  /\s(?:width|height|preserveAspectRatio|x|y)\s*=\s*(?:"[^"]*"|'[^']*')/g
 
 /**
- * Rewrite the source root `<svg>` so it fills its parent viewport while keeping
- * its own aspect ratio.
+ * How the source fills the node box. Mirrors Cytoscape.js `background-fit`, so
+ * `NodeGraphicsFit` and the Vizmapper fit values both satisfy it.
+ */
+export type ImageFit = 'contain' | 'cover' | 'none'
+
+/**
+ * Rewrite the source root `<svg>` so it fills its parent viewport as `fit` asks.
  *
  * Without this the source renders at its natural size inside the wrapper, which
  * crops anything larger than the node — measurably so: a 100x100 source in a
  * 140x60 node lost its centre entirely, and the visible remnant drifted further
  * off-centre the more the canvas was zoomed.
  *
+ * The fit is applied here, not by Cytoscape: the wrapper hands it an image
+ * already exactly the node's size, so `background-fit` has nothing left to do.
+ *   - `contain` → `meet`, the whole source visible inside the box.
+ *   - `cover` → `slice`, the box filled and the overflow clipped.
+ *   - `none` → the source at its own size, centred, when it declares one;
+ *     `meet` otherwise, because a source with only a `viewBox` has no natural
+ *     size to honour.
+ *
  * A source carrying `width`/`height` but no `viewBox` has no scalable coordinate
  * system, so one is derived from those dimensions before they are replaced.
  */
-const fitSourceToViewport = (rawSvg: string): string =>
+const fitSourceToViewport = (
+  rawSvg: string,
+  boxWidth: number,
+  boxHeight: number,
+  fit: ImageFit,
+): string =>
   rawSvg.replace(
     /<svg\b([^>]*?)(\/?)>/,
     (whole: string, attrs: string, selfClose: string) => {
@@ -162,7 +180,14 @@ const fitSourceToViewport = (rawSvg: string): string =>
       }
       next = next.replace(ROOT_ATTRS_TO_REPLACE, '')
 
-      return `<svg${next} width="100%" height="100%" preserveAspectRatio="xMidYMid meet"${selfClose}>`
+      if (fit === 'none' && width !== undefined && height !== undefined) {
+        const x = (boxWidth - width) / 2
+        const y = (boxHeight - height) / 2
+        return `<svg${next} x="${x}" y="${y}" width="${width}" height="${height}" preserveAspectRatio="xMidYMid meet"${selfClose}>`
+      }
+
+      const aspect = fit === 'cover' ? 'xMidYMid slice' : 'xMidYMid meet'
+      return `<svg${next} width="100%" height="100%" preserveAspectRatio="${aspect}"${selfClose}>`
     },
   )
 
@@ -174,8 +199,13 @@ const fitSourceToViewport = (rawSvg: string): string =>
  * offset at zero and avoids a canvas bug where a background image whose bounding
  * box is smaller than the node drifts off its anchor as the view zooms. See
  * docs/design/custom-graphics-image/zoom-bug-demo.html for a repro. Within that
- * box the source keeps its own aspect ratio, so a wide graphic uses the node's
- * full width instead of being confined to a min(width, height) square.
+ * box the source is laid out per `fit`, which defaults to `'contain'`: it keeps
+ * its own aspect ratio, so a wide graphic uses the node's full width instead of
+ * being confined to a min(width, height) square.
+ *
+ * `fit` must be applied here rather than left to Cytoscape's `background-fit`:
+ * the returned image is already exactly the node box, so every Cytoscape fit
+ * mode would be a no-op on it.
  *
  * Non-SVG URLs pass through untouched. On any decode failure the input is
  * returned unchanged, so a malformed URI degrades to "unsized" rather than
@@ -185,6 +215,7 @@ export const wrapSvgDataUriForSize = (
   url: string,
   width: number,
   height: number,
+  fit: ImageFit = 'contain',
 ): string => {
   if (!url.startsWith('data:image/svg+xml')) {
     return url
@@ -202,7 +233,7 @@ export const wrapSvgDataUriForSize = (
       ? atob(data)
       : decodeURIComponent(data)
 
-    const wrapperSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">${fitSourceToViewport(rawSvg)}</svg>`
+    const wrapperSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">${fitSourceToViewport(rawSvg, width, height, fit)}</svg>`
 
     return 'data:image/svg+xml,' + encodeURIComponent(wrapperSvg)
   } catch (e) {

--- a/src/models/VisualStyleModel/impl/imageSourceImpl.ts
+++ b/src/models/VisualStyleModel/impl/imageSourceImpl.ts
@@ -46,7 +46,16 @@ export const normalizeImageSource = (value: unknown): ImageSourceResult => {
     return { kind: 'rejected', reason: 'empty', raw: '' }
   }
 
-  const raw = String(value).trim()
+  let raw: string
+  try {
+    raw = String(value).trim()
+  } catch {
+    // String() throws on a symbol, and on an object whose Symbol.toPrimitive or
+    // toString throws or is absent (Object.create(null)). A hook returning one
+    // of those must degrade like any other unusable value, because this runs in
+    // the render path where a throw would break the frame.
+    return { kind: 'rejected', reason: 'unrecognized', raw: '' }
+  }
   if (raw === '') {
     return { kind: 'rejected', reason: 'empty', raw: '' }
   }
@@ -104,6 +113,27 @@ const readLength = (value: string | undefined): number | undefined => {
 }
 
 /**
+ * Read one root attribute, accepting either quote style.
+ *
+ * Single quotes are legal in SVG, so a source written `width='100'` must be
+ * found here — otherwise the cleanup below leaves it in place and the wrapper
+ * emits two `width` attributes, which is invalid XML and fails to load at all.
+ *
+ * Case-sensitive on purpose: SVG attribute names are, so `WIDTH` is not a width.
+ */
+const readRootAttr = (attrs: string, name: string): string | undefined => {
+  const match = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`).exec(
+    attrs,
+  )
+  if (match === null) return undefined
+  return match[1] ?? match[2]
+}
+
+/** The attributes the wrapper reasserts, in either quote style. */
+const ROOT_ATTRS_TO_REPLACE =
+  /\s(?:width|height|preserveAspectRatio)\s*=\s*(?:"[^"]*"|'[^']*')/g
+
+/**
  * Rewrite the source root `<svg>` so it fills its parent viewport while keeping
  * its own aspect ratio.
  *
@@ -119,21 +149,18 @@ const fitSourceToViewport = (rawSvg: string): string =>
   rawSvg.replace(
     /<svg\b([^>]*?)(\/?)>/,
     (whole: string, attrs: string, selfClose: string) => {
-      const width = readLength(/\bwidth="([^"]*)"/.exec(attrs)?.[1])
-      const height = readLength(/\bheight="([^"]*)"/.exec(attrs)?.[1])
+      const width = readLength(readRootAttr(attrs, 'width'))
+      const height = readLength(readRootAttr(attrs, 'height'))
 
       let next = attrs
       if (
-        !/\bviewBox=/.test(next) &&
+        !/\bviewBox\s*=/.test(next) &&
         width !== undefined &&
         height !== undefined
       ) {
         next += ` viewBox="0 0 ${width} ${height}"`
       }
-      next = next.replace(
-        /\s(width|height|preserveAspectRatio)="[^"]*"/g,
-        '',
-      )
+      next = next.replace(ROOT_ATTRS_TO_REPLACE, '')
 
       return `<svg${next} width="100%" height="100%" preserveAspectRatio="xMidYMid meet"${selfClose}>`
     },

--- a/src/models/VisualStyleModel/impl/mapperFactory.ts
+++ b/src/models/VisualStyleModel/impl/mapperFactory.ts
@@ -21,6 +21,10 @@ import {
 // import * as d3Color from 'd3-color'
 import { VisualPropertyValueTypeName } from '../VisualPropertyValueTypeName'
 import { normalizeEnumValue } from './enumValueNormalization'
+import {
+  describeImageSourceRejection,
+  normalizeImageSource,
+} from './imageSourceImpl'
 
 const enumTypes: Set<VisualPropertyValueTypeName> = new Set([
   VisualPropertyValueTypeName.NodeShape,
@@ -71,68 +75,49 @@ const customGraphicPassthroughFn = (
   pm: PassthroughMappingFunction,
   value: VisualPropertyValueType,
 ): VisualPropertyValueType => {
-  if (value == null || value === '') {
-    return pm.defaultValue
-  }
+  // Scheme policy and raw-<svg> promotion are shared with the renderer and the
+  // app render-hook API — see imageSourceImpl.ts.
+  const source = normalizeImageSource(value)
 
-  const str = String(value).trim()
+  switch (source.kind) {
+    // Image (raster or vector, class chosen by content so it round-trips to Desktop)
+    case 'url':
+      return makeImageGraphics(source.url)
 
-  // 1. Reject file: and blob: URLs
-  if (str.startsWith('blob:')) {
-    logUi.warn(
-      'Blob URLs are ephemeral and cannot be used for custom graphics:',
-      str.substring(0, 80),
-    )
-    return pm.defaultValue
-  }
-  if (str.startsWith('file:')) {
-    logUi.warn(
-      'Local file URLs are not supported for custom graphics:',
-      str.substring(0, 80),
-    )
-    return pm.defaultValue
-  }
-
-  // 2. Raw SVG detection → inline data URI
-  if (str.startsWith('<svg')) {
-    const dataUri = 'data:image/svg+xml,' + encodeURIComponent(str)
-    return makeImageGraphics(dataUri)
-  }
-
-  // 3. HTTP/HTTPS URL or data: URI → image (raster or vector, chosen by content)
-  if (
-    str.startsWith('http://') ||
-    str.startsWith('https://') ||
-    str.startsWith('data:')
-  ) {
-    return makeImageGraphics(str)
-  }
-
-  // 4. JSON chart object
-  if (str.startsWith('{')) {
-    try {
-      const parsed = JSON.parse(str)
-      // Distinguish chart types by checking for chart-specific fields
-      if (
-        Array.isArray(parsed.cy_dataColumns) &&
-        Array.isArray(parsed.cy_colors)
-      ) {
-        const isRing = parsed.cy_holeSize !== undefined
-        return {
-          type: CustomGraphicsTypeType.Chart,
-          name: isRing
-            ? CustomGraphicsNameType.RingChart
-            : CustomGraphicsNameType.PieChart,
-          properties: parsed,
-        } as CustomGraphicsType
+    // JSON chart object
+    case 'json':
+      try {
+        const parsed = JSON.parse(source.raw)
+        // Distinguish chart types by checking for chart-specific fields
+        if (
+          Array.isArray(parsed.cy_dataColumns) &&
+          Array.isArray(parsed.cy_colors)
+        ) {
+          const isRing = parsed.cy_holeSize !== undefined
+          return {
+            type: CustomGraphicsTypeType.Chart,
+            name: isRing
+              ? CustomGraphicsNameType.RingChart
+              : CustomGraphicsNameType.PieChart,
+            properties: parsed,
+          } as CustomGraphicsType
+        }
+      } catch {
+        // Malformed JSON — fall through to default
       }
-    } catch {
-      // Malformed JSON — fall through to default
-    }
-  }
+      return pm.defaultValue
 
-  // 5. Unrecognized string — return default silently
-  return pm.defaultValue
+    default:
+      // 'empty' and 'unrecognized' are ordinary misses on a passthrough column,
+      // so stay silent. Bad schemes are worth a warning.
+      if (source.reason === 'blob' || source.reason === 'file') {
+        logUi.warn(
+          `${describeImageSourceRejection(source.reason)}:`,
+          source.raw.substring(0, 80),
+        )
+      }
+      return pm.defaultValue
+  }
 }
 
 /**

--- a/test/playwright/cywebapi-ready.spec.ts
+++ b/test/playwright/cywebapi-ready.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from './fixtures'
 // `cywebapi:ready` event. The unit-level cywebapi-ready.test.ts only checks a
 // hand-built mock object, so it is blind to a bundler regression — this is not.
 
-// The 10 public domain namespaces assembled in src/app-api/core/index.ts.
+// The public domain namespaces assembled in src/app-api/core/index.ts.
 const EXPECTED_API_KEYS = [
   'element',
   'network',
@@ -17,6 +17,7 @@ const EXPECTED_API_KEYS = [
   'export',
   'workspace',
   'contextMenu',
+  'nodeGraphics',
 ]
 
 test.describe('window.CyWebApi public surface', () => {

--- a/test/playwright/node-graphics-hook.spec.ts
+++ b/test/playwright/node-graphics-hook.spec.ts
@@ -1,0 +1,289 @@
+import fs from 'fs'
+import path from 'path'
+
+import {
+  expect,
+  getWorkspaceNetworkCount,
+  gotoAndWaitReady,
+  test,
+} from './fixtures'
+
+// Proves the two claims that unit tests cannot reach, against the real bundle
+// and a real Cytoscape.js instance:
+//
+//   1. A render hook's image actually lands on the node, as an ELEMENT STYLE
+//      BYPASS. The unit tests use a stub cy, so they verify the call but not
+//      that Cytoscape.js accepts it or that a stylesheet reapply preserves it.
+//   2. That image never reaches exported CX2, while a Vizmapper custom graphic
+//      still does.
+//
+// The cy instance is reached through `window.debug.cy` (registerDebugTool in
+// CyjsRenderer). Debug is enabled by seeding its localStorage override before
+// navigation, so this works in both a dev server and a production preview
+// build rather than silently skipping in CI.
+
+const CX2_FIXTURE = path.resolve(
+  __dirname,
+  '../fixtures/cx2/valid/small-network.valid.cx2',
+)
+const IMPORT_URL = 'https://fixtures.invalid/node-graphics-fixture.cx2'
+
+const SENTINEL_MARKER = 'CYWEB_HOOK_SENTINEL'
+const SENTINEL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle id="${SENTINEL_MARKER}" cx="5" cy="5" r="4" fill="#4caf50"/></svg>`
+
+/**
+ * `window.debug` and `window.CyWebApi` are already declared by the app
+ * (src/custom.d.ts and the api-types package), so this narrows them for the
+ * in-page callbacks rather than redeclaring and conflicting. The cast is written
+ * out at each use because `page.evaluate` callbacks run in the browser and
+ * cannot close over anything defined here.
+ */
+type DebugGlobals = { debug?: Record<string, any>; CyWebApi?: any }
+
+test.describe('Node graphics render hook', () => {
+  test('paints a hook image as a cy style bypass and keeps it out of CX2', async ({
+    page,
+  }) => {
+    const cx2 = fs.readFileSync(CX2_FIXTURE, 'utf8')
+    await page.route(IMPORT_URL, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: {
+          'access-control-allow-origin': '*',
+          'content-length': String(Buffer.byteLength(cx2)),
+        },
+        body: route.request().method() === 'HEAD' ? undefined : cx2,
+      }),
+    )
+
+    // Enable debug before boot so registerDebugTool('cy', cy) reaches window.
+    await page.addInitScript(() => {
+      localStorage.setItem('cyweb-debug-enabled', 'true')
+    })
+
+    await gotoAndWaitReady(page, `/?import=${encodeURIComponent(IMPORT_URL)}`)
+    await expect
+      .poll(() => getWorkspaceNetworkCount(page), { timeout: 15000 })
+      .toBe(1)
+
+    // The renderer has mounted and registered its cy instance.
+    await page.waitForFunction(
+      () => (window as unknown as DebugGlobals).debug?.cy !== undefined,
+      undefined,
+      {
+        timeout: 30_000,
+      },
+    )
+    await page.waitForFunction(
+      () =>
+        ((window as unknown as DebugGlobals).debug?.cy?.nodes().length ?? 0) >
+        0,
+      undefined,
+      { timeout: 30_000 },
+    )
+
+    const networkId = await page.evaluate(() => {
+      const result = (
+        window as unknown as DebugGlobals
+      ).CyWebApi.workspace.getNetworkIds()
+      return result.success ? result.data.networkIds[0] : undefined
+    })
+    expect(networkId).toBeTruthy()
+
+    // Baseline: no hook, so no node carries a background-image bypass.
+    const before = await page.evaluate(() =>
+      (window as unknown as DebugGlobals)
+        .debug!.cy.nodes()
+        .map((n: any) => n.style('background-image')),
+    )
+    expect(
+      before.every((v: string) => v === undefined || v === 'none' || v === ''),
+    ).toBe(true)
+
+    // ── Register the hook ────────────────────────────────────────────────────
+
+    const registered = await page.evaluate((svg) => {
+      return (
+        window as unknown as DebugGlobals
+      ).CyWebApi.nodeGraphics.setRenderHook(() => svg)
+    }, SENTINEL_SVG)
+    expect(registered.success).toBe(true)
+
+    // Every node picks up the image. The hook runs in chunks across animation
+    // frames, so poll rather than assert immediately.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () =>
+              (window as unknown as DebugGlobals)
+                .debug!.cy.nodes()
+                .filter((n: any) => {
+                  const v = n.style('background-image')
+                  return typeof v === 'string' && v.startsWith('data:image/svg')
+                }).length,
+          ),
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0)
+
+    // The image survived, and Cytoscape.js parsed it as a real property value.
+    const painted = await page.evaluate(() => {
+      const node = (window as unknown as DebugGlobals).debug!.cy.nodes()[0]
+      return {
+        image: node.style('background-image'),
+        fit: node.style('background-fit'),
+      }
+    })
+    expect(painted.image).toContain('data:image/svg')
+    expect(decodeURIComponent(painted.image)).toContain(SENTINEL_MARKER)
+    expect(painted.fit).toBe('contain')
+
+    // ── The constraint: none of that reaches CX2 ─────────────────────────────
+    //
+    // Asserted structurally rather than by byte-equality against a pre-hook
+    // export: a live app runs its layout asynchronously, so two exports taken
+    // seconds apart legitimately differ in node x/y. The deterministic
+    // byte-equality claim lives in exporter.nodeGraphics.test.ts, which has no
+    // layout to race.
+
+    const exported = await page.evaluate((id) => {
+      const result = (
+        window as unknown as DebugGlobals
+      ).CyWebApi.export.exportToCx2(id)
+      if (!result.success) return { ok: false as const }
+      const aspects: any[] = result.data
+      const find = (key: string) =>
+        aspects.find((a) => Object.prototype.hasOwnProperty.call(a, key))?.[key]
+      return {
+        ok: true as const,
+        json: JSON.stringify(aspects),
+        nodeBypasses: find('nodeBypasses'),
+        nodeDefaults: find('visualProperties')?.[0]?.default?.node ?? {},
+      }
+    }, networkId)
+
+    expect(exported.ok).toBe(true)
+    expect(exported.json).not.toContain(SENTINEL_MARKER)
+    expect(exported.json).not.toContain('data:image/svg')
+    // Nothing was written as a bypass or a style default.
+    expect(exported.nodeBypasses).toEqual([])
+    expect(
+      Object.keys(exported.nodeDefaults!).filter((k) => k.includes('IMAGE')),
+    ).toEqual([])
+
+    // ── Clearing the hook removes the bypass ─────────────────────────────────
+
+    const cleared = await page.evaluate(() =>
+      (
+        window as unknown as DebugGlobals
+      ).CyWebApi.nodeGraphics.clearRenderHook(),
+    )
+    expect(cleared.success).toBe(true)
+
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () =>
+              (window as unknown as DebugGlobals)
+                .debug!.cy.nodes()
+                .filter((n: any) => {
+                  const v = n.style('background-image')
+                  return typeof v === 'string' && v.startsWith('data:image/svg')
+                }).length,
+          ),
+        { timeout: 15000 },
+      )
+      .toBe(0)
+  })
+
+  test('a bypass survives a stylesheet reapply', async ({ page }) => {
+    // The load-bearing cytoscape behavior this design rests on: cy.style(sheet)
+    // installs a new Style object without clearing element bypasses. A change to
+    // the visual style triggers that reapply through onStyleModelUpdate.
+    const cx2 = fs.readFileSync(CX2_FIXTURE, 'utf8')
+    await page.route(IMPORT_URL, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: {
+          'access-control-allow-origin': '*',
+          'content-length': String(Buffer.byteLength(cx2)),
+        },
+        body: route.request().method() === 'HEAD' ? undefined : cx2,
+      }),
+    )
+    await page.addInitScript(() => {
+      localStorage.setItem('cyweb-debug-enabled', 'true')
+    })
+
+    await gotoAndWaitReady(page, `/?import=${encodeURIComponent(IMPORT_URL)}`)
+    await expect
+      .poll(() => getWorkspaceNetworkCount(page), { timeout: 15000 })
+      .toBe(1)
+    await page.waitForFunction(
+      () =>
+        ((window as unknown as DebugGlobals).debug?.cy?.nodes().length ?? 0) >
+        0,
+      undefined,
+      { timeout: 30_000 },
+    )
+
+    const networkId = await page.evaluate(() => {
+      const result = (
+        window as unknown as DebugGlobals
+      ).CyWebApi.workspace.getNetworkIds()
+      return result.success ? result.data.networkIds[0] : undefined
+    })
+
+    await page.evaluate(
+      (svg) =>
+        (window as unknown as DebugGlobals).CyWebApi.nodeGraphics.setRenderHook(
+          () => svg,
+        ),
+      SENTINEL_SVG,
+    )
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() =>
+            String(
+              (window as unknown as DebugGlobals)
+                .debug!.cy.nodes()[0]
+                .style('background-image'),
+            ),
+          ),
+        { timeout: 15000 },
+      )
+      .toContain('data:image/svg')
+
+    // Change a default visual property, forcing cy.style(cyStyle) to rerun.
+    const styled = await page.evaluate(
+      (id) =>
+        (window as unknown as DebugGlobals).CyWebApi.visualStyle.setDefault(
+          id,
+          'nodeBackgroundColor',
+          '#123456',
+        ),
+      networkId,
+    )
+    expect(styled.success).toBe(true)
+
+    // The stylesheet was replaced; the bypass must still be there.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() =>
+            String(
+              (window as unknown as DebugGlobals)
+                .debug!.cy.nodes()[0]
+                .style('background-image'),
+            ),
+          ),
+        { timeout: 15000 },
+      )
+      .toContain('data:image/svg')
+  })
+})

--- a/test/playwright/node-graphics-hook.spec.ts
+++ b/test/playwright/node-graphics-hook.spec.ts
@@ -41,9 +41,12 @@ const SENTINEL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10
 type DebugGlobals = { debug?: Record<string, any>; CyWebApi?: any }
 
 test.describe('Node graphics render hook', () => {
-  test('paints a hook image as a cy style bypass and keeps it out of CX2', async ({
-    page,
-  }) => {
+  /**
+   * Serve the CX2 fixture at the import URL, and enable debug before boot so
+   * `registerDebugTool('cy', cy)` reaches `window`. The HEAD response carries the
+   * headers with no body, which is what the importer probes for first.
+   */
+  test.beforeEach(async ({ page }) => {
     const cx2 = fs.readFileSync(CX2_FIXTURE, 'utf8')
     await page.route(IMPORT_URL, (route) =>
       route.fulfill({
@@ -56,12 +59,14 @@ test.describe('Node graphics render hook', () => {
         body: route.request().method() === 'HEAD' ? undefined : cx2,
       }),
     )
-
-    // Enable debug before boot so registerDebugTool('cy', cy) reaches window.
     await page.addInitScript(() => {
       localStorage.setItem('cyweb-debug-enabled', 'true')
     })
+  })
 
+  test('paints a hook image as a cy style bypass and keeps it out of CX2', async ({
+    page,
+  }) => {
     await gotoAndWaitReady(page, `/?import=${encodeURIComponent(IMPORT_URL)}`)
     await expect
       .poll(() => getWorkspaceNetworkCount(page), { timeout: 15000 })
@@ -203,22 +208,6 @@ test.describe('Node graphics render hook', () => {
     // The load-bearing cytoscape behavior this design rests on: cy.style(sheet)
     // installs a new Style object without clearing element bypasses. A change to
     // the visual style triggers that reapply through onStyleModelUpdate.
-    const cx2 = fs.readFileSync(CX2_FIXTURE, 'utf8')
-    await page.route(IMPORT_URL, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        headers: {
-          'access-control-allow-origin': '*',
-          'content-length': String(Buffer.byteLength(cx2)),
-        },
-        body: route.request().method() === 'HEAD' ? undefined : cx2,
-      }),
-    )
-    await page.addInitScript(() => {
-      localStorage.setItem('cyweb-debug-enabled', 'true')
-    })
-
     await gotoAndWaitReady(page, `/?import=${encodeURIComponent(IMPORT_URL)}`)
     await expect
       .poll(() => getWorkspaceNetworkCount(page), { timeout: 15000 })
@@ -237,6 +226,7 @@ test.describe('Node graphics render hook', () => {
       ).CyWebApi.workspace.getNetworkIds()
       return result.success ? result.data.networkIds[0] : undefined
     })
+    expect(networkId).toBeTruthy()
 
     await page.evaluate(
       (svg) =>


### PR DESCRIPTION
This pull request introduces a new "node graphics render hook" system, allowing external apps to dynamically generate and display custom images on network nodes in Cytoscape Web. The hook mechanism enables per-node images based on live data, without polluting export formats or the visual style, and includes robust invalidation, deduplication, and error handling. The documentation details the design rationale, contract, architecture, and limitations.

Key changes:

**Feature: Node graphics render hook**
* Adds a synchronous hook API (`api.nodeGraphics.setRenderHook`) for apps to supply custom images per node, which are applied as Cytoscape.js `background-image` bypasses.
* Ensures hook-generated images never reach exported CX2 files or persist in visual styles, maintaining separation between ephemeral app state and saved network data.

**Design and architecture**
* Documents the entire data flow, invalidation triggers, and coalescing strategies to efficiently and safely update images, including chunked processing and session-scoped error limits.
* Explains why bypassing element data and stylesheets is necessary, and how the system interacts with Cytoscape.js internals to ensure correct precedence and draw order.

**API contract and limitations**
* Defines the hook contract, accepted image formats, error handling, and the synchronous v1 design, with planned future support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added node graphics render hooks for dynamically customizing node images.
  * Hooks support registration, replacement, removal, and targeted or full-network refreshes.
  * Supports image URLs, data URIs, SVG graphics, configurable sizing, opacity, fit, and placement.
  * Graphics update automatically as node data and network views change.
  * Hook-generated graphics take precedence over mapped images and remain excluded from CX2 exports.

* **Bug Fixes**
  * Improved image-source validation, SVG sizing, cleanup, and rendering consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->