### PR TITLE
fix(renderer): create annotation canvases once per Cytoscape instance

### DIFF
--- a/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
+++ b/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer.tsx
@@ -38,7 +38,7 @@ import type {
   Orientation,
   PaperSize,
 } from '../../ToolBar/DataMenu/ExportNetworkToImage/PdfExportForm'
-import { CxToCyCanvas } from './annotations/cyjsAnnotationRenderer'
+import { createAnnotationLayers } from './annotations/cyjsAnnotationRenderer'
 import { addCyElements } from './cyjsFactoryUtil'
 import { applyViewModel, createCyjsDataMapper } from './cyjsRenderUtil'
 import {
@@ -95,8 +95,10 @@ const CyjsRenderer = ({
     IdType | undefined
   >(undefined)
 
-  // Canvas layer state for annotation layers, to clear previous network layers before rendering the next network
-  const [annotationLayers, setAnnotationLayers] = useState<any[]>([])
+  // Annotation canvases. They belong to the Cytoscape instance, not to a single
+  // render: `cyCanvas()` appends a new canvas on every call, so creating them
+  // per render left a frozen copy behind each time (issue #675).
+  const annotationLayersRef = useRef<any>(null)
 
   // Cytoscape instance and container ref
   const [cy, setCy] = useState<any>(null)
@@ -812,28 +814,17 @@ const CyjsRenderer = ({
       },
     }
 
-    // Clear all annotation layers before rendering new ones
-    annotationLayers.forEach((layer) => {
-      const ctx = layer?.getCanvas()?.getContext('2d')
-      if (ctx !== undefined) {
-        layer.clear(ctx)
-      }
-    })
-
-    // Set up annotation rendering utilities
-    const annotationRenderer = new CxToCyCanvas()
-
-    // Render annotations if present, otherwise clear annotation layers
-    if (annotations.length > 0) {
-      const result = annotationRenderer.drawAnnotationsFromNiceCX(
-        cy,
-        niceCXForCyAnnotationRendering,
+    // Swap the annotation data on the canvases created with the Cytoscape
+    // instance. `cy.removeAllListeners()` above dropped their redraw handlers,
+    // so re-attach them; `attach()` is idempotent.
+    const annotationLayers = annotationLayersRef.current
+    if (annotationLayers !== null) {
+      annotationLayers.setAnnotations(niceCXForCyAnnotationRendering)
+      annotationLayers.setBackgroundColor(
+        annotations.length > 0 ? bgColor : undefined,
       )
-      annotationRenderer.drawBackground(cy, bgColor)
-
-      setAnnotationLayers([result.topLayer, result.bottomLayer])
-    } else {
-      setAnnotationLayers([])
+      annotationLayers.attach()
+      annotationLayers.redraw()
     }
 
     // --- Finalize Rendering ---
@@ -1168,11 +1159,16 @@ const CyjsRenderer = ({
       })
       cyInstance.current = cy
 
+      // One annotation canvas set per instance, reused by every render.
+      annotationLayersRef.current = createAnnotationLayers(cy)
+
       const unregisterDebugTool = registerDebugTool('cy', cy)
       setCy(cy)
 
       return () => {
         unregisterDebugTool()
+        annotationLayersRef.current?.dispose()
+        annotationLayersRef.current = null
         cyInstance.current?.destroy()
         cyInstance.current = null
         isInitialized.current = false
@@ -1181,6 +1177,8 @@ const CyjsRenderer = ({
 
     return () => {
       // Reset the guard so a StrictMode remount recreates the instance.
+      annotationLayersRef.current?.dispose()
+      annotationLayersRef.current = null
       cyInstance.current?.destroy()
       cyInstance.current = null
       isInitialized.current = false

--- a/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer_docs/CyjsRenderer.md
+++ b/src/features/NetworkPanel/CyjsRenderer/CyjsRenderer_docs/CyjsRenderer.md
@@ -127,8 +127,12 @@ The core **`renderNetwork(forceFit = true)`** function is responsible for:
    - Mouseover/mouseout for hover highlighting
 
 9. **Annotations**
-   - Use `CxToCyCanvas` and `CX_ANNOTATIONS_KEY` to render CX annotations onto a canvas overlay
-   - Track `annotationLayers` so old layers can be removed when switching networks
+   - Use `createAnnotationLayers` and `CX_ANNOTATIONS_KEY` to render CX annotations onto a canvas overlay
+   - The three canvases are created once per Cytoscape instance and held in `annotationLayersRef`.
+     `cyCanvas()` appends a new canvas on every call, so creating them per render left a frozen
+     copy behind each time (issue #675).
+   - Each render calls `setAnnotations`, `setBackgroundColor`, `attach` and `redraw`. `attach` is
+     idempotent and re-registers the redraw handlers that `cy.removeAllListeners()` dropped.
 
 ### Selection & Display Modes
 

--- a/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.js
+++ b/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.js
@@ -501,7 +501,12 @@ export class CxToCyCanvas {
         const width = parseFloat(shapeMap['width'])
         const height = parseFloat(shapeMap['height'])
 
-        if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(width) && Number.isFinite(height)) {
+        if (
+          Number.isFinite(x) &&
+          Number.isFinite(y) &&
+          Number.isFinite(width) &&
+          Number.isFinite(height)
+        ) {
           // Default to horizontal gradient if no orientation specified
           const x2 = shapeMap['orientation'] === 'vertical' ? x : x + width
           const y2 = shapeMap['orientation'] === 'vertical' ? y + height : y
@@ -549,7 +554,12 @@ export class CxToCyCanvas {
             const x2 = x + x2_ratio * width
             const y2 = y + y2_ratio * height
 
-            if (Number.isFinite(x1) && Number.isFinite(y1) && Number.isFinite(x2) && Number.isFinite(y2)) {
+            if (
+              Number.isFinite(x1) &&
+              Number.isFinite(y1) &&
+              Number.isFinite(x2) &&
+              Number.isFinite(y2)
+            ) {
               const gradient = ctx.createLinearGradient(x1, y1, x2, y2)
 
               for (let i = 2; i < parts.length; i++) {
@@ -597,25 +607,6 @@ export class CxToCyCanvas {
     }
   }
 
-  drawBackground(cytoscapeInstance, cxBGColor) {
-    const backgroundLayer = cytoscapeInstance.cyCanvas({
-      zIndex: -2,
-    })
-
-    const backgroundCanvas = backgroundLayer.getCanvas()
-    const backgroundCtx = backgroundCanvas.getContext('2d')
-
-    cytoscapeInstance.on('render cyCanvas.resize', () => {
-      backgroundCtx.fillStyle = cxBGColor
-      backgroundCtx.fillRect(
-        0,
-        0,
-        backgroundCanvas.width,
-        backgroundCanvas.height,
-      )
-    })
-  }
-
   getAnnotationElementsFromNiceCX(niceCX) {
     if (niceCX['networkAttributes']) {
       return niceCX['networkAttributes']['elements'].filter(function (element) {
@@ -626,118 +617,109 @@ export class CxToCyCanvas {
     }
   }
 
-  drawAnnotationsFromAnnotationElements(cytoscapeInstance, annotationElements) {
-    //console.log("setting up annotations");
-    const bottomLayer = cytoscapeInstance.cyCanvas({
-      zIndex: -1,
-    })
+  /**
+   * Paint `annotationElements` onto the top and bottom annotation layers.
+   *
+   * Pure paint: the caller owns the canvases and decides when to repaint. See
+   * `createAnnotationLayers` for the canvas lifecycle.
+   *
+   * @param {object} layers `{ bottomLayer, bottomCtx, topLayer, topCtx }`
+   * @param {Array} annotationElements CX `__Annotations` network attributes
+   */
+  paintAnnotations(layers, annotationElements) {
+    const { bottomLayer, bottomCtx, topLayer, topCtx } = layers
+    var colorFromInt = this._colorFromInt
+    var shapeFunctions = this._shapeFunctions
 
-    const topLayer = cytoscapeInstance.cyCanvas({
-      zIndex: 1,
-    })
+    bottomLayer.resetTransform(bottomCtx)
+    bottomLayer.clear(bottomCtx)
+    bottomLayer.setTransform(bottomCtx)
 
-    const bottomCanvas = bottomLayer.getCanvas()
-    const bottomCtx = bottomCanvas.getContext('2d')
+    bottomCtx.save()
 
-    const topCanvas = topLayer.getCanvas()
-    const topCtx = topCanvas.getContext('2d')
+    topLayer.resetTransform(topCtx)
+    topLayer.clear(topCtx)
+    topLayer.setTransform(topCtx)
 
-    this.topLayer = topLayer
-    this.bottomLayer = bottomLayer
+    topCtx.save()
 
-    cytoscapeInstance.on('render cyCanvas.resize', () => {
-      var colorFromInt = this._colorFromInt
-      var shapeFunctions = this._shapeFunctions
-      //console.log("render cyCanvas.resize event");
-      bottomLayer.resetTransform(bottomCtx)
-      bottomLayer.clear(bottomCtx)
-      bottomLayer.setTransform(bottomCtx)
+    var indexedAnnotations = {}
+    var topAnnotations = []
+    var bottomAnnotations = []
 
-      bottomCtx.save()
-
-      topLayer.resetTransform(topCtx)
-      topLayer.clear(topCtx)
-      topLayer.setTransform(topCtx)
-
-      topCtx.save()
-
-      var indexedAnnotations = {}
-      var topAnnotations = []
-      var bottomAnnotations = []
-
-      annotationElements.forEach(function (element) {
-        element['v'].forEach(function (annotation) {
-          var annotationKVList = annotation.split('|')
-          var annotationMap = {}
-          annotationKVList.forEach(function (annotationKV) {
-            var kvPair = annotationKV.split('=')
-            annotationMap[kvPair[0]] = kvPair[1]
-          })
-
-          indexedAnnotations[annotationMap['uuid']] = annotationMap
-
-          if (annotationMap['canvas'] == 'foreground') {
-            topAnnotations.push(annotationMap['uuid'])
-          } else {
-            bottomAnnotations.push(annotationMap['uuid'])
-          }
+    annotationElements.forEach(function (element) {
+      element['v'].forEach(function (annotation) {
+        var annotationKVList = annotation.split('|')
+        var annotationMap = {}
+        annotationKVList.forEach(function (annotationKV) {
+          var kvPair = annotationKV.split('=')
+          annotationMap[kvPair[0]] = kvPair[1]
         })
+
+        indexedAnnotations[annotationMap['uuid']] = annotationMap
+
+        if (annotationMap['canvas'] == 'foreground') {
+          topAnnotations.push(annotationMap['uuid'])
+        } else {
+          bottomAnnotations.push(annotationMap['uuid'])
+        }
       })
-      var zOrderCompare = function (a, b) {
-        let annotationA = indexedAnnotations[a]
-        let annotationB = indexedAnnotations[b]
-        return parseInt(annotationB['z']) - parseInt(annotationA['z'])
-      }
+    })
+    var zOrderCompare = function (a, b) {
+      let annotationA = indexedAnnotations[a]
+      let annotationB = indexedAnnotations[b]
+      return parseInt(annotationB['z']) - parseInt(annotationA['z'])
+    }
 
-      topAnnotations.sort(zOrderCompare)
-      bottomAnnotations.sort(zOrderCompare)
+    topAnnotations.sort(zOrderCompare)
+    bottomAnnotations.sort(zOrderCompare)
 
-      var contextAnnotationMap = [
-        { context: topCtx, annotations: topAnnotations },
-        { context: bottomCtx, annotations: bottomAnnotations },
-      ]
-      contextAnnotationMap.forEach(function (contextAnnotationPair) {
-        let ctx = contextAnnotationPair.context
-        contextAnnotationPair.annotations.forEach(function (annotationUUID) {
-          let annotationMap = indexedAnnotations[annotationUUID]
+    var contextAnnotationMap = [
+      { context: topCtx, annotations: topAnnotations },
+      { context: bottomCtx, annotations: bottomAnnotations },
+    ]
+    contextAnnotationMap.forEach(function (contextAnnotationPair) {
+      let ctx = contextAnnotationPair.context
+      contextAnnotationPair.annotations.forEach(function (annotationUUID) {
+        let annotationMap = indexedAnnotations[annotationUUID]
+        if (
+          annotationMap['type'] ==
+            'org.cytoscape.view.presentation.annotations.ShapeAnnotation' ||
+          annotationMap['type'] ==
+            'org.cytoscape.view.presentation.annotations.BoundedTextAnnotation'
+        ) {
+          //ctx.beginPath();
+          const zoom = annotationMap['zoom']
+            ? parseFloat(annotationMap['zoom'])
+            : 1
+
+          ctx.lineWidth = annotationMap['edgeThickness']
+
+          annotationMap['width'] = parseFloat(annotationMap['width']) / zoom
+          annotationMap['height'] = parseFloat(annotationMap['height']) / zoom
+          if (shapeFunctions[annotationMap['shapeType']]) {
+            ctx.strokeStyle = colorFromInt(
+              annotationMap['edgeColor'],
+              annotationMap['edgeOpacity'],
+            )
+            shapeFunctions[annotationMap['shapeType']](annotationMap, ctx)
+
+            //ctx.stroke();
+          } else {
+            console.warn('Invalid shape type: ' + annotationMap['shapeType'])
+          }
+        } else if (
+          annotationMap['type'] ==
+          'org.cytoscape.view.presentation.annotations.ArrowAnnotation'
+        ) {
           if (
-            annotationMap['type'] ==
-              'org.cytoscape.view.presentation.annotations.ShapeAnnotation' ||
-            annotationMap['type'] ==
-              'org.cytoscape.view.presentation.annotations.BoundedTextAnnotation'
+            annotationMap['targetAnnotation'] &&
+            annotationMap['sourceAnnotation']
           ) {
-            //ctx.beginPath();
-            const zoom = annotationMap['zoom']
-              ? parseFloat(annotationMap['zoom'])
-              : 1
-
-            ctx.lineWidth = annotationMap['edgeThickness']
-
-            annotationMap['width'] = parseFloat(annotationMap['width']) / zoom
-            annotationMap['height'] = parseFloat(annotationMap['height']) / zoom
-            if (shapeFunctions[annotationMap['shapeType']]) {
-              ctx.strokeStyle = colorFromInt(
-                annotationMap['edgeColor'],
-                annotationMap['edgeOpacity'],
-              )
-              shapeFunctions[annotationMap['shapeType']](annotationMap, ctx)
-
-              //ctx.stroke();
-            } else {
-              console.warn('Invalid shape type: ' + annotationMap['shapeType'])
-            }
-          } else if (
-            annotationMap['type'] ==
-            'org.cytoscape.view.presentation.annotations.ArrowAnnotation'
-          ) {
-            if (
-              annotationMap['targetAnnotation'] &&
-              annotationMap['sourceAnnotation']
-            ) {
-              // The following is a start to implementing arrow annotations. To follow Cytoscape's
-              // implementation, it would take a great deal of math and special cases, so has been
-              // left for later work.
-              /*
+            // The following is a start to implementing arrow annotations. To follow Cytoscape's
+            // implementation, it would take a great deal of math and special cases, so has been
+            // left for later work.
+            /*
                     ctx.beginPath();
                     
                     let sourceX = sourceAnnotation['x'];
@@ -751,94 +733,184 @@ export class CxToCyCanvas {
 
                     ctx.closePath();
                    */
-              ctx.stroke()
+            ctx.stroke()
+          }
+        }
+
+        var text
+        var textX
+        var textY
+
+        if (
+          annotationMap['type'] ==
+          'org.cytoscape.view.presentation.annotations.TextAnnotation'
+        ) {
+          text = annotationMap['text']
+          ctx.textBaseline = 'top'
+          ctx.textAlign = 'left'
+          textX = annotationMap['x']
+          textY = annotationMap['y']
+        } else if (
+          annotationMap['type'] ==
+          'org.cytoscape.view.presentation.annotations.BoundedTextAnnotation'
+        ) {
+          text = annotationMap['text']
+
+          ctx.textBaseline = 'middle'
+          ctx.textAlign = 'center'
+
+          textX = parseFloat(annotationMap['x']) + annotationMap['width'] / 2
+          textY = parseFloat(annotationMap['y']) + annotationMap['height'] / 2
+        }
+        if (text && textX && textY) {
+          const zoom = annotationMap['zoom']
+            ? parseFloat(annotationMap['zoom'])
+            : 1
+          const fontSize = parseFloat(annotationMap['fontSize']) / zoom
+          var fontFamily
+
+          if (annotationMap['fontFamily']) {
+            if (
+              JAVA_LOGICAL_FONT_FAMILY_LIST.includes(
+                annotationMap['fontFamily'],
+              )
+            ) {
+              fontFamily =
+                JAVA_LOGICAL_FONT_STACK_MAP[annotationMap['fontFamily']]
+            } else if (COMMON_OS_FONT_STACK_MAP[annotationMap['fontFamily']]) {
+              fontFamily = COMMON_OS_FONT_STACK_MAP[annotationMap['fontFamily']]
+            } else {
+              fontFamily = 'sans-serif'
             }
           }
+          ctx.font = fontSize + 'px ' + fontFamily
 
-          var text
-          var textX
-          var textY
-
-          if (
-            annotationMap['type'] ==
-            'org.cytoscape.view.presentation.annotations.TextAnnotation'
-          ) {
-            text = annotationMap['text']
-            ctx.textBaseline = 'top'
-            ctx.textAlign = 'left'
-            textX = annotationMap['x']
-            textY = annotationMap['y']
-          } else if (
-            annotationMap['type'] ==
-            'org.cytoscape.view.presentation.annotations.BoundedTextAnnotation'
-          ) {
-            text = annotationMap['text']
-
-            ctx.textBaseline = 'middle'
-            ctx.textAlign = 'center'
-
-            textX = parseFloat(annotationMap['x']) + annotationMap['width'] / 2
-            textY = parseFloat(annotationMap['y']) + annotationMap['height'] / 2
+          if (annotationMap['color']) {
+            let fillColor = colorFromInt(annotationMap['color'], '100')
+            ctx.fillStyle = fillColor
           }
-          if (text && textX && textY) {
-            const zoom = annotationMap['zoom']
-              ? parseFloat(annotationMap['zoom'])
-              : 1
-            const fontSize = parseFloat(annotationMap['fontSize']) / zoom
-            var fontFamily
-
-            if (annotationMap['fontFamily']) {
-              if (
-                JAVA_LOGICAL_FONT_FAMILY_LIST.includes(
-                  annotationMap['fontFamily'],
-                )
-              ) {
-                fontFamily =
-                  JAVA_LOGICAL_FONT_STACK_MAP[annotationMap['fontFamily']]
-              } else if (
-                COMMON_OS_FONT_STACK_MAP[annotationMap['fontFamily']]
-              ) {
-                fontFamily =
-                  COMMON_OS_FONT_STACK_MAP[annotationMap['fontFamily']]
-              } else {
-                fontFamily = 'sans-serif'
-              }
-            }
-            ctx.font = fontSize + 'px ' + fontFamily
-
-            if (annotationMap['color']) {
-              let fillColor = colorFromInt(annotationMap['color'], '100')
-              ctx.fillStyle = fillColor
-            }
-            ctx.fillText(text.toString(), textX, textY)
-          }
-        })
+          ctx.fillText(text.toString(), textX, textY)
+        }
       })
-
-      topCtx.restore()
-      bottomCtx.restore()
     })
 
-    return {
-      topLayer: topLayer,
-      bottomLayer: bottomLayer,
-    }
+    topCtx.restore()
+    bottomCtx.restore()
+  }
+}
+
+/**
+ * Owns the three annotation canvases of one Cytoscape instance.
+ *
+ * `cyCanvas()` appends a new `<canvas>` on every call and never reuses one, so
+ * creating layers per render left one frozen canvas set behind per render
+ * (issue #675). The layers are created once here; each render swaps the
+ * annotation data and repaints the same canvases.
+ *
+ * `renderNetwork` calls `cy.removeAllListeners()`, which drops both the redraw
+ * handler and the `resize` handler the extension registers for its canvas.
+ * `attach()` re-registers both and is idempotent, so callers run it after every
+ * render.
+ *
+ * @param {object} cytoscapeInstance a Cytoscape core with `cyCanvas` registered
+ * @returns a controller: `attach`, `setAnnotations`, `setBackgroundColor`,
+ *          `redraw`, `dispose`
+ */
+export const createAnnotationLayers = (cytoscapeInstance) => {
+  const painter = new CxToCyCanvas()
+
+  const backgroundLayer = cytoscapeInstance.cyCanvas({ zIndex: -2 })
+  const bottomLayer = cytoscapeInstance.cyCanvas({ zIndex: -1 })
+  const topLayer = cytoscapeInstance.cyCanvas({ zIndex: 1 })
+
+  const backgroundCanvas = backgroundLayer.getCanvas()
+  const backgroundCtx = backgroundCanvas.getContext('2d')
+  const bottomCanvas = bottomLayer.getCanvas()
+  const topCanvas = topLayer.getCanvas()
+  const canvases = [backgroundCanvas, bottomCanvas, topCanvas]
+
+  const layers = {
+    bottomLayer,
+    bottomCtx: bottomCanvas.getContext('2d'),
+    topLayer,
+    topCtx: topCanvas.getContext('2d'),
   }
 
-  drawAnnotationsFromNiceCX(cytoscapeInstance, niceCX) {
-    const annotationElements = this.getAnnotationElementsFromNiceCX(niceCX)
-    return this.drawAnnotationsFromAnnotationElements(
-      cytoscapeInstance,
-      annotationElements,
-    )
+  let annotationElements = []
+  let backgroundColor
+
+  const paint = () => {
+    if (backgroundColor === undefined) {
+      backgroundCtx.clearRect(
+        0,
+        0,
+        backgroundCanvas.width,
+        backgroundCanvas.height,
+      )
+    } else {
+      backgroundCtx.fillStyle = backgroundColor
+      backgroundCtx.fillRect(
+        0,
+        0,
+        backgroundCanvas.width,
+        backgroundCanvas.height,
+      )
+    }
+    painter.paintAnnotations(layers, annotationElements)
   }
 
-  clearAnnotationsFromCanvas() {
-    if (self.topLayer !== undefined) {
-      self.topLayer.clear()
+  // The extension sizes its canvas to the container on `resize` and loses that
+  // handler to `removeAllListeners`. Re-implement it so the annotation canvases
+  // keep tracking the container across renders.
+  const resize = () => {
+    const container = cytoscapeInstance.container()
+    if (container === null || container === undefined) {
+      return
     }
-    if (self.bottomLayer !== undefined) {
-      self.bottomLayer.clear()
-    }
+    const width = container.offsetWidth
+    const height = container.offsetHeight
+    const pixelRatio = window.devicePixelRatio || 1
+    canvases.forEach((canvas) => {
+      canvas.width = width * pixelRatio
+      canvas.height = height * pixelRatio
+      canvas.style.width = width + 'px'
+      canvas.style.height = height + 'px'
+    })
+    paint()
+  }
+
+  const off = () => {
+    cytoscapeInstance.off('render cyCanvas.resize', paint)
+    cytoscapeInstance.off('resize', resize)
+  }
+
+  return {
+    /** (Re-)register the redraw handlers. Idempotent. */
+    attach() {
+      off()
+      cytoscapeInstance.on('render cyCanvas.resize', paint)
+      cytoscapeInstance.on('resize', resize)
+    },
+
+    /** Replace the annotations drawn from the next paint on. */
+    setAnnotations(niceCX) {
+      annotationElements = painter.getAnnotationElementsFromNiceCX(niceCX)
+    },
+
+    /** Color of the bottom-most canvas; `undefined` leaves it transparent. */
+    setBackgroundColor(color) {
+      backgroundColor = color
+    },
+
+    /** Paint now, rather than waiting for the next `render` event. */
+    redraw() {
+      paint()
+    },
+
+    /** Drop the handlers and remove the canvases from the container. */
+    dispose() {
+      off()
+      canvases.forEach((canvas) => canvas.remove())
+    },
   }
 }

--- a/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.js
+++ b/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.js
@@ -839,7 +839,34 @@ export const createAnnotationLayers = (cytoscapeInstance) => {
   let annotationElements = []
   let backgroundColor
 
+  // Match the canvases to the container. The extension does this on `resize`
+  // and loses the handler to `removeAllListeners`, and Cytoscape does not emit
+  // `resize` for every layout change that moves the container, so this runs on
+  // every paint instead. Assigning `width` clears a canvas, hence the guard.
+  const syncSize = () => {
+    const container = cytoscapeInstance.container()
+    if (container === null || container === undefined) {
+      return
+    }
+    const pixelRatio = window.devicePixelRatio || 1
+    const width = container.offsetWidth
+    const height = container.offsetHeight
+    canvases.forEach((canvas) => {
+      if (
+        canvas.width === width * pixelRatio &&
+        canvas.height === height * pixelRatio
+      ) {
+        return
+      }
+      canvas.width = width * pixelRatio
+      canvas.height = height * pixelRatio
+      canvas.style.width = width + 'px'
+      canvas.style.height = height + 'px'
+    })
+  }
+
   const paint = () => {
+    syncSize()
     if (backgroundColor === undefined) {
       backgroundCtx.clearRect(
         0,
@@ -859,37 +886,15 @@ export const createAnnotationLayers = (cytoscapeInstance) => {
     painter.paintAnnotations(layers, annotationElements)
   }
 
-  // The extension sizes its canvas to the container on `resize` and loses that
-  // handler to `removeAllListeners`. Re-implement it so the annotation canvases
-  // keep tracking the container across renders.
-  const resize = () => {
-    const container = cytoscapeInstance.container()
-    if (container === null || container === undefined) {
-      return
-    }
-    const width = container.offsetWidth
-    const height = container.offsetHeight
-    const pixelRatio = window.devicePixelRatio || 1
-    canvases.forEach((canvas) => {
-      canvas.width = width * pixelRatio
-      canvas.height = height * pixelRatio
-      canvas.style.width = width + 'px'
-      canvas.style.height = height + 'px'
-    })
-    paint()
-  }
-
   const off = () => {
-    cytoscapeInstance.off('render cyCanvas.resize', paint)
-    cytoscapeInstance.off('resize', resize)
+    cytoscapeInstance.off('render cyCanvas.resize resize', paint)
   }
 
   return {
     /** (Re-)register the redraw handlers. Idempotent. */
     attach() {
       off()
-      cytoscapeInstance.on('render cyCanvas.resize', paint)
-      cytoscapeInstance.on('resize', resize)
+      cytoscapeInstance.on('render cyCanvas.resize resize', paint)
     },
 
     /** Replace the annotations drawn from the next paint on. */

--- a/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createAnnotationLayers } from './cyjsAnnotationRenderer'
+
+/**
+ * The single shape annotation from
+ * `test/fixtures/ndex/2496d8c5-5c74-11ec-b3be-0ac135e8bacf.valid.cx2`.
+ */
+const SHAPE_ANNOTATION =
+  'edgeThickness=1.0|canvas=background|fillOpacity=100.0|' +
+  'type=org.cytoscape.view.presentation.annotations.ShapeAnnotation|' +
+  'uuid=6723bbfb-39e1-49b5-83a3-b31b33426b53|' +
+  'customShape=NZ M 0.0 8.0 L 100.0 8.0 L 100.0 80.0 L 0.0 80.0 Z |' +
+  'shapeType=CUSTOM|edgeColor=-16777216|edgeOpacity=100.0|name=Round Rectangle|' +
+  'x=300.0|width=285.33|y=650.66|z=0|height=50.66'
+
+const niceCX = (annotations: string[]): any => ({
+  networkAttributes: {
+    elements: [{ n: '__Annotations', v: annotations }],
+  },
+})
+
+/** A 2D context that records the drawing calls made against it. */
+const createRecordingContext = (): any => {
+  const calls: string[] = []
+  const target: any = { calls }
+  return new Proxy(target, {
+    get(t, prop) {
+      if (prop in t) return t[prop]
+      return (...args: any[]) => {
+        calls.push(String(prop))
+        return args
+      }
+    },
+    set(t, prop, value) {
+      t[prop] = value
+      return true
+    },
+  })
+}
+
+/**
+ * A Cytoscape stand-in that mimics the parts `createAnnotationLayers` touches:
+ * `cyCanvas()` appends a fresh canvas every call (as the real extension does),
+ * and `removeAllListeners()` drops every handler (as `renderNetwork` does).
+ */
+const createFakeCy = (): any => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let handlers: Array<{ event: string; handler: (...a: any[]) => void }> = []
+
+  const cy: any = {
+    container: () => container,
+    on(events: string, handler: (...a: any[]) => void) {
+      events.split(/\s+/).forEach((event) => handlers.push({ event, handler }))
+    },
+    off(events: string, handler: (...a: any[]) => void) {
+      const targets = events.split(/\s+/)
+      handlers = handlers.filter(
+        (h) => !(targets.includes(h.event) && h.handler === handler),
+      )
+    },
+    removeAllListeners() {
+      handlers = []
+    },
+    trigger(event: string) {
+      handlers
+        .filter((h) => h.event === event)
+        .forEach(({ handler }) => handler())
+    },
+    handlerCount: () => handlers.length,
+    canvases: () => Array.from(container.querySelectorAll('canvas')),
+    cyCanvas(options: any) {
+      const canvas = document.createElement('canvas')
+      const ctx = createRecordingContext()
+      canvas.getContext = (() => ctx) as any
+      canvas.setAttribute('style', `z-index:${options.zIndex}`)
+      container.appendChild(canvas)
+      // The real extension registers this and loses it to removeAllListeners.
+      cy.on('resize', () => {})
+      return {
+        getCanvas: () => canvas,
+        clear: () => {},
+        resetTransform: () => {},
+        setTransform: () => {},
+      }
+    },
+  }
+  return cy
+}
+
+/** What `renderNetwork` does around the annotation layers on every render. */
+const simulateRender = (cy: any, layers: any, annotations: string[]): void => {
+  cy.removeAllListeners()
+  layers.setAnnotations(niceCX(annotations))
+  layers.setBackgroundColor('#FFFFFF')
+  layers.attach()
+  layers.redraw()
+}
+
+const paintedShapes = (cy: any): number =>
+  cy
+    .canvases()
+    .flatMap(
+      (canvas: HTMLCanvasElement) => (canvas.getContext('2d') as any).calls,
+    )
+    .filter((call: string) => call === 'bezierCurveTo' || call === 'lineTo')
+    .length
+
+describe('createAnnotationLayers', () => {
+  let cy: any
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    cy = createFakeCy()
+  })
+
+  it('creates exactly three canvases', () => {
+    createAnnotationLayers(cy)
+    expect(cy.canvases()).toHaveLength(3)
+  })
+
+  it('keeps three canvases across repeated renders', () => {
+    const layers = createAnnotationLayers(cy)
+    for (let i = 0; i < 4; i++) {
+      simulateRender(cy, layers, [SHAPE_ANNOTATION])
+    }
+    expect(cy.canvases()).toHaveLength(3)
+  })
+
+  it('repaints on render after renderNetwork calls removeAllListeners', () => {
+    const layers = createAnnotationLayers(cy)
+    simulateRender(cy, layers, [SHAPE_ANNOTATION])
+
+    const before = paintedShapes(cy)
+    cy.trigger('render')
+    expect(paintedShapes(cy)).toBeGreaterThan(before)
+  })
+
+  it('does not accumulate duplicate handlers when attach is called repeatedly', () => {
+    const layers = createAnnotationLayers(cy)
+    layers.attach()
+    const afterFirst = cy.handlerCount()
+    layers.attach()
+    layers.attach()
+    expect(cy.handlerCount()).toBe(afterFirst)
+  })
+
+  it('draws the annotations supplied by the latest render only', () => {
+    const layers = createAnnotationLayers(cy)
+    simulateRender(cy, layers, [SHAPE_ANNOTATION])
+    const withAnnotation = paintedShapes(cy)
+    expect(withAnnotation).toBeGreaterThan(0)
+
+    simulateRender(cy, layers, [])
+    const before = paintedShapes(cy)
+    cy.trigger('render')
+    expect(paintedShapes(cy)).toBe(before)
+  })
+
+  it('removes its canvases and handlers on dispose', () => {
+    const layers = createAnnotationLayers(cy)
+    cy.removeAllListeners() // drop the extension's own resize handlers
+    layers.attach()
+    layers.dispose()
+    expect(cy.canvases()).toHaveLength(0)
+    expect(cy.handlerCount()).toBe(0)
+  })
+})

--- a/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.test.ts
+++ b/src/features/NetworkPanel/CyjsRenderer/annotations/cyjsAnnotationRenderer.test.ts
@@ -43,8 +43,14 @@ const createRecordingContext = (): any => {
  * `cyCanvas()` appends a fresh canvas every call (as the real extension does),
  * and `removeAllListeners()` drops every handler (as `renderNetwork` does).
  */
+const CONTAINER_WIDTH = 400
+const CONTAINER_HEIGHT = 300
+
 const createFakeCy = (): any => {
   const container = document.createElement('div')
+  // jsdom does no layout, so the offsets a real container reports are stubbed.
+  Object.defineProperty(container, 'offsetWidth', { value: CONTAINER_WIDTH })
+  Object.defineProperty(container, 'offsetHeight', { value: CONTAINER_HEIGHT })
   document.body.appendChild(container)
   let handlers: Array<{ event: string; handler: (...a: any[]) => void }> = []
 
@@ -155,6 +161,25 @@ describe('createAnnotationLayers', () => {
     const before = paintedShapes(cy)
     cy.trigger('render')
     expect(paintedShapes(cy)).toBe(before)
+  })
+
+  it('sizes the canvases to the container on paint', () => {
+    const layers = createAnnotationLayers(cy)
+    const pixelRatio = window.devicePixelRatio || 1
+
+    // The extension sized them at creation; a container that grows afterwards
+    // without a Cytoscape `resize` event must still be picked up.
+    cy.canvases().forEach((canvas: HTMLCanvasElement) => {
+      canvas.width = 0
+      canvas.height = 0
+    })
+
+    layers.redraw()
+
+    cy.canvases().forEach((canvas: HTMLCanvasElement) => {
+      expect(canvas.width).toBe(CONTAINER_WIDTH * pixelRatio)
+      expect(canvas.height).toBe(CONTAINER_HEIGHT * pixelRatio)
+    })
   })
 
   it('removes its canvases and handlers on dispose', () => {

--- a/test/playwright/annotation-canvas-lifecycle.spec.ts
+++ b/test/playwright/annotation-canvas-lifecycle.spec.ts
@@ -1,0 +1,261 @@
+import path from 'path'
+
+import {
+  expect,
+  getWorkspaceNetworkCount,
+  gotoAndWaitReady,
+  test,
+} from './fixtures'
+import type { Page } from '@playwright/test'
+
+// Regression: #675 — annotation canvases from earlier renders were orphaned.
+// `renderNetwork` called `cyCanvas()` on every render, which appends a new
+// canvas and never reuses one, and `cy.removeAllListeners()` dropped the redraw
+// handlers of the older sets. Those canvases kept their last-painted pixels and
+// stayed fixed while the network zoomed and panned under them.
+
+const ANNOTATED_CX2 = path.resolve(
+  __dirname,
+  '../fixtures/ndex/2496d8c5-5c74-11ec-b3be-0ac135e8bacf.valid.cx2',
+)
+
+const ANNOTATED_NETWORK_NAME =
+  'WP5049 - Glycolysis in senescence - Homo sapiens'
+
+const PLAIN_CX2 = path.resolve(
+  __dirname,
+  '../fixtures/cx2/valid/small-network.valid.cx2',
+)
+
+const PLAIN_NETWORK_NAME = 'Test Network 20 nodes'
+
+// Cytoscape's own three layers plus one annotation set: background (z-index
+// -2), bottom (-1) and top (1).
+const EXPECTED_CANVAS_COUNT = 6
+
+// The annotation layer the fixture's shape annotation is drawn on: its
+// `canvas=background` property puts it on the bottom annotation layer.
+const ANNOTATION_CANVAS_Z_INDEX = '-1'
+
+// Signature of a canvas with nothing painted on it.
+const BLANK_SIGNATURE = '0:0'
+
+const importNetworkFile = async (page: Page, file: string): Promise<void> => {
+  await page.locator('[data-testid="toolbar-data-menu-menu-button"]').click()
+  await page.getByRole('menuitem', { name: 'Import' }).click()
+  const fromFileItem = page.getByRole('menuitem', {
+    name: 'Network from File...',
+  })
+  await expect(fromFileItem).toBeVisible()
+  await fromFileItem.click()
+  await expect(
+    page.locator('[data-testid="file-upload-dropzone"]'),
+  ).toBeVisible()
+  await page
+    .locator('[data-testid="file-upload-dropzone"] input[type="file"]')
+    .setInputFiles(file)
+}
+
+const countCanvases = (page: Page): Promise<number> =>
+  page.locator('#cy-container canvas').count()
+
+/**
+ * Open a network by clicking its entry in the workspace panel — the same path
+ * the bug report takes. `workspace.switchCurrentNetwork` moves the store but
+ * does not drive the loader, so the panel would sit on "Loading network data".
+ */
+const openNetwork = async (page: Page, name: string): Promise<void> => {
+  await page
+    .locator('[data-testid="network-browser-panel"]')
+    .getByText(name)
+    .first()
+    .click()
+}
+
+/**
+ * Wait until the renderer has put canvases on screen.
+ *
+ * A file import can reach the workspace before its network row is readable from
+ * IndexedDB. `useLoadCyNetwork` then shows "Failed to load network data" and
+ * never retries, so a reload is the only way forward. That race is unrelated to
+ * #675; handling it here keeps this spec independent of it.
+ */
+const waitForRenderedNetwork = async (page: Page): Promise<void> => {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const rendered = await page
+      .locator('#cy-container canvas')
+      .nth(EXPECTED_CANVAS_COUNT - 1)
+      .waitFor({ state: 'attached', timeout: 10000 })
+      .then(() => true)
+      .catch(() => false)
+
+    // The error panel can replace a renderer that already put canvases up, so
+    // the state only counts once it has held for a moment.
+    if (rendered) {
+      await page.waitForTimeout(1500)
+      const loadFailed = await page
+        .getByText('Failed to load network data')
+        .first()
+        .isVisible()
+        .catch(() => false)
+      const stillRendered = (await countCanvases(page)) >= EXPECTED_CANVAS_COUNT
+      if (!loadFailed && stillRendered) return
+    }
+
+    await page.reload()
+    await page.waitForFunction(
+      () => (window as unknown as { __cywebReady?: boolean }).__cywebReady,
+      undefined,
+      { timeout: 30000 },
+    )
+  }
+  throw new Error(
+    `the network never rendered ${EXPECTED_CANVAS_COUNT} canvases`,
+  )
+}
+
+/**
+ * Cheap fingerprint of every canvas under `#cy-container`, keyed by the inline
+ * z-index the layer was created with. Sampled rather than hashed in full: the
+ * test only needs "did these pixels change".
+ */
+const canvasSignatures = (page: Page): Promise<Record<string, string>> =>
+  page.evaluate(() => {
+    const signatures: Record<string, string> = {}
+    const canvases = Array.from(
+      document.querySelectorAll<HTMLCanvasElement>('#cy-container canvas'),
+    )
+    canvases.forEach((canvas, index) => {
+      const ctx = canvas.getContext('2d')
+      if (ctx === null || canvas.width === 0) return
+      const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      let sum = 0
+      let painted = 0
+      // Alpha channel of every pixel: a stroke a sparser sample would miss is
+      // still counted, and weighting by position makes a translation show up.
+      for (let i = 3; i < data.length; i += 4) {
+        if (data[i] !== 0) {
+          painted++
+          sum = (sum + i) % 2147483647
+        }
+      }
+      const zIndex = canvas.style.zIndex || 'none'
+      signatures[`${zIndex}#${index}`] = `${sum}:${painted}`
+    })
+    return signatures
+  })
+
+test.describe('Annotation canvas lifecycle', () => {
+  test('keeps one annotation canvas set across re-renders and network switches', async ({
+    page,
+  }) => {
+    // Recovering the import race below can cost several reloads.
+    test.setTimeout(120000)
+
+    await gotoAndWaitReady(page)
+    await importNetworkFile(page, ANNOTATED_CX2)
+
+    await expect
+      .poll(() => getWorkspaceNetworkCount(page), { timeout: 30000 })
+      .toBe(1)
+    await waitForRenderedNetwork(page)
+    await expect
+      .poll(() => countCanvases(page), { timeout: 30000 })
+      .toBe(EXPECTED_CANVAS_COUNT)
+
+    // A second network to switch to and back from.
+    await importNetworkFile(page, PLAIN_CX2)
+    await expect
+      .poll(() => getWorkspaceNetworkCount(page), { timeout: 30000 })
+      .toBe(2)
+
+    for (let i = 0; i < 3; i++) {
+      await openNetwork(page, PLAIN_NETWORK_NAME)
+      await waitForRenderedNetwork(page)
+      await expect
+        .poll(() => countCanvases(page), { timeout: 30000 })
+        .toBe(EXPECTED_CANVAS_COUNT)
+
+      await openNetwork(page, ANNOTATED_NETWORK_NAME)
+      await waitForRenderedNetwork(page)
+      await expect
+        .poll(() => countCanvases(page), { timeout: 30000 })
+        .toBe(EXPECTED_CANVAS_COUNT)
+    }
+  })
+
+  test('repaints every annotation layer on zoom', async ({ page }) => {
+    test.setTimeout(120000)
+
+    await gotoAndWaitReady(page)
+    await importNetworkFile(page, ANNOTATED_CX2)
+
+    await expect
+      .poll(() => getWorkspaceNetworkCount(page), { timeout: 30000 })
+      .toBe(1)
+    await waitForRenderedNetwork(page)
+
+    /** Keys of the annotation layers that currently hold painted pixels. */
+    const paintedAnnotationKeys = async (): Promise<string[]> => {
+      const signatures = await canvasSignatures(page)
+      return Object.keys(signatures).filter(
+        (key) =>
+          key.startsWith(`${ANNOTATION_CANVAS_Z_INDEX}#`) &&
+          signatures[key] !== BLANK_SIGNATURE,
+      )
+    }
+
+    // Capture the container box, the painted layers and their signatures in one
+    // step: the panel remounts while the network settles, and a value read
+    // before a remount does not describe the canvases that follow it.
+    let box: { x: number; y: number; width: number; height: number } | null =
+      null
+    let keys: string[] = []
+    let before: Record<string, string> = {}
+
+    await expect
+      .poll(
+        async () => {
+          // Bounded: the config sets no action timeout, so an unbounded
+          // boundingBox() on a briefly detached container blocks the test out.
+          const measured = await page
+            .locator('#cy-container')
+            .boundingBox({ timeout: 2000 })
+            .catch(() => null)
+          if (measured === null) return false
+          const painted = await paintedAnnotationKeys()
+          if (painted.length === 0) return false
+          box = measured
+          keys = painted
+          before = await canvasSignatures(page)
+          return true
+        },
+        { timeout: 60000 },
+      )
+      .toBe(true)
+
+    // Zoom with the wheel over the network, the way a user does.
+    const { x, y, width, height } = box as unknown as {
+      x: number
+      y: number
+      width: number
+      height: number
+    }
+    await page.mouse.move(x + width / 2, y + height / 2)
+    for (let i = 0; i < 5; i++) {
+      await page.mouse.wheel(0, -120)
+    }
+
+    // Every painted annotation layer must have moved with the network. A layer
+    // that keeps its signature is a frozen layer — the #675 symptom.
+    await expect
+      .poll(
+        async () => {
+          const after = await canvasSignatures(page)
+          return keys.filter((key) => after[key] === before[key])
+        },
+        { timeout: 30000 },
+      )
+      .toEqual([])
+  })
+})


### PR DESCRIPTION
`cyCanvas()` appends a new canvas on every call and never reuses one, so `renderNetwork` added three annotation canvases per render and removed none. `cy.removeAllListeners()` then dropped the redraw handlers of the older sets, leaving them frozen at the transform they last painted. The rounded rectangle stayed put while the network zoomed and panned under it, and every network switch added one more copy.

`createAnnotationLayers(cy)` now owns the three canvases for the lifetime of the Cytoscape instance. Each render swaps the annotation data and re-attaches the handlers instead of building new layers. `attach()` also replaces the extension's own `resize` handler, which `removeAllListeners` drops as well.

Fixes #675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation rendering stability when switching between networks.
  * Preserved annotation layers during zooming and redraws.
  * Prevented duplicate or stale annotation canvases from accumulating.
  * Ensured annotation cleanup works correctly during renderer reloads and remounts.

* **Tests**
  * Added automated coverage for annotation rendering, canvas reuse, repainting, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->