### PR TITLE
fix(workspace): move pane data-testids off Allotment onto real DOM elements

### DIFF
--- a/.serena/memories/lessons.md
+++ b/.serena/memories/lessons.md
@@ -38,6 +38,8 @@
 - [2026-08-03] jsdom drops CSS values it cannot parse: `getComputedStyle` returns `auto` for `width: min(500px, calc(100% - 32px))` while `calc(100% - 32px)` resolves fine. Layout-assertion unit tests must stick to values jsdom's cssstyle understands, or assert in Playwright instead.
 - [2026-08-25] MUI dialog dismissal: `stopPropagation()` on a `<Dialog>`'s own `onClick`/`onKeyDown` blocks NEITHER backdrop click nor Escape — MUI runs the user handler first and dismisses regardless. A paired `preventDefault()` DOES break typing inside the dialog. `disableEscapeKeyDown={false}` is the default and does nothing. Modals now close by button only: render through `CyDialog` (`src/components/CyDialog.tsx`), and every dialog needs a visible Cancel/Close or the user is trapped. See `docs/specifications/DIALOG_DISMISS_POLICY.md`.
 
+- [2026-08-28] Allotment drops unknown props: `Allotment`/`Allotment.Pane` forward only their declared props (children, className, minSize, maxSize, preferredSize, priority, snap, visible) — a `data-testid` on them never reaches the DOM (the library even hardcodes `data-testid="split-view-view"` on pane containers). Put test ids on a real element (wrapper Box) inside the pane; a Playwright wait on a pane-level testid otherwise times out, and the onboarding-tour anchor spec's source-literal fallback will NOT catch the dead attribute.
+
 ## Agent Workflow
 
 - [2026-07-28] Documentation patching: Treat truncated combined command output as diagnostic only; re-read the exact target range before constructing a multi-hunk `apply_patch`, because apparent duplicate lines may be output artifacts rather than file content.

--- a/src/features/Onboarding/tours/visibleSteps.ts
+++ b/src/features/Onboarding/tours/visibleSteps.ts
@@ -8,9 +8,9 @@ import { TourStepDef } from './types'
  * current network. This has to be an explicit check rather than a side effect
  * of joyride's TARGET_NOT_FOUND handling: joyride skips a step only when its
  * target is missing from the DOM, and several network-only targets are mounted
- * whether or not a network is loaded — `workspace-editor-center-pane` is an
- * unconditional Allotment.Pane in WorkspaceEditor, and `table-browser` sits on
- * TableBrowser's root Box. Those two therefore never self-skipped, so a
+ * whether or not a network is loaded — `workspace-editor-center-pane` sits on
+ * an always-mounted wrapper Box inside WorkspaceEditor's center pane, and
+ * `table-browser` sits on TableBrowser's root Box. Those two never self-skip, so a
  * first-run user with an empty workspace was told their network was drawn on
  * the canvas and that the table held the data behind the graph.
  */

--- a/src/features/Workspace/WorkspaceEditor.tsx
+++ b/src/features/Workspace/WorkspaceEditor.tsx
@@ -431,13 +431,17 @@ const WorkSpaceEditor = (): JSX.Element => {
   // Return the main component including the network panel, network view, and the table browser
   return (
     <Box
+      data-testid="workspace-editor"
       sx={{
         height: '100%',
         width: '100%',
         overflow: 'hidden',
       }}
     >
-      <Allotment data-testid="workspace-editor">
+      {/* Allotment / Allotment.Pane only forward their declared props, so a
+          data-testid put on them never reaches the DOM. Test ids live on the
+          wrapper Boxes inside each pane instead. */}
+      <Allotment>
         <Allotment
           vertical
           onChange={(sizes: number[]) => {
@@ -511,16 +515,23 @@ const WorkSpaceEditor = (): JSX.Element => {
                 </Box>
               )}
             </Allotment.Pane>
-            <Allotment.Pane data-testid="workspace-editor-center-pane">
-              <Outlet />
-              <NetworkPanel
-                networkId={currentNetworkId}
-                failedToLoad={failedToLoad}
-              />
+            <Allotment.Pane>
+              {/* Always mounted whether or not a network is loaded — the
+                  onboarding tour anchors its canvas step here (see
+                  tours/visibleSteps.ts). */}
+              <Box
+                data-testid="workspace-editor-center-pane"
+                sx={{ height: '100%', width: '100%' }}
+              >
+                <Outlet />
+                <NetworkPanel
+                  networkId={currentNetworkId}
+                  failedToLoad={failedToLoad}
+                />
+              </Box>
             </Allotment.Pane>
           </Allotment>
           <Allotment.Pane
-            data-testid="workspace-editor-bottom-pane"
             minSize={28}
             preferredSize={'25%'} // percentage of the total height of the workspace
             maxSize={
@@ -528,64 +539,72 @@ const WorkSpaceEditor = (): JSX.Element => {
               panels.bottom === PanelState.OPEN ? window.innerHeight * 0.9 : 28
             }
           >
-            {panels.bottom === PanelState.CLOSED ? (
-              <Tooltip title="Open table panel" arrow placement="top">
+            <Box
+              data-testid="workspace-editor-bottom-pane"
+              sx={{ height: '100%', width: '100%' }}
+            >
+              {panels.bottom === PanelState.CLOSED ? (
+                <Tooltip title="Open table panel" arrow placement="top">
+                  <Box
+                    data-testid="workspace-editor-bottom-panel-closed"
+                    onClick={() => setPanelState(Panel.BOTTOM, PanelState.OPEN)}
+                    sx={{
+                      width: '100%',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: (theme) =>
+                        theme.palette.background.paper,
+                      color: (theme) => theme.palette.text.secondary,
+                      borderTop: (theme) =>
+                        `2px solid ${theme.palette.divider}`,
+                      cursor: 'pointer',
+                      '&:hover': {
+                        color: (theme) => theme.palette.text.primary,
+                      },
+                    }}
+                  >
+                    <ExpandLessIcon />
+                  </Box>
+                </Tooltip>
+              ) : (
                 <Box
-                  data-testid="workspace-editor-bottom-panel-closed"
-                  onClick={() => setPanelState(Panel.BOTTOM, PanelState.OPEN)}
+                  data-testid="workspace-editor-bottom-panel-open"
                   sx={{
-                    width: '100%',
+                    height: '100%',
                     display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: (theme) => theme.palette.background.paper,
-                    color: (theme) => theme.palette.text.secondary,
-                    borderTop: (theme) => `2px solid ${theme.palette.divider}`,
-                    cursor: 'pointer',
-                    '&:hover': {
-                      color: (theme) => theme.palette.text.primary,
-                    },
+                    borderTop: (theme) => `4px solid ${theme.palette.divider}`,
                   }}
                 >
-                  <ExpandLessIcon />
-                </Box>
-              </Tooltip>
-            ) : (
-              <Box
-                data-testid="workspace-editor-bottom-panel-open"
-                sx={{
-                  height: '100%',
-                  display: 'flex',
-                  borderTop: (theme) => `4px solid ${theme.palette.divider}`,
-                }}
-              >
-                <Suspense
-                  fallback={
-                    <div data-testid="workspace-editor-table-browser-loading">
-                      {`Loading from NDEx`}
-                    </div>
-                  }
-                  key={currentNetworkId}
-                >
-                  <TableBrowser
-                    setHeight={setTableBrowserHeight}
-                    height={tableBrowserHeight}
-                    currentNetworkId={
-                      activeNetworkView === undefined ||
-                      activeNetworkView === ''
-                        ? currentNetworkId
-                        : activeNetworkView
+                  <Suspense
+                    fallback={
+                      <div data-testid="workspace-editor-table-browser-loading">
+                        {`Loading from NDEx`}
+                      </div>
                     }
-                  />
-                </Suspense>
-              </Box>
-            )}
+                    key={currentNetworkId}
+                  >
+                    <TableBrowser
+                      setHeight={setTableBrowserHeight}
+                      height={tableBrowserHeight}
+                      currentNetworkId={
+                        activeNetworkView === undefined ||
+                        activeNetworkView === ''
+                          ? currentNetworkId
+                          : activeNetworkView
+                      }
+                    />
+                  </Suspense>
+                </Box>
+              )}
+            </Box>
           </Allotment.Pane>
         </Allotment>
 
         {panels.right === PanelState.OPEN && (
-          <Allotment.Pane data-testid="workspace-editor-right-pane">
+          <Allotment.Pane>
             <Box
+              data-testid="workspace-editor-right-pane"
               sx={{
                 width: '100%',
                 height: '100%',


### PR DESCRIPTION
Fixes #693

## Problem

`Allotment` / `Allotment.Pane` only forward their declared props (`children`, `className`, `minSize`, `maxSize`, `preferredSize`, `priority`, `snap`, `visible`), so the `data-testid` attributes WorkspaceEditor placed on them were silently dropped — the library even hardcodes `data-testid="split-view-view"` on its pane containers. Consequences:

- The Getting Started tour's "canvas" step targets `workspace-editor-center-pane`; with the selector matching nothing, react-joyride fired `TARGET_NOT_FOUND` and silently skipped the step even with a network loaded.
- The CI anchor guard (`onboarding-tour-anchors.spec.ts`) didn't catch it because its source-literal fallback matched the dead attribute.
- Test authors waiting on these ids (e.g. `workspace-editor-right-pane`) got unexplained timeouts.

## Fix

Move each id onto a real DOM element instead of deleting them:

- `workspace-editor` → the editor's existing root `Box`
- `workspace-editor-center-pane` → a new full-size wrapper `Box` around `Outlet` + `NetworkPanel` (restores the tour step)
- `workspace-editor-bottom-pane` → a new full-size wrapper `Box` around the open/closed table-panel branches
- `workspace-editor-right-pane` → the pane's existing full-size inner `Box`

All wrappers are 100%×100% and every pane child already sizes to 100% of its parent, so layout is unchanged. Also updates the stale comment in `tours/visibleSteps.ts` and records the allotment prop-forwarding gotcha in `.serena/memories/lessons.md`.

## Verification

- No existing Playwright spec relies on the pane-level ids (checked `test/playwright/`).
- `npm run test:checks:quiet`: lint, typecheck, and all 3846 unit tests pass.
- Verified in the running app: all four ids resolve to exactly one correctly positioned element each, with layout identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace editor targeting for onboarding tours and automated interactions.
  * Ensured the workspace editor’s center area remains available consistently, including while network content loads.
  * Corrected element identification so workspace editor regions can be reliably located.

* **Documentation**
  * Added guidance for placing test identifiers on rendered elements within pane layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->