### PR TITLE
Say where the workspace lives: persistence status, online/offline, and a Data menu grouped around local-first storage (#697)

### DIFF
--- a/src/data/hooks/stores/AppStore.ts
+++ b/src/data/hooks/stores/AppStore.ts
@@ -24,6 +24,7 @@ import {
   putAppSettingToDb,
   putServiceAppToDb,
 } from '../../db'
+import { trackWrite } from './trackWrite'
 
 export const serviceFetcher = async (url: string): Promise<ServiceApp> => {
   // Fetch the service app metadata from the given URL
@@ -109,7 +110,7 @@ export const useAppStore = create(
         return
       }
       const serviceApp = await serviceFetcher(url)
-      await putServiceAppToDb(serviceApp)
+      await trackWrite(putServiceAppToDb(serviceApp))
 
       set((state) => {
         const newState = AppStoreImpl.addService(state, serviceApp)
@@ -140,7 +141,7 @@ export const useAppStore = create(
         return
       }
       const serviceApp = await serviceFetcher(url)
-      await putServiceAppToDb(serviceApp)
+      await trackWrite(putServiceAppToDb(serviceApp))
 
       set((state) => {
         const newState = AppStoreImpl.refreshService(state, serviceApp)
@@ -155,7 +156,7 @@ export const useAppStore = create(
         urls.map(async (url) => {
           try {
             const serviceApp = await serviceFetcher(url)
-            await putServiceAppToDb(serviceApp)
+            await trackWrite(putServiceAppToDb(serviceApp))
             set((state) => {
               const newState = AppStoreImpl.refreshService(state, serviceApp)
               state.serviceApps = newState.serviceApps
@@ -220,7 +221,7 @@ export const useAppStore = create(
         state.serviceApps = newState.serviceApps
 
         // Update the cached service app
-        putServiceAppToDb({ ...newState.serviceApps[url] })
+        trackWrite(putServiceAppToDb({ ...newState.serviceApps[url] }))
           .then(() => {
             logStore.info(
               `[${useAppStore.name}]: Target column updated for service app: ${url}`,
@@ -260,7 +261,7 @@ export const useAppStore = create(
         state.serviceApps = newState.serviceApps
 
         // Update the cached service app
-        putServiceAppToDb({ ...newState.serviceApps[url] })
+        trackWrite(putServiceAppToDb({ ...newState.serviceApps[url] }))
           .then(() => {
             logStore.info(
               `[${useAppStore.name}]: Target column updated for service app: ${url}`,
@@ -304,12 +305,14 @@ export const useAppStore = create(
       })
       // Persist to IndexedDB
       if (source !== undefined) {
-        putAppSettingToDb('manifestSource', source).catch((error) => {
-          logStore.error(
-            `[${useAppStore.name}]:[setManifestSource] Failed to persist:`,
-            error,
-          )
-        })
+        trackWrite(putAppSettingToDb('manifestSource', source)).catch(
+          (error) => {
+            logStore.error(
+              `[${useAppStore.name}]:[setManifestSource] Failed to persist:`,
+              error,
+            )
+          },
+        )
       } else {
         deleteAppSettingFromDb('manifestSource').catch((error) => {
           logStore.error(

--- a/src/data/hooks/stores/AppStore.ts
+++ b/src/data/hooks/stores/AppStore.ts
@@ -122,7 +122,7 @@ export const useAppStore = create(
     removeService: (url: string) => {
       set((state) => {
         const newState = AppStoreImpl.removeService(state, url)
-        deleteServiceAppFromDb(url).catch((error) => {
+        trackWrite(deleteServiceAppFromDb(url)).catch((error) => {
           logStore.error(
             `[${useAppStore.name}]: Failed to delete service metadata from ${url}`,
             error,
@@ -314,7 +314,7 @@ export const useAppStore = create(
           },
         )
       } else {
-        deleteAppSettingFromDb('manifestSource').catch((error) => {
+        trackWrite(deleteAppSettingFromDb('manifestSource')).catch((error) => {
           logStore.error(
             `[${useAppStore.name}]:[setManifestSource] Failed to delete:`,
             error,
@@ -330,7 +330,7 @@ export const useAppStore = create(
         state.loadStates = newState.loadStates
         return state
       })
-      deleteAppFromDb(id).catch((error) => {
+      trackWrite(deleteAppFromDb(id)).catch((error) => {
         logStore.error(
           `[${useAppStore.name}]:[remove] Failed to delete app ${id} from DB:`,
           error,

--- a/src/data/hooks/stores/FilterStore.ts
+++ b/src/data/hooks/stores/FilterStore.ts
@@ -171,7 +171,7 @@ export const useFilterStore = create(
         // being filled FROM the database, and deleting the row back out would
         // mint a change record every peer tab then hydrates in turn.
         if (!isHydrating()) {
-          void deleteFilterFromDb(name).catch((e) => {
+          void trackWrite(deleteFilterFromDb(name)).catch((e) => {
             logStore.error(
               `[${useFilterStore.name}]: Failed to delete the filter from db: ${name}`,
               e,

--- a/src/data/hooks/stores/FilterStore.ts
+++ b/src/data/hooks/stores/FilterStore.ts
@@ -14,6 +14,7 @@ import { ValueType } from '../../../models/TableModel'
 import { deleteFilterFromDb, putFilterToDb } from '../../db'
 import { toPlainObject } from '../../db/serialization'
 import { isHydrating } from './hydrationContext'
+import { trackWrite } from './trackWrite'
 
 /**
  * The store for both search and filter.
@@ -146,7 +147,7 @@ export const useFilterStore = create(
         // Convert to plain object before saving (filter may be an Immer proxy)
         const plainFilter = toPlainObject(filter)
         if (!isHydrating()) {
-          void putFilterToDb(plainFilter)
+          void trackWrite(putFilterToDb(plainFilter))
             .then(() => {
               logStore.info(
                 `[${useFilterStore.name}]: New filter saved to db: ${filter.name}`,
@@ -187,7 +188,7 @@ export const useFilterStore = create(
         // Convert to plain object before saving (filter may be an Immer proxy)
         const plainFilter = toPlainObject(filter)
         if (!isHydrating()) {
-          void putFilterToDb(plainFilter).catch((e) => {
+          void trackWrite(putFilterToDb(plainFilter)).catch((e) => {
             logStore.error(
               `[${useFilterStore.name}]: Failed to update the filter in db: ${name}`,
               e,
@@ -209,7 +210,7 @@ export const useFilterStore = create(
           // Convert Immer proxy to plain object before saving
           const plainFilter = toPlainObject(newFilter)
           if (!isHydrating()) {
-            putFilterToDb(plainFilter)
+            trackWrite(putFilterToDb(plainFilter))
               .then(() => {
                 logStore.info(
                   `[${useFilterStore.name}]: Range updated in db: ${name}`,

--- a/src/data/hooks/stores/NetworkStore.ts
+++ b/src/data/hooks/stores/NetworkStore.ts
@@ -320,7 +320,7 @@ export const useNetworkStore = create(
           // A stale pending put must never resurrect the deleted row
           cancelWrite(`NetworkStore:${networkId}`)
           if (!isHydrating()) {
-            void deleteNetworkFromDb(networkId).then(() => {
+            void trackWrite(deleteNetworkFromDb(networkId)).then(() => {
               logStore.info(
                 `[${useNetworkStore.name}]: Deleted network from db: ${networkId}`,
               )
@@ -335,7 +335,7 @@ export const useNetworkStore = create(
           }
           const newState = NetworkStoreImpl.deleteAll(state)
           if (!isHydrating()) {
-            clearNetworksFromDb()
+            trackWrite(clearNetworksFromDb())
               .then(() => {
                 logStore.info(
                   `[${useNetworkStore.name}]: Deleted all networks from db`,

--- a/src/data/hooks/stores/NetworkStore.ts
+++ b/src/data/hooks/stores/NetworkStore.ts
@@ -23,6 +23,7 @@ import {
 } from '../../db'
 import { cancelWrite, scheduleWrite } from './persistenceScheduler'
 import { isHydrating } from './hydrationContext'
+import { trackWrite } from './trackWrite'
 
 /**
  * Persist one network to IndexedDB, keyed by the network that was actually
@@ -43,6 +44,7 @@ const persistNetwork = (networkId: IdType): void => {
       // Deleted while the write was pending
       return Promise.resolve()
     }
+    // No trackWrite here: the scheduler reports every write it runs.
     return putNetworkToDb(network)
   })
 }
@@ -300,7 +302,7 @@ export const useNetworkStore = create(
             network.id,
           )
           if (!isHydrating()) {
-            void putNetworkToDb(network)
+            void trackWrite(putNetworkToDb(network))
               .then(() => {
                 logStore.info(`New network has been added to DB: ${network.id}`)
               })

--- a/src/data/hooks/stores/NetworkSummaryStore.ts
+++ b/src/data/hooks/stores/NetworkSummaryStore.ts
@@ -69,7 +69,7 @@ export const useNetworkSummaryStore = create(
         delete state.summaries[networkId]
       })
       if (!isHydrating()) {
-        void deleteNetworkSummaryFromDb(networkId)
+        void trackWrite(deleteNetworkSummaryFromDb(networkId))
           .then(() => {
             logStore.info(`[${STORE_LABEL}]: Summary deleted: ${networkId}`)
           })
@@ -83,7 +83,7 @@ export const useNetworkSummaryStore = create(
         state.summaries = {}
       })
       if (!isHydrating()) {
-        void clearNetworkSummaryFromDb()
+        void trackWrite(clearNetworkSummaryFromDb())
           .then((val) => {
             logStore.info(`[${STORE_LABEL}]: Summary cleared: ${val}`)
           })

--- a/src/data/hooks/stores/NetworkSummaryStore.ts
+++ b/src/data/hooks/stores/NetworkSummaryStore.ts
@@ -18,6 +18,7 @@ import {
 } from '../../db'
 import { toPlainObject } from '../../db/serialization'
 import { isHydrating } from './hydrationContext'
+import { trackWrite } from './trackWrite'
 const STORE_LABEL = 'NetworkSummaryStore'
 
 export const useNetworkSummaryStore = create(
@@ -28,11 +29,13 @@ export const useNetworkSummaryStore = create(
         state.summaries[networkId] = summary
       })
       if (!isHydrating()) {
-        void putNetworkSummaryToDb(toPlainObject(summary)).catch((err) => {
-          logStore.error(
-            `[${STORE_LABEL}]: Failed to save summary ${networkId}: ${err}`,
-          )
-        })
+        void trackWrite(putNetworkSummaryToDb(toPlainObject(summary))).catch(
+          (err) => {
+            logStore.error(
+              `[${STORE_LABEL}]: Failed to save summary ${networkId}: ${err}`,
+            )
+          },
+        )
       }
     },
     addAll: (summaries: Record<IdType, NetworkSummary>) => {
@@ -48,7 +51,7 @@ export const useNetworkSummaryStore = create(
       // Convert Immer proxy to plain object before saving
       const updatedSummary = toPlainObject({ ...summary, ...summaryUpdate })
       if (!isHydrating()) {
-        void putNetworkSummaryToDb(updatedSummary).catch((err) => {
+        void trackWrite(putNetworkSummaryToDb(updatedSummary)).catch((err) => {
           logStore.error(
             `[${STORE_LABEL}]: Failed to update summary ${networkId}: ${err}`,
           )

--- a/src/data/hooks/stores/OpaqueAspectStore.ts
+++ b/src/data/hooks/stores/OpaqueAspectStore.ts
@@ -20,6 +20,7 @@ import {
 } from '../../db'
 import { toPlainObject } from '../../db/serialization'
 import { isHydrating } from './hydrationContext'
+import { trackWrite } from './trackWrite'
 
 /**
  * Persistence helpers that stand down during cross-tab hydration.
@@ -37,7 +38,7 @@ const persistAspects = (networkId: IdType, aspects: OpaqueAspects): void => {
   if (isHydrating()) {
     return
   }
-  void putOpaqueAspectsToDb(networkId, aspects).catch((e) => {
+  void trackWrite(putOpaqueAspectsToDb(networkId, aspects)).catch((e) => {
     logStore.error(
       `[${useOpaqueAspectStore.name}]: Failed to persist opaque aspects for ${networkId}`,
       e,

--- a/src/data/hooks/stores/OpaqueAspectStore.ts
+++ b/src/data/hooks/stores/OpaqueAspectStore.ts
@@ -50,7 +50,7 @@ const removeAspects = (networkId: IdType): void => {
   if (isHydrating()) {
     return
   }
-  void deleteOpaqueAspectsFromDb(networkId).catch((e) => {
+  void trackWrite(deleteOpaqueAspectsFromDb(networkId)).catch((e) => {
     logStore.error(
       `[${useOpaqueAspectStore.name}]: Failed to delete opaque aspects for ${networkId}`,
       e,
@@ -62,7 +62,7 @@ const removeAllAspects = (): void => {
   if (isHydrating()) {
     return
   }
-  void clearOpaqueAspectsFromDb().catch((e) => {
+  void trackWrite(clearOpaqueAspectsFromDb()).catch((e) => {
     logStore.error(
       `[${useOpaqueAspectStore.name}]: Failed to clear opaque aspects`,
       e,

--- a/src/data/hooks/stores/PersistenceStatusStore.spec.ts
+++ b/src/data/hooks/stores/PersistenceStatusStore.spec.ts
@@ -157,6 +157,19 @@ describe('trackWrite', () => {
     )
   })
 
+  it('reports a failed delete, not only a failed put', async () => {
+    // A delete that fails on its own leaves memory and disk disagreeing, and
+    // the removed row returns on reload — the case the indicator exists for.
+    await trackWrite(Promise.reject(new Error('delete blocked'))).catch(
+      () => {},
+    )
+
+    expect(statusOf()).toBe('failed')
+    expect(usePersistenceStatusStore.getState().lastError).toBe(
+      'delete blocked',
+    )
+  })
+
   it('re-throws so the caller keeps its own error handling', async () => {
     const onError = vi.fn()
 

--- a/src/data/hooks/stores/PersistenceStatusStore.spec.ts
+++ b/src/data/hooks/stores/PersistenceStatusStore.spec.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  MIN_SAVING_MS,
+  usePersistenceStatusStore,
+} from './PersistenceStatusStore'
+import { trackWrite } from './trackWrite'
+
+const statusOf = () => usePersistenceStatusStore.getState().status
+
+describe('PersistenceStatusStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    usePersistenceStatusStore.getState().reset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Settle the hold that keeps a clean burst reading `saving`. */
+  const runOutHold = (): void => {
+    vi.advanceTimersByTime(MIN_SAVING_MS)
+  }
+
+  it('starts idle, with nothing to report yet', () => {
+    const state = usePersistenceStatusStore.getState()
+    expect(state.status).toBe('idle')
+    expect(state.pending).toBe(0)
+    expect(state.lastSavedAt).toBeUndefined()
+    expect(state.lastError).toBeUndefined()
+  })
+
+  it('reports saving while a write is in flight, then saved', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+
+    writeStarted()
+    expect(statusOf()).toBe('saving')
+
+    writeSettled()
+    // Held at 'saving' so the state is readable, but the save is already
+    // recorded.
+    expect(statusOf()).toBe('saving')
+    expect(usePersistenceStatusStore.getState().lastSavedAt).toBeTypeOf(
+      'number',
+    )
+
+    runOutHold()
+    expect(statusOf()).toBe('saved')
+  })
+
+  it('stays saving until the last write of a burst settles', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+
+    writeStarted()
+    writeStarted()
+    writeSettled()
+    expect(statusOf()).toBe('saving')
+    expect(usePersistenceStatusStore.getState().pending).toBe(1)
+
+    writeSettled()
+    runOutHold()
+    expect(statusOf()).toBe('saved')
+  })
+
+  it('reports failed when any write in the burst failed', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+
+    writeStarted()
+    writeStarted()
+    writeSettled(new Error('quota exceeded'))
+    // The sibling write still succeeds, but the burst is already tainted.
+    writeSettled()
+
+    expect(statusOf()).toBe('failed')
+    expect(usePersistenceStatusStore.getState().lastError).toBe(
+      'quota exceeded',
+    )
+    expect(usePersistenceStatusStore.getState().lastSavedAt).toBeUndefined()
+  })
+
+  it('keeps a failure visible until a later burst completes cleanly', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+
+    writeStarted()
+    writeSettled(new Error('disk full'))
+    expect(statusOf()).toBe('failed')
+
+    writeStarted()
+    writeSettled()
+    runOutHold()
+    expect(statusOf()).toBe('saved')
+    expect(usePersistenceStatusStore.getState().lastError).toBeUndefined()
+  })
+
+  it('clamps a settle that has no matching start', () => {
+    // A negative counter would leave the status stuck on 'saving' forever.
+    usePersistenceStatusStore.getState().writeSettled()
+    expect(usePersistenceStatusStore.getState().pending).toBe(0)
+    expect(statusOf()).toBe('saved')
+  })
+
+  it('keeps reporting saving when a write starts during the hold', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+
+    writeStarted()
+    writeSettled()
+    expect(statusOf()).toBe('saving')
+
+    // A second burst begins before the first one's hold expires; the expiring
+    // timer must not report 'saved' over a write that is still open.
+    writeStarted()
+    runOutHold()
+    expect(statusOf()).toBe('saving')
+
+    writeSettled()
+    runOutHold()
+    expect(statusOf()).toBe('saved')
+  })
+
+  it('drops the hold when the burst failed', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+
+    writeStarted()
+    writeSettled(new Error('quota exceeded'))
+    // No hold: a failure is reported the moment it is known.
+    expect(statusOf()).toBe('failed')
+
+    runOutHold()
+    expect(statusOf()).toBe('failed')
+  })
+
+  it('stringifies a non-Error rejection', () => {
+    const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+    writeStarted()
+    writeSettled('InvalidStateError')
+    expect(usePersistenceStatusStore.getState().lastError).toBe(
+      'InvalidStateError',
+    )
+  })
+})
+
+describe('trackWrite', () => {
+  beforeEach(() => {
+    usePersistenceStatusStore.getState().reset()
+  })
+
+  it('resolves to the wrapped value and records the save', async () => {
+    const result = await trackWrite(Promise.resolve('written'))
+
+    expect(result).toBe('written')
+    // Real timers here, so the status is still inside its readable hold.
+    expect(statusOf()).toBe('saving')
+    expect(usePersistenceStatusStore.getState().lastSavedAt).toBeTypeOf(
+      'number',
+    )
+  })
+
+  it('re-throws so the caller keeps its own error handling', async () => {
+    const onError = vi.fn()
+
+    await trackWrite(Promise.reject(new Error('boom'))).catch(onError)
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(statusOf()).toBe('failed')
+    expect(usePersistenceStatusStore.getState().lastError).toBe('boom')
+  })
+})

--- a/src/data/hooks/stores/PersistenceStatusStore.ts
+++ b/src/data/hooks/stores/PersistenceStatusStore.ts
@@ -42,9 +42,14 @@ const clearHold = (): void => {
  * - burst ended, at least one write failed -> `failed`, `lastError` kept
  *
  * A failure therefore stays visible until a later burst completes cleanly,
- * which is the point at which saving demonstrably works again. Deletes are not
- * tracked: a database that cannot accept a delete cannot accept a put either,
- * so the puts already report the condition.
+ * which is the point at which saving demonstrably works again.
+ *
+ * Every IndexedDB mutation reports, deletes and clears included. An earlier
+ * version tracked puts alone, on the reasoning that a database too broken to
+ * delete is too broken to write — true, but beside the point: a delete that
+ * fails on its own leaves memory and disk disagreeing, and the row the user
+ * just removed comes back on reload. That is exactly what this indicator
+ * exists to tell them.
  */
 export const usePersistenceStatusStore = create(
   immer<PersistenceStatusStore>((set, get) => ({

--- a/src/data/hooks/stores/PersistenceStatusStore.ts
+++ b/src/data/hooks/stores/PersistenceStatusStore.ts
@@ -1,0 +1,131 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+
+import { PersistenceStatusStore } from '@/models/StoreModel/PersistenceStatusStoreModel'
+
+/**
+ * How long `saving` stays reported once a burst has begun.
+ *
+ * A write is scheduled 300ms after the last mutation (`WRITE_DELAY_MS`) and
+ * then usually settles within a frame, so without a floor the `saving` state
+ * would last less than one paint — and when start and settle land in the same
+ * React batch, the UI would never observe it at all. Holding here rather than
+ * in the component is what makes that second case work: the store sees every
+ * transition, a subscriber only sees the ones it is rendered between.
+ */
+export const MIN_SAVING_MS = 700
+
+/** Pending flip from `saving` to `saved`. Module state, not store state. */
+let holdTimer: ReturnType<typeof setTimeout> | undefined
+
+const clearHold = (): void => {
+  if (holdTimer !== undefined) {
+    clearTimeout(holdTimer)
+    holdTimer = undefined
+  }
+}
+
+/**
+ * Whether the workspace is reaching IndexedDB, so the toolbar can say so.
+ *
+ * In-memory only: this describes the current tab's writes and must not itself
+ * be persisted. Every write path reports here through `trackWrite`
+ * (`./trackWrite.ts`) — including the ones that do not go through
+ * `persistenceScheduler`, because an indicator that watched only the scheduler
+ * would read "Saved in this browser" while a style or summary write was
+ * failing.
+ *
+ * Status rule, applied per burst of overlapping writes:
+ *
+ * - any write in flight -> `saving`
+ * - burst ended, every write succeeded -> `saved`, `lastSavedAt` stamped
+ * - burst ended, at least one write failed -> `failed`, `lastError` kept
+ *
+ * A failure therefore stays visible until a later burst completes cleanly,
+ * which is the point at which saving demonstrably works again. Deletes are not
+ * tracked: a database that cannot accept a delete cannot accept a put either,
+ * so the puts already report the condition.
+ */
+export const usePersistenceStatusStore = create(
+  immer<PersistenceStatusStore>((set, get) => ({
+    status: 'idle',
+    pending: 0,
+    burstFailed: false,
+    burstStartedAt: 0,
+
+    writeStarted: () => {
+      clearHold()
+      set((state) => {
+        if (state.pending === 0) {
+          state.burstFailed = false
+          state.burstStartedAt = Date.now()
+        }
+        state.pending += 1
+        state.status = 'saving'
+      })
+    },
+
+    writeSettled: (error?: unknown) => {
+      set((state) => {
+        // Clamped rather than trusted: a stray settle without its start would
+        // otherwise leave `pending` negative and the status stuck on 'saving'.
+        state.pending = Math.max(0, state.pending - 1)
+        if (error !== undefined) {
+          state.burstFailed = true
+          state.lastError =
+            error instanceof Error ? error.message : String(error)
+        }
+        if (state.pending > 0) {
+          return
+        }
+        if (state.burstFailed) {
+          // A failure is the more important of the two states and must not
+          // wait out a hold that is reporting the opposite.
+          state.status = 'failed'
+          return
+        }
+        state.lastSavedAt = Date.now()
+        state.lastError = undefined
+        state.status = 'saved'
+      })
+
+      if (get().status !== 'saved') {
+        clearHold()
+        return
+      }
+
+      const remaining = MIN_SAVING_MS - (Date.now() - get().burstStartedAt)
+      if (remaining <= 0) {
+        return
+      }
+      // Report the (already recorded) save only once it has been visible as
+      // `saving` for long enough to read.
+      set((state) => {
+        state.status = 'saving'
+      })
+      clearHold()
+      holdTimer = setTimeout(() => {
+        holdTimer = undefined
+        // A write that started during the hold owns the status now.
+        if (get().pending > 0 || get().burstFailed) {
+          return
+        }
+        set((state) => {
+          state.status = 'saved'
+        })
+      }, remaining)
+    },
+
+    reset: () => {
+      clearHold()
+      set((state) => {
+        state.status = 'idle'
+        state.pending = 0
+        state.burstFailed = false
+        state.burstStartedAt = 0
+        state.lastSavedAt = undefined
+        state.lastError = undefined
+      })
+    },
+  })),
+)

--- a/src/data/hooks/stores/StyleLibraryStore.ts
+++ b/src/data/hooks/stores/StyleLibraryStore.ts
@@ -124,7 +124,7 @@ export const useStyleLibraryStore = create(
         delete state.templates[id]
         return state
       })
-      void deleteStyleTemplateFromDb(id).catch((e) => {
+      void trackWrite(deleteStyleTemplateFromDb(id)).catch((e) => {
         logStore.error(
           `[${STORE_LABEL}]: Failed to delete template ${id}: ${e}`,
         )
@@ -136,7 +136,7 @@ export const useStyleLibraryStore = create(
         state.templates = {}
         return state
       })
-      void clearStyleLibraryFromDb().catch((e) => {
+      void trackWrite(clearStyleLibraryFromDb()).catch((e) => {
         logStore.error(`[${STORE_LABEL}]: Failed to clear style library: ${e}`)
       })
     },

--- a/src/data/hooks/stores/StyleLibraryStore.ts
+++ b/src/data/hooks/stores/StyleLibraryStore.ts
@@ -17,6 +17,7 @@ import {
   getAllStyleTemplatesFromDb,
   putStyleTemplateToDb,
 } from '../../db'
+import { trackWrite } from './trackWrite'
 
 /**
  * Workspace-level visual style template library.
@@ -79,7 +80,7 @@ export const useStyleLibraryStore = create(
       // Outside the recipe: an Immer producer must be pure, and a write issued
       // from inside one runs before the draft is finalized.
       if (created !== undefined) {
-        void putStyleTemplateToDb(created).catch((e) => {
+        void trackWrite(putStyleTemplateToDb(created)).catch((e) => {
           logStore.error(
             `[${STORE_LABEL}]: Failed to persist template ${id}: ${e}`,
           )
@@ -110,7 +111,7 @@ export const useStyleLibraryStore = create(
         return state
       })
       if (persisted !== undefined) {
-        void putStyleTemplateToDb(persisted).catch((e) => {
+        void trackWrite(putStyleTemplateToDb(persisted)).catch((e) => {
           logStore.error(
             `[${STORE_LABEL}]: Failed to persist template ${id}: ${e}`,
           )

--- a/src/data/hooks/stores/TableStore.ts
+++ b/src/data/hooks/stores/TableStore.ts
@@ -27,6 +27,7 @@ import { VisualPropertyGroup } from '../../../models/VisualStyleModel/VisualProp
 import { clearTablesFromDb, deleteTablesFromDb, putTablesToDb } from '../../db'
 import { isHydrating } from './hydrationContext'
 import { persistNetworkSlices } from './persistNetworkSlices'
+import { trackWrite } from './trackWrite'
 
 const persist = (config: StateCreator<TableStore>) =>
   persistNetworkSlices<TableStore, TableRecord>(config, {
@@ -354,7 +355,7 @@ export const useTableStore = create(
             // Skip during cross-tab hydration: the peer tab already deleted
             // this row, so re-deleting it only mints another change record.
             if (!isHydrating()) {
-              void deleteTablesFromDb(networkId)
+              void trackWrite(deleteTablesFromDb(networkId))
                 .then(() => {
                   logStore.info(
                     `[${useTableStore.name}]: Deleted network table from db: ${networkId}`,
@@ -374,7 +375,7 @@ export const useTableStore = create(
           set((state) => {
             state.tables = {}
             if (!isHydrating()) {
-              clearTablesFromDb()
+              trackWrite(clearTablesFromDb())
                 .then(() => {
                   logStore.info(
                     `[${useTableStore.name}]: Deleted all network tables from db`,

--- a/src/data/hooks/stores/ViewModelStore.ts
+++ b/src/data/hooks/stores/ViewModelStore.ts
@@ -22,6 +22,7 @@ import {
 import { isHydrating } from './hydrationContext'
 import { persistNetworkSlices } from './persistNetworkSlices'
 import { scheduleWrite } from './persistenceScheduler'
+import { trackWrite } from './trackWrite'
 
 // Re-export for compatibility
 export const DEF_VIEW_TYPE = ViewModelImpl.DEF_VIEW_TYPE
@@ -325,7 +326,7 @@ export const useViewModelStore = create(
           // Skip during cross-tab hydration: the peer tab already deleted this
           // row, so re-deleting it locally only mints another change record.
           if (!isHydrating()) {
-            void deleteNetworkViewsFromDb(networkId)
+            void trackWrite(deleteNetworkViewsFromDb(networkId))
               .then(() => {
                 logStore.info(
                   `[ViewModelStore]: Deleted network views from db: ${networkId}`,
@@ -345,7 +346,7 @@ export const useViewModelStore = create(
         },
         deleteAll() {
           if (!isHydrating()) {
-            void clearNetworkViewsFromDb()
+            void trackWrite(clearNetworkViewsFromDb())
               .then(() => {
                 logStore.info('[ViewModelStore]: Deleted all network views')
               })

--- a/src/data/hooks/stores/VisualStyleStore.ts
+++ b/src/data/hooks/stores/VisualStyleStore.ts
@@ -711,7 +711,7 @@ export const useVisualStyleStore = create(
           // Skip during cross-tab hydration: the peer tab already deleted this
           // row, so re-deleting it locally only mints another change record.
           if (!isHydrating()) {
-            void deleteVisualStyleFromDb(networkId)
+            void trackWrite(deleteVisualStyleFromDb(networkId))
               .then(() => {
                 logStore.info(
                   `[${useVisualStyleStore.name}]: Deleted visual style from db: ${networkId}`,
@@ -732,7 +732,7 @@ export const useVisualStyleStore = create(
           state.visualStyles = {}
           state.styleSets = {}
           if (!isHydrating()) {
-            clearVisualStyleFromDb()
+            trackWrite(clearVisualStyleFromDb())
               .then(() => {
                 logStore.info(
                   `[${useVisualStyleStore.name}]: Deleted all visual styles from db`,

--- a/src/data/hooks/stores/VisualStyleStore.ts
+++ b/src/data/hooks/stores/VisualStyleStore.ts
@@ -46,6 +46,7 @@ import {
 import { isHydrating } from './hydrationContext'
 import { persistNetworkSlices } from './persistNetworkSlices'
 import { useUndoStore } from './UndoStore'
+import { trackWrite } from './trackWrite'
 
 /**
  * Assemble the complete VisualStyleSet of a network from store state.
@@ -123,7 +124,7 @@ const isStyleSetAtCap = (styles: Record<IdType, unknown>): boolean =>
 const persistStyleSetOf = (networkId: IdType): void => {
   const assembled = assembleStyleSet(useVisualStyleStore.getState(), networkId)
   if (assembled !== undefined) {
-    void putVisualStyleSetToDb(networkId, assembled).catch((e) => {
+    void trackWrite(putVisualStyleSetToDb(networkId, assembled)).catch((e) => {
       logStore.error(
         `[VisualStyleStore]: Failed to persist style set of network ${networkId}: ${e}`,
       )
@@ -139,10 +140,12 @@ const persistStyleSetOf = (networkId: IdType): void => {
  */
 const clearUndoHistoryOf = (networkId: IdType): void => {
   useUndoStore.getState().addStack(networkId, { undoStack: [], redoStack: [] })
-  void putUndoRedoStackToDb(networkId, {
-    undoStack: [],
-    redoStack: [],
-  }).catch((e) => {
+  void trackWrite(
+    putUndoRedoStackToDb(networkId, {
+      undoStack: [],
+      redoStack: [],
+    }),
+  ).catch((e) => {
     logStore.error(
       `[VisualStyleStore]: Failed to persist cleared undo stack of network ${networkId}: ${e}`,
     )

--- a/src/data/hooks/stores/WorkspaceStore.ts
+++ b/src/data/hooks/stores/WorkspaceStore.ts
@@ -19,6 +19,7 @@ import { announceDatabaseReset } from '@/data/db/lifecycle'
 import { deleteDb, putWorkspaceToDb } from '../../db'
 import { toPlainObject } from '../../db/serialization'
 import { isHydrating } from './hydrationContext'
+import { trackWrite } from './trackWrite'
 
 const EMPTY_WORKSPACE: Workspace = {
   id: '',
@@ -89,7 +90,7 @@ const persist =
               toPlainObject(withoutTabNetworkId(lastWorkspace)),
             )
           ) {
-            void putWorkspaceToDb(plainWorkspace).catch((e) => {
+            void trackWrite(putWorkspaceToDb(plainWorkspace)).catch((e) => {
               logStore.error(
                 `[${useWorkspaceStore.name}]: Failed to persist workspace`,
                 e,

--- a/src/data/hooks/stores/persistNetworkSlices.ts
+++ b/src/data/hooks/stores/persistNetworkSlices.ts
@@ -3,6 +3,7 @@ import { StateCreator, StoreApi } from 'zustand'
 import { logStore } from '../../../debug'
 import { IdType } from '../../../models/IdType'
 import { cancelWrite, scheduleWrite } from './persistenceScheduler'
+import { trackWrite } from './trackWrite'
 import { isHydrating } from './hydrationContext'
 
 /**
@@ -88,7 +89,7 @@ export const persistNetworkSlices =
             // A stale pending put must never resurrect a deleted row
             cancelWrite(`${options.label}:${networkId}`)
             if (options.removeSlice !== undefined) {
-              void options.removeSlice(networkId).catch((e) => {
+              void trackWrite(options.removeSlice(networkId)).catch((e) => {
                 logStore.error(
                   `[${options.label}] Failed to delete from IndexedDB`,
                   e,

--- a/src/data/hooks/stores/persistenceScheduler.ts
+++ b/src/data/hooks/stores/persistenceScheduler.ts
@@ -1,4 +1,5 @@
 import { logStore } from '../../../debug'
+import { trackWrite } from './trackWrite'
 
 /**
  * Trailing write coalescer for IndexedDB persistence (REVIEW.md A2).
@@ -45,7 +46,7 @@ const runWrite = async (key: string): Promise<void> => {
 
   const write = (async () => {
     try {
-      await pending.execute()
+      await trackWrite(pending.execute())
     } catch (e) {
       logStore.error(
         `[${pending.label}] Failed to persist to IndexedDB (key: ${key})`,

--- a/src/data/hooks/stores/trackWrite.ts
+++ b/src/data/hooks/stores/trackWrite.ts
@@ -1,7 +1,11 @@
 import { usePersistenceStatusStore } from './PersistenceStatusStore'
 
 /**
- * Report one IndexedDB write to {@link usePersistenceStatusStore}.
+ * Report one IndexedDB mutation to {@link usePersistenceStatusStore}.
+ *
+ * Puts, deletes and clears all go through here: a delete that fails leaves
+ * memory and disk disagreeing just as a failed put does, and the row comes
+ * back on reload.
  *
  * Returns a promise that settles the same way the wrapped one does — the
  * rejection is re-thrown — so every existing `.catch` that logs the failure

--- a/src/data/hooks/stores/trackWrite.ts
+++ b/src/data/hooks/stores/trackWrite.ts
@@ -1,0 +1,25 @@
+import { usePersistenceStatusStore } from './PersistenceStatusStore'
+
+/**
+ * Report one IndexedDB write to {@link usePersistenceStatusStore}.
+ *
+ * Returns a promise that settles the same way the wrapped one does — the
+ * rejection is re-thrown — so every existing `.catch` that logs the failure
+ * keeps working unchanged. Wrapping is the whole integration:
+ *
+ * ```ts
+ * void trackWrite(putNetworkSummaryToDb(summary)).catch((e) => { ... })
+ * ```
+ */
+export const trackWrite = async <T>(promise: Promise<T>): Promise<T> => {
+  const { writeStarted, writeSettled } = usePersistenceStatusStore.getState()
+  writeStarted()
+  try {
+    const result = await promise
+    writeSettled()
+    return result
+  } catch (error) {
+    writeSettled(error)
+    throw error
+  }
+}

--- a/src/data/hooks/useOnlineStatus.ts
+++ b/src/data/hooks/useOnlineStatus.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Whether the browser currently reports a network connection.
+ *
+ * Deliberately separate from local persistence: Cytoscape Web keeps the
+ * workspace in this browser, so editing and autosave continue while offline.
+ * Only NDEx and other remote services are affected, and they are the only
+ * things that should be gated on this.
+ *
+ * `navigator.onLine` is a lower bound, not a guarantee: it reports whether the
+ * machine has a link, not whether NDEx is reachable. Treat `false` as certainly
+ * offline and `true` as "worth trying".
+ */
+
+const subscribe = (onChange: () => void): (() => void) => {
+  window.addEventListener('online', onChange)
+  window.addEventListener('offline', onChange)
+  return () => {
+    window.removeEventListener('online', onChange)
+    window.removeEventListener('offline', onChange)
+  }
+}
+
+const getSnapshot = (): boolean => window.navigator.onLine
+
+// SSR / prerender has no navigator; assume online so nothing renders as
+// unavailable in a context that cannot know.
+const getServerSnapshot = (): boolean => true
+
+export const useOnlineStatus = (): boolean =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)

--- a/src/features/Onboarding/content/concepts.ts
+++ b/src/features/Onboarding/content/concepts.ts
@@ -26,6 +26,8 @@ export const CONCEPT_SLIDES: ConceptSlide[] = [
     body: [
       'Your workspace holds every network you are working with, along with their tables and visual styles.',
       'It is saved automatically in this browser, so your networks are still here when you come back. Networks in a workspace are shared across browser tabs on this computer.',
+      'Nothing is uploaded to NDEx — or anywhere else — unless you ask for it. Editing a network you opened from NDEx leaves the copy in NDEx untouched.',
+      'Browser storage is not a backup: clearing site data, switching browsers or profiles, and private windows all lose it. Use Data › Export Workspace Backup, or save to NDEx, for a copy that outlives this browser.',
     ],
   },
   {

--- a/src/features/SummaryPanel/NetworkPropertyPanel.tsx
+++ b/src/features/SummaryPanel/NetworkPropertyPanel.tsx
@@ -43,7 +43,11 @@ import { KeycloakContext } from '@/boot/keycloak'
 import { IdType } from '../../models/IdType'
 import { NetworkSummary } from '../../models/NetworkSummaryModel'
 import { getRowActionStates } from './networkRowActions'
-import { getSaveButtonState, getSaveMenuItemState } from './networkSaveStatus'
+import {
+  getNetworkProvenance,
+  getSaveButtonState,
+  getSaveMenuItemState,
+} from './networkSaveStatus'
 
 // Lazy load the heavy network property editor with rich text editing capabilities
 const NetworkPropertyEditor = lazy(() => import('./NetworkPropertyEditor'))
@@ -150,6 +154,11 @@ export const NetworkPropertyPanel = ({
     networkModified,
     isNdex: summary.isNdex,
     authenticated,
+  })
+
+  const provenance = getNetworkProvenance({
+    networkModified,
+    isNdex: summary.isNdex,
   })
 
   const saveMenuItemState = getSaveMenuItemState({
@@ -544,20 +553,15 @@ export const NetworkPropertyPanel = ({
               gap: 1,
             }}
           >
-            <Tooltip
-              title={
-                summary.isNdex
-                  ? 'A network stored in the NDEx database (ndexbio.org)'
-                  : 'A network stored on your local machine'
-              }
-            >
+            <Tooltip title={provenance.originTooltip}>
               <Chip
+                data-testid="network-origin-chip"
                 color={summary.isNdex ? 'primary' : 'success'}
                 size="small"
                 sx={{ opacity: 0.8 }}
                 label={
                   <Typography sx={{ fontSize: 10 }} variant="caption">
-                    {summary.isNdex ? 'NDEx' : 'Local'}
+                    {provenance.origin}
                   </Typography>
                 }
               />
@@ -570,6 +574,25 @@ export const NetworkPropertyPanel = ({
             </Typography>
             {networkActionsMenuButton}
           </Box>
+          {provenance.modifiedLabel !== undefined && (
+            <Tooltip
+              title={provenance.modifiedTooltip}
+              placement="bottom-start"
+            >
+              <Typography
+                data-testid="network-modified-label"
+                variant="caption"
+                sx={{
+                  display: 'block',
+                  color: theme.palette.warning.main,
+                  ml: 0.5,
+                  fontSize: 10,
+                }}
+              >
+                {provenance.modifiedLabel}
+              </Typography>
+            </Tooltip>
+          )}
           {summary.sourcePath && (
             <Tooltip
               title="Import path from NDEx. This location is a snapshot and may not reflect recent moves or folder changes in NDEx."

--- a/src/features/SummaryPanel/networkSaveStatus.test.ts
+++ b/src/features/SummaryPanel/networkSaveStatus.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest'
 
-import { getSaveButtonState, getSaveMenuItemState } from './networkSaveStatus'
+import {
+  getNetworkProvenance,
+  getSaveButtonState,
+  getSaveMenuItemState,
+} from './networkSaveStatus'
 
 describe('getSaveButtonState (CW-488)', () => {
   it('shows the up-to-date state when there are no changes', () => {
@@ -139,5 +143,57 @@ describe('getSaveMenuItemState', () => {
       isCurrentNetwork: false,
     })
     expect(state.hint).toBe('Sign in to save to NDEx')
+  })
+})
+
+describe('getNetworkProvenance', () => {
+  it('reports an unmodified NDEx network as NDEx with nothing outstanding', () => {
+    const result = getNetworkProvenance({
+      networkModified: false,
+      isNdex: true,
+    })
+
+    expect(result.origin).toBe('NDEx')
+    expect(result.modifiedLabel).toBeUndefined()
+  })
+
+  it('reports an unmodified local network as Local with nothing outstanding', () => {
+    const result = getNetworkProvenance({
+      networkModified: false,
+      isNdex: false,
+    })
+
+    expect(result.origin).toBe('Local')
+    expect(result.modifiedLabel).toBeUndefined()
+  })
+
+  it('names the divergence from NDEx, not just "modified"', () => {
+    // The consequential fact about an edited NDEx network is that the remote
+    // copy is untouched — the row has to say so without a hover.
+    const result = getNetworkProvenance({ networkModified: true, isNdex: true })
+
+    expect(result.origin).toBe('NDEx')
+    expect(result.modifiedLabel).toBe('Changes not saved to NDEx')
+    expect(result.modifiedTooltip).toContain('unchanged until you save')
+  })
+
+  it('marks an edited local network as modified locally', () => {
+    const result = getNetworkProvenance({
+      networkModified: true,
+      isNdex: false,
+    })
+
+    expect(result.origin).toBe('Local')
+    expect(result.modifiedLabel).toBe('Modified locally')
+  })
+
+  it('keeps origin independent of modification state', () => {
+    // The chip says where the network came from; it must not flip to 'Local'
+    // just because an NDEx network has unsaved edits.
+    for (const networkModified of [true, false]) {
+      expect(
+        getNetworkProvenance({ networkModified, isNdex: true }).origin,
+      ).toBe('NDEx')
+    }
   })
 })

--- a/src/features/SummaryPanel/networkSaveStatus.ts
+++ b/src/features/SummaryPanel/networkSaveStatus.ts
@@ -95,3 +95,54 @@ export const getSaveMenuItemState = ({
 
   return { label, hint, disabled: hint !== undefined }
 }
+
+export interface NetworkProvenance {
+  /** Where the network came from. Short enough for a chip. */
+  origin: 'NDEx' | 'Local'
+  /** Tooltip for the origin chip. */
+  originTooltip: string
+  /**
+   * Visible label for local edits that are not in the network's remote copy,
+   * or undefined when there is nothing unsaved.
+   */
+  modifiedLabel?: string
+  /** Tooltip for that label. */
+  modifiedTooltip?: string
+}
+
+/**
+ * Origin and local-modification state of one network row (#697).
+ *
+ * `networkModified` already drove the save icon's colour and tooltip, which
+ * left the most consequential fact about an NDEx-backed network — that editing
+ * it here does not touch the copy in NDEx — visible only on hover. This returns
+ * the same state as text the row can render at rest.
+ *
+ * Origin and modification are reported separately on purpose: the chip says
+ * where the network came from, not where its current contents are.
+ */
+export const getNetworkProvenance = ({
+  networkModified,
+  isNdex,
+}: {
+  networkModified: boolean
+  isNdex: boolean
+}): NetworkProvenance => {
+  const origin: NetworkProvenance['origin'] = isNdex ? 'NDEx' : 'Local'
+  const originTooltip = isNdex
+    ? 'Opened from the NDEx database (ndexbio.org). Your working copy is stored in this browser.'
+    : 'Created or imported here. This network exists only in this browser until you save it to NDEx or export it.'
+
+  if (!networkModified) {
+    return { origin, originTooltip }
+  }
+
+  return {
+    origin,
+    originTooltip,
+    modifiedLabel: isNdex ? 'Changes not saved to NDEx' : 'Modified locally',
+    modifiedTooltip: isNdex
+      ? 'Edited since it was opened from NDEx. The copy in NDEx is unchanged until you save to it.'
+      : 'Edited since it was created or imported. The changes are saved in this browser only.',
+  }
+}

--- a/src/features/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/CopyNetworkToNDExMenuItem.tsx
@@ -30,6 +30,7 @@ import { HcxValidationSaveDialog } from '../../HierarchyViewer/components/Valida
 import { useHcxValidatorStore } from '../../HierarchyViewer/store/HcxValidatorStore'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 
 export const CopyNetworkToNDExMenuItem = (
   props: BaseMenuItemProps,
@@ -166,14 +167,15 @@ export const CopyNetworkToNDExMenuItem = (
   if (!authenticated && currentNetworkId !== '') {
     tooltipTitle = 'Login to save a copy of the current network to NDEx'
   }
+  const ndex = useNdexGate(enabled, tooltipTitle)
 
   return (
     <>
       <DropdownMenuItem
         label="Save Copy to NDEx"
         icon={<CloudUploadIcon />}
-        tooltip={tooltipTitle}
-        disabled={!enabled}
+        tooltip={ndex.tooltip}
+        disabled={ndex.disabled}
         onClick={handleClick}
       />
       {enabled && (

--- a/src/features/ToolBar/DataMenu/DataMenu_docs/WorkspaceMenuItems.md
+++ b/src/features/ToolBar/DataMenu/DataMenu_docs/WorkspaceMenuItems.md
@@ -138,7 +138,7 @@ Dialog component for naming a workspace before saving to NDEx.
 
 ### Saving a Workspace (New)
 
-1. User clicks "Save Workspace As..." menu item
+1. User clicks "Save Workspace to NDEx As..." menu item
 2. Naming dialog opens
 3. User enters workspace name
 4. System checks for duplicate names

--- a/src/features/ToolBar/DataMenu/ExportWorkspaceBackupMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/ExportWorkspaceBackupMenuItem.tsx
@@ -1,13 +1,21 @@
 import DownloadIcon from '@mui/icons-material/Download'
 import { ReactElement } from 'react'
 
-import { useMessageStore } from '../../../data/hooks/stores/MessageStore'
-import { logUi } from '../../../debug'
-import { MessageSeverity } from '../../../models/MessageModel'
+import { useMessageStore } from '@/data/hooks/stores/MessageStore'
+import { logUi } from '@/debug'
+import { MessageSeverity } from '@/models/MessageModel'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
 
-export const ExportDatabaseMenuItem = (
+/**
+ * Writes the whole local workspace — every network, table, style and the
+ * workspace row itself — to a file the user can keep.
+ *
+ * Named for what it is to a user rather than for the storage underneath
+ * (#697): this was `Export Database Snapshot` under Help > Developer, where
+ * the one durable backup of a local-first app was effectively hidden.
+ */
+export const ExportWorkspaceBackupMenuItem = (
   props: BaseMenuItemProps,
 ): ReactElement => {
   const addMessage = useMessageStore((state) => state.addMessage)
@@ -22,17 +30,17 @@ export const ExportDatabaseMenuItem = (
       )
       await exportDatabaseSnapshotToFile()
       addMessage({
-        message: 'Database snapshot exported successfully.',
+        message: 'Workspace backup exported.',
         duration: 3000,
         severity: MessageSeverity.SUCCESS,
       })
     } catch (error) {
       logUi.error(
-        `[${ExportDatabaseMenuItem.name}]:[${handleExport.name}] Failed to export database snapshot`,
+        `[${ExportWorkspaceBackupMenuItem.name}]:[${handleExport.name}] Failed to export database snapshot`,
         error,
       )
       addMessage({
-        message: 'Failed to export database snapshot. Please try again.',
+        message: 'Failed to export the workspace backup. Please try again.',
         duration: 5000,
         severity: MessageSeverity.ERROR,
       })
@@ -41,7 +49,7 @@ export const ExportDatabaseMenuItem = (
 
   return (
     <DropdownMenuItem
-      label="Export Database Snapshot"
+      label="Export Workspace Backup..."
       icon={<DownloadIcon />}
       onClick={handleExport}
     />

--- a/src/features/ToolBar/DataMenu/LoadDemoNetworksMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/LoadDemoNetworksMenuItem.tsx
@@ -8,8 +8,12 @@ import { useNetworkSummaryStore } from '../../../data/hooks/stores/NetworkSummar
 import { useWorkspaceStore } from '../../../data/hooks/stores/WorkspaceStore'
 import { NetworkSummary } from '../../../models'
 import { IdType } from '../../../models/IdType'
+import { useMessageStore } from '../../../data/hooks/stores/MessageStore'
+import { MessageSeverity } from '../../../models/MessageModel'
+import { logUi } from '../../../debug'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 
 export const LoadDemoNetworksMenuItem = (
   props: BaseMenuItemProps,
@@ -28,35 +32,59 @@ export const LoadDemoNetworksMenuItem = (
     (state) => state.setCurrentNetworkId,
   )
   const { getToken } = useCredentialStore()
-  const handleAddDemoNetworks = async () => {
-    const token = await getToken()
-    const summaries = await fetchNdexSummaries(testNetworks, token)
-    addNetworks(testNetworks)
+  const addMessage = useMessageStore((state) => state.addMessage)
 
-    addSummaries(
-      summaries.reduce(
-        (acc, summary) => {
-          acc[summary.externalId] = summary
-          return acc
-        },
-        {} as Record<IdType, NetworkSummary>,
-      ),
-    )
+  // The sample networks are fetched from NDEx, so this is a remote operation
+  // like the rest of them and goes grey with the others when offline.
+  const ndex = useNdexGate(true, '')
 
-    setCurrentNetworkId(testNetworks[0])
-    navigateToNetwork({
-      workspaceId: workspace.id,
-      networkId: testNetworks[0],
-      searchParams: new URLSearchParams(location.search),
-      replace: false,
-    })
-    props.onClick()
+  const handleAddDemoNetworks = async (): Promise<void> => {
+    // DropdownMenuItem calls onClick without awaiting, so a rejection here
+    // used to surface as an unhandled rejection and nothing else: the menu
+    // closed and no networks appeared, with no indication why.
+    try {
+      const token = await getToken()
+      const summaries = await fetchNdexSummaries(testNetworks, token)
+      addNetworks(testNetworks)
+
+      addSummaries(
+        summaries.reduce(
+          (acc, summary) => {
+            acc[summary.externalId] = summary
+            return acc
+          },
+          {} as Record<IdType, NetworkSummary>,
+        ),
+      )
+
+      setCurrentNetworkId(testNetworks[0])
+      navigateToNetwork({
+        workspaceId: workspace.id,
+        networkId: testNetworks[0],
+        searchParams: new URLSearchParams(location.search),
+        replace: false,
+      })
+    } catch (error) {
+      logUi.error(
+        `[${LoadDemoNetworksMenuItem.name}]:[handleAddDemoNetworks] Failed to fetch the sample networks`,
+        error,
+      )
+      addMessage({
+        message: 'Could not reach NDEx to load the sample networks.',
+        duration: 5000,
+        severity: MessageSeverity.ERROR,
+      })
+    } finally {
+      props.onClick()
+    }
   }
 
   return (
     <DropdownMenuItem
       label="Open Sample Networks"
-      onClick={handleAddDemoNetworks}
+      tooltip={ndex.tooltip}
+      disabled={ndex.disabled}
+      onClick={() => void handleAddDemoNetworks()}
     />
   )
 }

--- a/src/features/ToolBar/DataMenu/LoadFromNdexMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/LoadFromNdexMenuItem.tsx
@@ -3,14 +3,19 @@ import { ReactElement } from 'react'
 
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 
 export const LoadFromNdexMenuItem = (
   props: BaseMenuItemProps,
 ): ReactElement => {
+  const ndex = useNdexGate(true, '')
+
   return (
     <DropdownMenuItem
       label="Open Network(s) from NDEx..."
       icon={<CloudDownloadIcon />}
+      tooltip={ndex.tooltip}
+      disabled={ndex.disabled}
       onClick={props.onClick}
     />
   )

--- a/src/features/ToolBar/DataMenu/LoadWorkspaceMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/LoadWorkspaceMenuItem.tsx
@@ -4,19 +4,24 @@ import { ReactElement, useContext } from 'react'
 import { KeycloakContext } from '@/boot/keycloak'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 
 export const LoadWorkspaceMenuItem = (
   props: BaseMenuItemProps,
 ): ReactElement => {
   const client = useContext(KeycloakContext)
   const authenticated: boolean = client?.authenticated ?? false
+  const ndex = useNdexGate(
+    authenticated,
+    authenticated ? '' : 'Login to see your own workspace',
+  )
 
   return (
     <DropdownMenuItem
       label="Open Workspace from NDEx..."
-      tooltip={authenticated ? '' : 'Login to see your own workspace'}
+      tooltip={ndex.tooltip}
       icon={<CloudDownloadIcon />}
-      disabled={!authenticated}
+      disabled={ndex.disabled}
       onClick={props.onClick}
     />
   )

--- a/src/features/ToolBar/DataMenu/OpenWorkspaceBackupMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/OpenWorkspaceBackupMenuItem.tsx
@@ -16,7 +16,14 @@ const DatabaseSnapshotFileUpload = lazy(() =>
   })),
 )
 
-export const ImportDatabaseMenuItem = (
+/**
+ * Restores a workspace previously written by `ExportWorkspaceBackupMenuItem`,
+ * replacing the local workspace wholesale.
+ *
+ * Named for what it is to a user rather than for the storage underneath
+ * (#697); this was `Import Database Snapshot` under Help > Developer.
+ */
+export const OpenWorkspaceBackupMenuItem = (
   props: BaseMenuItemProps,
 ): ReactElement => {
   const [showUpload, setShowUpload] = useState(false)
@@ -54,7 +61,7 @@ export const ImportDatabaseMenuItem = (
           0,
         )
         addMessage({
-          message: `Database snapshot imported successfully. ${totalImported} records imported.`,
+          message: `Workspace backup opened. ${totalImported} records restored.`,
           duration: 5000,
           severity: MessageSeverity.SUCCESS,
         })
@@ -66,7 +73,7 @@ export const ImportDatabaseMenuItem = (
       } else {
         const errorMsg = result.errors?.join(', ') || 'Unknown error'
         addMessage({
-          message: `Database snapshot import completed with errors: ${errorMsg}`,
+          message: `Workspace backup opened with errors: ${errorMsg}`,
           duration: 7000,
           severity: MessageSeverity.WARNING,
         })
@@ -76,7 +83,7 @@ export const ImportDatabaseMenuItem = (
       }
     } catch (error) {
       logUi.error(
-        `[${ImportDatabaseMenuItem.name}]:[${handleImport.name}] Failed to import database snapshot`,
+        `[${OpenWorkspaceBackupMenuItem.name}]:[${handleImport.name}] Failed to import database snapshot`,
         error,
       )
       addMessage({
@@ -106,7 +113,7 @@ export const ImportDatabaseMenuItem = (
   return (
     <>
       <DropdownMenuItem
-        label="Import Database Snapshot..."
+        label="Open Workspace Backup..."
         icon={<UploadIcon />}
         onClick={handleMenuItemClick}
       />
@@ -122,13 +129,13 @@ export const ImportDatabaseMenuItem = (
         </Suspense>
       )}
       <ConfirmationDialog
-        title="Import Database Snapshot"
-        message={`Are you sure you want to import the database snapshot from "${file?.name}"? This will replace all existing data in the database. This action cannot be undone.`}
+        title="Open Workspace Backup"
+        message={`Open the workspace backup "${file?.name}"? Everything currently in your local workspace — networks, tables and styles — is replaced. This cannot be undone.`}
         onConfirm={handleImport}
         onCancel={handleCancel}
         open={showConfirm}
         setOpen={setShowConfirm}
-        buttonTitle="Import (cannot be undone)"
+        buttonTitle="Open Backup (cannot be undone)"
         isAlert={true}
       />
     </>

--- a/src/features/ToolBar/DataMenu/OpenWorkspaceBackupMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/OpenWorkspaceBackupMenuItem.tsx
@@ -83,12 +83,12 @@ export const OpenWorkspaceBackupMenuItem = (
       }
     } catch (error) {
       logUi.error(
-        `[${OpenWorkspaceBackupMenuItem.name}]:[${handleImport.name}] Failed to import database snapshot`,
+        `[${OpenWorkspaceBackupMenuItem.name}]:[${handleImport.name}] Failed to open the workspace backup`,
         error,
       )
       addMessage({
         message:
-          'Failed to import database snapshot. Please check the file format and try again.',
+          'Failed to open the workspace backup. Please check the file and try again.',
         duration: 5000,
         severity: MessageSeverity.ERROR,
       })

--- a/src/features/ToolBar/DataMenu/ResetLocalWorkspace.tsx
+++ b/src/features/ToolBar/DataMenu/ResetLocalWorkspace.tsx
@@ -9,7 +9,7 @@ export const ResetLocalWorkspaceMenuItem = (
 ): ReactElement => {
   return (
     <DropdownMenuItem
-      label="Clear Local Database"
+      label="Clear Local Workspace..."
       icon={<CancelOutlinedIcon />}
       onClick={props.onClick}
     />

--- a/src/features/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
+++ b/src/features/ToolBar/DataMenu/SaveToNDExMenuItem.tsx
@@ -39,6 +39,7 @@ import { HcxValidationSaveDialog } from '../../HierarchyViewer/components/Valida
 import { useHcxValidatorStore } from '../../HierarchyViewer/store/HcxValidatorStore'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 
 export const SaveToNDExMenuItem = (props: BaseMenuItemProps): ReactElement => {
   const { ndexBaseUrl } = useContext(AppConfigContext)
@@ -276,6 +277,7 @@ export const SaveToNDExMenuItem = (props: BaseMenuItemProps): ReactElement => {
   const enabled =
     currentNetworkId !== '' &&
     (summary?.isNdex ? isModified && editPermission : authenticated)
+  const ndex = useNdexGate(enabled, tooltipText)
 
   const dialog = (
     <CyDialog data-testid="save-to-ndex-sync-dialog" open={showConfirmDialog}>
@@ -330,9 +332,9 @@ export const SaveToNDExMenuItem = (props: BaseMenuItemProps): ReactElement => {
     <>
       <DropdownMenuItem
         label="Save Network to NDEx"
-        tooltip={tooltipText}
+        tooltip={ndex.tooltip}
         icon={<CloudUploadIcon />}
-        disabled={!enabled}
+        disabled={ndex.disabled}
         onClick={handleClick}
       />
       {enabled && (

--- a/src/features/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/features/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -40,7 +40,7 @@ export const SaveWorkspaceToNDExMenuItem = (
   return (
     <>
       <DropdownMenuItem
-        label="Save Workspace As..."
+        label="Save Workspace to NDEx As..."
         tooltip={tooltipTitle}
         disabled={!enabled}
         onClick={enabled ? handleSaveWorkspaceToNDEx : () => {}}

--- a/src/features/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
+++ b/src/features/ToolBar/DataMenu/SaveWorkspaceToNDEx.tsx
@@ -6,6 +6,7 @@ import { useWorkspaceStore } from '../../../data/hooks/stores/WorkspaceStore'
 import { KeycloakContext } from '@/boot/keycloak'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 import { WorkspaceNamingDialog } from './WorkspaceNamingDialog'
 
 export const SaveWorkspaceToNDExMenuItem = (
@@ -36,13 +37,14 @@ export const SaveWorkspaceToNDExMenuItem = (
   if (!enabled && allNetworkId.length > 0) {
     tooltipTitle = 'Login to save a copy of the current workspace to NDEx'
   }
+  const ndex = useNdexGate(enabled, tooltipTitle)
 
   return (
     <>
       <DropdownMenuItem
         label="Save Workspace to NDEx As..."
-        tooltip={tooltipTitle}
-        disabled={!enabled}
+        tooltip={ndex.tooltip}
+        disabled={ndex.disabled}
         onClick={enabled ? handleSaveWorkspaceToNDEx : () => {}}
       />
       {enabled && (

--- a/src/features/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/features/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -102,7 +102,7 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
   return (
     <>
       <DropdownMenuItem
-        label="Save Workspace"
+        label="Save Workspace to NDEx"
         tooltip={tooltipTitle}
         disabled={!enabled}
         onClick={enabled ? handleSaveWorkspaceToNDEx : () => {}}

--- a/src/features/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
+++ b/src/features/ToolBar/DataMenu/SaveWorkspaceToNDExOverwrite.tsx
@@ -9,6 +9,7 @@ import { KeycloakContext } from '@/boot/keycloak'
 import { MessageSeverity } from '../../../models/MessageModel'
 import { BaseMenuItemProps } from '../BaseMenuItemProps'
 import { DropdownMenuItem } from '../DropdownMenu'
+import { useNdexGate } from './ndexAvailability'
 import { WorkspaceNamingDialog } from './WorkspaceNamingDialog'
 
 export const SaveWorkspaceToNDExOverwriteMenuItem = (
@@ -98,13 +99,14 @@ export const SaveWorkspaceToNDExOverwriteMenuItem = (
   } else if (allNetworkId.length > 0) {
     tooltipTitle = 'Login to save/overwrite the current workspace to NDEx'
   }
+  const ndex = useNdexGate(enabled, tooltipTitle)
 
   return (
     <>
       <DropdownMenuItem
         label="Save Workspace to NDEx"
-        tooltip={tooltipTitle}
-        disabled={!enabled}
+        tooltip={ndex.tooltip}
+        disabled={ndex.disabled}
         onClick={enabled ? handleSaveWorkspaceToNDEx : () => {}}
       />
       {enabled && (

--- a/src/features/ToolBar/DataMenu/index.tsx
+++ b/src/features/ToolBar/DataMenu/index.tsx
@@ -23,12 +23,14 @@ import { CopyNetworkToNDExMenuItem } from './CopyNetworkToNDExMenuItem'
 import { DownloadNetworkMenuItem } from './DownloadNetworkMenuItem'
 import { DuplicateNetworkMenuItem } from './DuplicateNetworkMenuItem'
 import { ExportImageMenuItem } from './ExportNetworkToImage/DynamicExportImageMenuItem'
+import { ExportWorkspaceBackupMenuItem } from './ExportWorkspaceBackupMenuItem'
 import { UploadNetworkMenuItem } from './ImportNetworkFromFileMenuItem'
 import { LoadDemoNetworksMenuItem } from './LoadDemoNetworksMenuItem'
 import { LoadFromNdexDialog } from './LoadFromNdexDialog'
 import { LoadFromNdexMenuItem } from './LoadFromNdexMenuItem'
 import LoadWorkspaceDialog from './LoadWorkspaceDialog'
 import { LoadWorkspaceMenuItem } from './LoadWorkspaceMenuItem'
+import { OpenWorkspaceBackupMenuItem } from './OpenWorkspaceBackupMenuItem'
 import { useLoadFromNdexDialogStore } from './store/loadFromNdexDialogStore'
 import { OpenNetworkInCytoscapeMenuItem } from './OpenNetworkInCytoscapeMenuItem'
 import { RemoveAllNetworksMenuItem } from './RemoveAllNetworksMenuItem'
@@ -167,7 +169,14 @@ export const DataMenu = () => {
     })
   }
 
+  /**
+   * Grouped around the local-first storage model (#697): what comes IN, what
+   * lives in this browser, what is deliberately pushed OUT to NDEx, and what
+   * destroys local data. Every NDEx entry names NDEx, so nothing in the menu
+   * can be read as the save that keeps ordinary edits — that already happened.
+   */
   const menuItems: MenuItem[] = [
+    { sectionHeader: 'Open' },
     {
       template: <LoadFromNdexMenuItem onClick={handleOpenNdexDialog} />,
     },
@@ -175,10 +184,10 @@ export const DataMenu = () => {
       template: <LoadWorkspaceMenuItem onClick={handleOpenWorkspaceDialog} />,
     },
     {
-      template: <LoadDemoNetworksMenuItem onClick={handleClose} />,
+      template: <OpenWorkspaceBackupMenuItem onClick={handleClose} />,
     },
     {
-      template: <OpenNetworkInCytoscapeMenuItem onClick={handleClose} />,
+      template: <LoadDemoNetworksMenuItem onClick={handleClose} />,
     },
     {
       label: 'Import',
@@ -192,26 +201,19 @@ export const DataMenu = () => {
         },
       ],
     },
-    {
-      separator: true,
-    },
+
+    { sectionHeader: 'Local Workspace' },
     {
       template: <DuplicateNetworkMenuItem onClick={handleClose} />,
-    },
-    {
-      template: <SaveToNDExMenuItem onClick={handleClose} />,
-    },
-    {
-      template: <CopyNetworkToNDExMenuItem onClick={handleClose} />,
     },
     {
       template: <DownloadNetworkMenuItem onClick={handleClose} />,
     },
     {
-      template: <SaveWorkspaceToNDExOverwriteMenuItem onClick={handleClose} />,
+      template: <ExportWorkspaceBackupMenuItem onClick={handleClose} />,
     },
     {
-      template: <SaveWorkspaceToNDExMenuItem onClick={handleClose} />,
+      template: <OpenNetworkInCytoscapeMenuItem onClick={handleClose} />,
     },
     {
       label: 'Export',
@@ -222,9 +224,22 @@ export const DataMenu = () => {
         },
       ],
     },
+
+    { sectionHeader: 'Publish / Share' },
     {
-      separator: true,
+      template: <SaveToNDExMenuItem onClick={handleClose} />,
     },
+    {
+      template: <CopyNetworkToNDExMenuItem onClick={handleClose} />,
+    },
+    {
+      template: <SaveWorkspaceToNDExOverwriteMenuItem onClick={handleClose} />,
+    },
+    {
+      template: <SaveWorkspaceToNDExMenuItem onClick={handleClose} />,
+    },
+
+    { sectionHeader: 'Manage' },
     {
       template: (
         <RemoveNetworkMenuItem onClick={handleOpenDeleteNetworkDialog} />
@@ -238,9 +253,6 @@ export const DataMenu = () => {
       ),
     },
     {
-      separator: true,
-    },
-    {
       template: (
         <ResetLocalWorkspaceMenuItem
           onClick={handleOpenResetLocalWorkspaceDialog}
@@ -248,8 +260,15 @@ export const DataMenu = () => {
       ),
     },
     ...(serviceMenuItems.length > 0
-      ? [{ separator: true }, ...serviceMenuItems]
+      ? [{ sectionHeader: 'Apps' }, ...serviceMenuItems]
       : []),
+    {
+      separator: true,
+    },
+    {
+      staticContent:
+        'Your workspace stays in this browser until you clear it or export a backup.',
+    },
   ]
 
   return (
@@ -297,12 +316,12 @@ export const DataMenu = () => {
         isAlert
       />
       <ConfirmationDialog
-        title="Reset Local Workspace (for developers)"
-        message="Are you sure you want to reset all workspace data? (This deletes all of the local cache)"
+        title="Clear Local Workspace"
+        message="Delete everything stored in this browser — all networks, tables, styles and the workspace itself? Anything you have not saved to NDEx or exported as a workspace backup is gone for good."
         onConfirm={handleResetLocalWorkspace}
         open={openResetLocalWorkspaceDialog}
         setOpen={setOpenResetLocalWorkspaceDialog}
-        buttonTitle="Reset Workspace (cannot be undone)"
+        buttonTitle="Clear Workspace (cannot be undone)"
         isAlert
       />
       {dialogs}

--- a/src/features/ToolBar/DataMenu/ndexAvailability.test.ts
+++ b/src/features/ToolBar/DataMenu/ndexAvailability.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { NDEX_OFFLINE_HINT, useNdexGate } from './ndexAvailability'
+
+const setOnline = (value: boolean): void => {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  })
+}
+
+describe('useNdexGate', () => {
+  beforeEach(() => {
+    setOnline(true)
+  })
+
+  it('passes the control through untouched while online', () => {
+    const { result } = renderHook(() => useNdexGate(true, ''))
+
+    expect(result.current.disabled).toBe(false)
+    expect(result.current.tooltip).toBe('')
+  })
+
+  it('keeps the control disabled for its own reason while online', () => {
+    const { result } = renderHook(() => useNdexGate(false, 'Login first'))
+
+    expect(result.current.disabled).toBe(true)
+    expect(result.current.tooltip).toBe('Login first')
+  })
+
+  it('disables an otherwise available control when offline', () => {
+    setOnline(false)
+    const { result } = renderHook(() => useNdexGate(true, ''))
+
+    expect(result.current.disabled).toBe(true)
+    expect(result.current.tooltip).toBe(NDEX_OFFLINE_HINT)
+  })
+
+  it("reports being offline ahead of the control's own reason", () => {
+    // Offline is the one the user can act on, and it explains every NDEx
+    // entry going grey at the same moment.
+    setOnline(false)
+    const { result } = renderHook(() => useNdexGate(false, 'Login first'))
+
+    expect(result.current.tooltip).toBe(NDEX_OFFLINE_HINT)
+  })
+
+  it('re-enables the control when the connection comes back', () => {
+    setOnline(false)
+    const { result } = renderHook(() => useNdexGate(true, ''))
+    expect(result.current.disabled).toBe(true)
+
+    act(() => {
+      setOnline(true)
+      window.dispatchEvent(new Event('online'))
+    })
+
+    expect(result.current.disabled).toBe(false)
+  })
+})

--- a/src/features/ToolBar/DataMenu/ndexAvailability.ts
+++ b/src/features/ToolBar/DataMenu/ndexAvailability.ts
@@ -1,0 +1,27 @@
+import { useOnlineStatus } from '@/data/hooks/useOnlineStatus'
+
+export const NDEX_OFFLINE_HINT =
+  'No connection — NDEx is unavailable. Local editing and autosave keep working.'
+
+/**
+ * Fold connectivity into a control's own enabled state and tooltip (#697).
+ *
+ * Only operations that talk to NDEx take this. Cytoscape Web keeps the
+ * workspace in this browser, so editing, layout, styling and autosave are
+ * unaffected by connectivity and must never be gated on it — an app that
+ * greys itself out when the network drops is claiming a dependency it does
+ * not have.
+ *
+ * Offline wins over any other reason the control is unavailable: it is the one
+ * the user can act on, and it explains every NDEx entry going grey at once.
+ */
+export const useNdexGate = (
+  enabled: boolean,
+  tooltip: string,
+): { disabled: boolean; tooltip: string } => {
+  const online = useOnlineStatus()
+
+  return online
+    ? { disabled: !enabled, tooltip }
+    : { disabled: true, tooltip: NDEX_OFFLINE_HINT }
+}

--- a/src/features/ToolBar/DatabaseSnapshotFileUpload.tsx
+++ b/src/features/ToolBar/DatabaseSnapshotFileUpload.tsx
@@ -17,8 +17,8 @@ export function DatabaseSnapshotFileUpload(
       handleClose={handleClose}
       onFileSelect={onFileSelect}
       acceptedFileTypes={['json']}
-      title="Import Database Snapshot"
-      description="Drag database snapshot file here"
+      title="Open Workspace Backup"
+      description="Drag a workspace backup file here"
       supportedFileTypesText="Supported file type: .json"
       maxFileSizeMB={100}
       testIds={{

--- a/src/features/ToolBar/DropdownMenu.spec.tsx
+++ b/src/features/ToolBar/DropdownMenu.spec.tsx
@@ -175,6 +175,50 @@ describe('DropdownMenu keyboard access', () => {
     expect(skipped).not.toHaveBeenCalled()
   })
 
+  it('renders section headers and footnotes without making them menu items', () => {
+    const run = vi.fn()
+    renderOpenMenu([
+      { sectionHeader: 'Open' },
+      { template: <DropdownMenuItem label="From NDEx..." onClick={run} /> },
+      { sectionHeader: 'Manage' },
+      { template: <DropdownMenuItem label="Remove Network" onClick={run} /> },
+      { staticContent: 'Stored in this browser.' },
+    ])
+
+    expect(screen.getByText('Open')).toBeTruthy()
+    expect(screen.getByText('Manage')).toBeTruthy()
+    expect(screen.getByText('Stored in this browser.')).toBeTruthy()
+
+    // Only the two real entries are menu items; a header the keyboard could
+    // land on reads to a screen reader as an action that does nothing.
+    const rows = screen.getAllByRole('menuitem')
+    expect(rows).toHaveLength(2)
+  })
+
+  it('skips section headers when arrowing through the menu', () => {
+    renderOpenMenu([
+      { sectionHeader: 'Open' },
+      { label: 'From NDEx...', command: vi.fn() },
+      { sectionHeader: 'Manage' },
+      { label: 'Remove Network', command: vi.fn() },
+      { staticContent: 'Stored in this browser.' },
+    ])
+
+    const menu = screen.getByRole('menu')
+    const rows = screen.getAllByRole('menuitem')
+
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(rows[0])
+
+    // The 'Manage' header sits between them and must not take a stop.
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(rows[1])
+
+    // Wraps past the footnote back to the first entry.
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(rows[0])
+  })
+
   it("points the trigger's aria-controls at the rendered menu", () => {
     renderOpenMenu([{ label: 'Run', command: vi.fn() }])
 

--- a/src/features/ToolBar/DropdownMenu.tsx
+++ b/src/features/ToolBar/DropdownMenu.tsx
@@ -124,6 +124,47 @@ function MenuLevel({
           return <Divider key={index} sx={{ my: 0.5 }} />
         }
 
+        // Non-interactive rows carry no role="menuitem", which is exactly what
+        // keeps focusableRows() from stopping on them.
+        if (item.sectionHeader !== undefined) {
+          return (
+            <Box
+              key={index}
+              data-testid={`menu-section-${item.sectionHeader}`}
+              sx={{
+                px: 2,
+                pt: 1,
+                pb: 0.5,
+                color: theme.palette.text.secondary,
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                userSelect: 'none',
+              }}
+            >
+              {item.sectionHeader}
+            </Box>
+          )
+        }
+
+        if (item.staticContent !== undefined) {
+          return (
+            <Box
+              key={index}
+              sx={{
+                px: 2,
+                py: 1,
+                color: theme.palette.text.secondary,
+                fontSize: 12,
+                userSelect: 'none',
+              }}
+            >
+              {item.staticContent}
+            </Box>
+          )
+        }
+
         const hasChildren = (item.items?.length ?? 0) > 0
         if (!hasChildren && item.template !== undefined) {
           // The row, not the template inside it, is the one focusable

--- a/src/features/ToolBar/HelpMenu/HelpMenu_docs/HelpMenu.md
+++ b/src/features/ToolBar/HelpMenu/HelpMenu_docs/HelpMenu.md
@@ -18,8 +18,6 @@ The `HelpMenu` feature implements the **Help** toolbar menu. It centralizes link
   - `AboutCytoscapeWebMenuItem`: Shows application information (version, links, etc.).
   - `TutorialMenuItem`: Links to end-user tutorials.
   - `DeveloperMenuItem`: Links to developer guide and technical docs.
-  - `ExportDatabaseMenuItem`: Exports the internal Dexie/IndexedDB database to a file.
-  - `ImportDatabaseMenuItem`: Imports a database snapshot into the local cache.
   - `CodeRepositoryMenuItem`: Links to the GitHub repository.
   - `CitationMenuItem`: Shows citation instructions for Cytoscape Web.
   - `BugReportMenuItem`: Links to issue tracker or bug-reporting form.

--- a/src/features/ToolBar/HelpMenu/index.tsx
+++ b/src/features/ToolBar/HelpMenu/index.tsx
@@ -9,8 +9,6 @@ import { BugReportMenuItem } from './BugReportMenuItem'
 import { CitationMenuItem } from './CitationMenuItem'
 import { CodeRepositoryMenuItem } from './CodeRepositoryMenuitem'
 import { DeveloperMenuItem } from './DeveloperMenuItem'
-import { ExportDatabaseMenuItem } from './ExportDatabaseMenuItem'
-import { ImportDatabaseMenuItem } from './ImportDatabaseMenuItem'
 import { LicenseDialog } from './LicenseDialog'
 import { LicenseMenuItem } from './LicenseMenuItem'
 import { TakeATourMenuItem } from './TakeATourMenuItem'
@@ -65,15 +63,6 @@ export const HelpMenu = () => {
         },
         {
           template: <CodeRepositoryMenuItem onClick={handleClose} />,
-        },
-        {
-          separator: true,
-        },
-        {
-          template: <ExportDatabaseMenuItem onClick={handleClose} />,
-        },
-        {
-          template: <ImportDatabaseMenuItem onClick={handleClose} />,
         },
       ],
     },

--- a/src/features/ToolBar/StorageIndicator.spec.tsx
+++ b/src/features/ToolBar/StorageIndicator.spec.tsx
@@ -1,0 +1,109 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePersistenceStatusStore } from '@/data/hooks/stores/PersistenceStatusStore'
+import { StorageIndicator } from './StorageIndicator'
+
+const setOnline = (value: boolean): void => {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  })
+}
+
+describe('StorageIndicator', () => {
+  beforeEach(() => {
+    usePersistenceStatusStore.getState().reset()
+    setOnline(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('reads "Saved in this browser" before anything has been written', () => {
+    render(<StorageIndicator />)
+
+    expect(
+      screen.getByTestId('storage-indicator').getAttribute('data-status'),
+    ).toBe('idle')
+    expect(screen.getByText('Saved in this browser')).toBeTruthy()
+  })
+
+  it('reports a write in flight', () => {
+    render(<StorageIndicator />)
+
+    act(() => {
+      usePersistenceStatusStore.getState().writeStarted()
+    })
+
+    expect(screen.getByText('Saving locally…')).toBeTruthy()
+  })
+
+  it('holds "Saving locally…" after a write that settles instantly', () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    render(<StorageIndicator />)
+
+    act(() => {
+      const store = usePersistenceStatusStore.getState()
+      store.writeStarted()
+      store.writeSettled()
+    })
+
+    // Start and settle landed in one React batch, so the component never
+    // rendered between them — the store's own hold is what keeps the label
+    // on screen.
+    expect(usePersistenceStatusStore.getState().lastSavedAt).toBeTypeOf(
+      'number',
+    )
+    expect(screen.getByText('Saving locally…')).toBeTruthy()
+
+    act(() => {
+      vi.advanceTimersByTime(800)
+    })
+    expect(screen.getByText('Saved in this browser')).toBeTruthy()
+  })
+
+  it('shows a failure immediately, without waiting out the hold', () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    render(<StorageIndicator />)
+
+    act(() => {
+      const store = usePersistenceStatusStore.getState()
+      store.writeStarted()
+      store.writeSettled(new Error('quota exceeded'))
+    })
+
+    expect(screen.getByText('Unable to save locally')).toBeTruthy()
+    expect(
+      screen.getByTestId('storage-indicator').getAttribute('data-status'),
+    ).toBe('failed')
+  })
+
+  it('reports connectivity separately from local persistence', () => {
+    setOnline(false)
+    render(<StorageIndicator />)
+
+    // Offline, yet the workspace is still saved locally — the two indicators
+    // must not contradict each other.
+    expect(screen.getByText('Offline')).toBeTruthy()
+    expect(screen.getByText('Saved in this browser')).toBeTruthy()
+  })
+
+  it('follows the browser online/offline events', () => {
+    render(<StorageIndicator />)
+    expect(screen.getByText('Online')).toBeTruthy()
+
+    act(() => {
+      setOnline(false)
+      window.dispatchEvent(new Event('offline'))
+    })
+    expect(screen.getByText('Offline')).toBeTruthy()
+
+    act(() => {
+      setOnline(true)
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(screen.getByText('Online')).toBeTruthy()
+  })
+})

--- a/src/features/ToolBar/StorageIndicator.tsx
+++ b/src/features/ToolBar/StorageIndicator.tsx
@@ -1,0 +1,132 @@
+import CloudOffIcon from '@mui/icons-material/CloudOff'
+import CloudQueueIcon from '@mui/icons-material/CloudQueue'
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import CloudSyncIcon from '@mui/icons-material/CloudSync'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import { Box, Tooltip, Typography } from '@mui/material'
+
+import { usePersistenceStatusStore } from '@/data/hooks/stores/PersistenceStatusStore'
+import { useOnlineStatus } from '@/data/hooks/useOnlineStatus'
+import { PersistenceStatus } from '@/models/StoreModel/PersistenceStatusStoreModel'
+import { darkPalette } from '@/theme'
+
+/** `3:45 PM` — the last-saved stamp is same-session, so the date adds nothing. */
+const timeOnly = (timestamp: number): string =>
+  new Date(timestamp).toLocaleTimeString('en-US', { timeStyle: 'short' })
+
+const LOCAL_STORAGE_EXPLANATION =
+  'Your workspace stays in this browser until you clear it or export a backup. Nothing is sent to NDEx unless you ask.'
+
+interface IndicatorLook {
+  label: string
+  tooltip: string
+  color: string
+  icon: JSX.Element
+}
+
+const storageLook = (
+  status: PersistenceStatus,
+  lastSavedAt: number | undefined,
+  lastError: string | undefined,
+): IndicatorLook => {
+  const iconSx = { fontSize: 16 }
+
+  if (status === 'saving') {
+    return {
+      label: 'Saving locally…',
+      tooltip: `Saving your workspace to this browser. ${LOCAL_STORAGE_EXPLANATION}`,
+      color: darkPalette.text.primary,
+      icon: <CloudSyncIcon sx={iconSx} />,
+    }
+  }
+
+  if (status === 'failed') {
+    return {
+      label: 'Unable to save locally',
+      tooltip:
+        `This browser rejected the last write${lastError !== undefined ? ` (${lastError})` : ''}. ` +
+        'Your recent changes exist only in this tab. Export a workspace backup or save your network to NDEx.',
+      color: '#ffb4a9',
+      icon: <ErrorOutlineIcon sx={iconSx} />,
+    }
+  }
+
+  // 'idle' and 'saved' read the same to the user — the workspace is on disk
+  // either way. They differ only in whether this session has written yet.
+  return {
+    label: 'Saved in this browser',
+    tooltip:
+      (lastSavedAt !== undefined
+        ? `Last saved locally: ${timeOnly(lastSavedAt)}. `
+        : '') + LOCAL_STORAGE_EXPLANATION,
+    color: '#8fd19e',
+    icon: <CheckCircleOutlineIcon sx={iconSx} />,
+  }
+}
+
+/**
+ * Toolbar readout of where the workspace lives and whether it is reaching
+ * this browser's storage (#697).
+ *
+ * Two separate facts, deliberately shown side by side: local persistence
+ * (left) keeps working while the connection (right) is down, and only remote
+ * operations such as NDEx depend on the second one.
+ */
+export const StorageIndicator = (): JSX.Element => {
+  const status = usePersistenceStatusStore((state) => state.status)
+  const lastSavedAt = usePersistenceStatusStore((state) => state.lastSavedAt)
+  const lastError = usePersistenceStatusStore((state) => state.lastError)
+  const online = useOnlineStatus()
+
+  const look = storageLook(status, lastSavedAt, lastError)
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mr: 1.5 }}>
+      <Tooltip title={look.tooltip}>
+        <Box
+          data-testid="storage-indicator"
+          data-status={status}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            color: look.color,
+          }}
+        >
+          {look.icon}
+          <Typography variant="caption" sx={{ whiteSpace: 'nowrap' }}>
+            {look.label}
+          </Typography>
+        </Box>
+      </Tooltip>
+
+      <Tooltip
+        title={
+          online
+            ? 'Connected. NDEx and other remote services are available.'
+            : 'No connection. Local editing and autosave keep working; NDEx and other remote services are unavailable.'
+        }
+      >
+        <Box
+          data-testid="connectivity-indicator"
+          data-online={online ? 'true' : 'false'}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            color: online ? darkPalette.text.secondary : '#ffcc80',
+          }}
+        >
+          {online ? (
+            <CloudQueueIcon sx={{ fontSize: 16 }} />
+          ) : (
+            <CloudOffIcon sx={{ fontSize: 16 }} />
+          )}
+          <Typography variant="caption" sx={{ whiteSpace: 'nowrap' }}>
+            {online ? 'Online' : 'Offline'}
+          </Typography>
+        </Box>
+      </Tooltip>
+    </Box>
+  )
+}

--- a/src/features/ToolBar/ToolBar.tsx
+++ b/src/features/ToolBar/ToolBar.tsx
@@ -12,6 +12,7 @@ import { EditMenu } from './EditMenu'
 import { HelpMenu } from './HelpMenu'
 import { LayoutMenu } from './LayoutMenu'
 import { SearchBox } from './Search'
+import { StorageIndicator } from './StorageIndicator'
 import { ThemeToggleButton } from './ThemeToggleButton'
 import { ToolsMenu } from './ToolsMenu'
 
@@ -48,6 +49,7 @@ export const ToolBar = (): JSX.Element => {
           </Box>
 
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <StorageIndicator />
             <DebugIndicator />
             <SearchBox />
             <ThemeToggleButton />

--- a/src/features/ToolBar/menuItemModel.ts
+++ b/src/features/ToolBar/menuItemModel.ts
@@ -16,4 +16,15 @@ export interface ToolbarMenuItem {
   separator?: boolean
   disabled?: boolean
   command?: () => void
+  /**
+   * Heading naming the group of rows that follows. Not focusable and not
+   * activatable — arrow navigation skips it.
+   */
+  sectionHeader?: string
+  /**
+   * Non-interactive content row, e.g. a footnote closing the menu. Skipped by
+   * arrow navigation like `sectionHeader`; use `template` for a row the user
+   * can actually click.
+   */
+  staticContent?: ReactNode
 }

--- a/src/features/Workspace/NetworkBrowserPanel/BackupReminder.spec.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/BackupReminder.spec.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useWorkspaceStore } from '@/data/hooks/stores/WorkspaceStore'
+import { useOnboardingStore } from '@/features/Onboarding/store/OnboardingStore'
+import { BACKUP_REMINDER_HINT_ID, BackupReminder } from './BackupReminder'
+
+const seedNetworks = (count: number): void => {
+  act(() => {
+    useWorkspaceStore.setState((state) => {
+      state.workspace.networkIds = Array.from(
+        { length: count },
+        (_, i) => `net-${i}`,
+      )
+      return state
+    })
+  })
+}
+
+describe('BackupReminder', () => {
+  beforeEach(() => {
+    useOnboardingStore.getState().reset()
+  })
+
+  it('stays quiet while the workspace holds little worth losing', () => {
+    seedNetworks(2)
+    render(<BackupReminder />)
+
+    expect(screen.queryByTestId('backup-reminder')).toBeNull()
+  })
+
+  it('appears once the workspace is worth backing up', () => {
+    seedNetworks(3)
+    render(<BackupReminder />)
+
+    expect(screen.getByTestId('backup-reminder')).toBeTruthy()
+  })
+
+  it('does not come back after being dismissed', () => {
+    seedNetworks(3)
+    const { unmount } = render(<BackupReminder />)
+
+    fireEvent.click(screen.getByTestId('backup-reminder-dismiss'))
+    expect(screen.queryByTestId('backup-reminder')).toBeNull()
+
+    // The dismissal is persisted, so a remount (or a page reload) keeps it hidden.
+    expect(useOnboardingStore.getState().dismissedHints).toContain(
+      BACKUP_REMINDER_HINT_ID,
+    )
+    unmount()
+    render(<BackupReminder />)
+    expect(screen.queryByTestId('backup-reminder')).toBeNull()
+  })
+
+  it('stays hidden when the hint was dismissed in an earlier session', () => {
+    seedNetworks(3)
+    act(() => {
+      useOnboardingStore.getState().dismissHint(BACKUP_REMINDER_HINT_ID)
+    })
+    render(<BackupReminder />)
+
+    expect(screen.queryByTestId('backup-reminder')).toBeNull()
+  })
+})

--- a/src/features/Workspace/NetworkBrowserPanel/BackupReminder.spec.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/BackupReminder.spec.tsx
@@ -52,6 +52,24 @@ describe('BackupReminder', () => {
     expect(screen.queryByTestId('backup-reminder')).toBeNull()
   })
 
+  it('withdraws dismissal while an export is running', () => {
+    seedNetworks(3)
+    render(<BackupReminder />)
+
+    fireEvent.click(screen.getByTestId('backup-reminder-export'))
+
+    // Dismissing mid-export would persist even if the export then failed,
+    // hiding the reminder from someone who now has no backup at all.
+    const dismiss = screen.getByTestId(
+      'backup-reminder-dismiss',
+    ) as HTMLButtonElement
+    expect(dismiss.disabled).toBe(true)
+    fireEvent.click(dismiss)
+    expect(useOnboardingStore.getState().dismissedHints).not.toContain(
+      BACKUP_REMINDER_HINT_ID,
+    )
+  })
+
   it('stays hidden when the hint was dismissed in an earlier session', () => {
     seedNetworks(3)
     act(() => {

--- a/src/features/Workspace/NetworkBrowserPanel/BackupReminder.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/BackupReminder.tsx
@@ -1,0 +1,109 @@
+import { Alert, Box, Button } from '@mui/material'
+import { ReactElement, useState } from 'react'
+
+import { useMessageStore } from '@/data/hooks/stores/MessageStore'
+import { useWorkspaceStore } from '@/data/hooks/stores/WorkspaceStore'
+import { logUi } from '@/debug'
+import { useOnboardingStore } from '@/features/Onboarding/store/OnboardingStore'
+import { MessageSeverity } from '@/models/MessageModel'
+
+/**
+ * Id under which the dismissal is recorded in `OnboardingStore.dismissedHints`,
+ * which persists to localStorage. Changing it makes the reminder reappear for
+ * everyone who has already dismissed it.
+ */
+export const BACKUP_REMINDER_HINT_ID = 'localStorageBackup'
+
+/**
+ * How many networks make a workspace worth backing up.
+ *
+ * One network is usually something the user just opened and can trivially open
+ * again; by the third they have arranged something they would not want to
+ * rebuild. Reminding earlier trains people to dismiss it unread.
+ */
+const REMIND_AT_NETWORK_COUNT = 3
+
+/**
+ * One-time notice that browser storage is not a backup (#697).
+ *
+ * Shown once the workspace holds enough to be worth losing, and never again
+ * after it is dismissed. Deliberately not a modal or a toast: the point is
+ * that browser storage is durable enough for normal use, so an interruption
+ * would misrepresent the risk.
+ */
+export const BackupReminder = (): ReactElement | null => {
+  const networkIds = useWorkspaceStore((state) => state.workspace.networkIds)
+  const dismissedHints = useOnboardingStore((state) => state.dismissedHints)
+  const dismissHint = useOnboardingStore((state) => state.dismissHint)
+  const addMessage = useMessageStore((state) => state.addMessage)
+  const [exporting, setExporting] = useState(false)
+
+  const dismissed = dismissedHints.includes(BACKUP_REMINDER_HINT_ID)
+  if (dismissed || networkIds.length < REMIND_AT_NETWORK_COUNT) {
+    return null
+  }
+
+  const handleExport = async (): Promise<void> => {
+    setExporting(true)
+    try {
+      // Loaded on demand: the snapshot module is heavy, and this component
+      // renders inside the eager workspace chunk.
+      const { exportDatabaseSnapshotToFile } = await import(
+        '@/data/db/snapshot'
+      )
+      await exportDatabaseSnapshotToFile()
+      addMessage({
+        message: 'Workspace backup exported.',
+        duration: 3000,
+        severity: MessageSeverity.SUCCESS,
+      })
+      // Dismissed on success only: a failed export leaves the user with no
+      // backup, which is exactly the state the reminder exists for.
+      dismissHint(BACKUP_REMINDER_HINT_ID)
+    } catch (error) {
+      logUi.error(
+        `[${BackupReminder.name}]:[handleExport] Failed to export the workspace backup`,
+        error,
+      )
+      addMessage({
+        message: 'Failed to export the workspace backup. Please try again.',
+        duration: 5000,
+        severity: MessageSeverity.ERROR,
+      })
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  return (
+    <Alert
+      data-testid="backup-reminder"
+      severity="info"
+      variant="outlined"
+      sx={{ m: 1, py: 0.5, fontSize: 12, alignItems: 'flex-start' }}
+      onClose={() => dismissHint(BACKUP_REMINDER_HINT_ID)}
+    >
+      This workspace lives in this browser. Clearing site data, switching
+      browsers or profiles, and private windows all lose it. Keep a copy you
+      control.
+      <Box sx={{ mt: 0.5, display: 'flex', gap: 1 }}>
+        <Button
+          data-testid="backup-reminder-export"
+          size="small"
+          variant="outlined"
+          disabled={exporting}
+          onClick={() => void handleExport()}
+        >
+          Export Backup
+        </Button>
+        <Button
+          data-testid="backup-reminder-dismiss"
+          size="small"
+          onClick={() => dismissHint(BACKUP_REMINDER_HINT_ID)}
+        >
+          Not now
+        </Button>
+      </Box>
+    </Alert>
+  )
+}

--- a/src/features/Workspace/NetworkBrowserPanel/BackupReminder.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/BackupReminder.tsx
@@ -81,7 +81,10 @@ export const BackupReminder = (): ReactElement | null => {
       severity="info"
       variant="outlined"
       sx={{ m: 1, py: 0.5, fontSize: 12, alignItems: 'flex-start' }}
-      onClose={() => dismissHint(BACKUP_REMINDER_HINT_ID)}
+      // Both dismissal routes are withdrawn while an export is running: a
+      // dismissal that lands before a FAILED export would persist, hiding the
+      // reminder from someone who now has no backup at all.
+      onClose={exporting ? undefined : () => dismissHint(BACKUP_REMINDER_HINT_ID)}
     >
       This workspace lives in this browser. Clearing site data, switching
       browsers or profiles, and private windows all lose it. Keep a copy you
@@ -99,6 +102,7 @@ export const BackupReminder = (): ReactElement | null => {
         <Button
           data-testid="backup-reminder-dismiss"
           size="small"
+          disabled={exporting}
           onClick={() => dismissHint(BACKUP_REMINDER_HINT_ID)}
         >
           Not now

--- a/src/features/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/NetworkBrowserPanel.tsx
@@ -25,6 +25,7 @@ import { isHCX } from '../../HierarchyViewer/utils/hierarchyUtil'
 import { NetworkSearchBar } from '../../NetworkSearch'
 import { prefetchOnIdle } from '@/utils/idlePrefetch'
 import { Summaries as SummaryList } from '../../SummaryPanel'
+import { BackupReminder } from './BackupReminder'
 import { WorkspaceNamePanel } from './WorkspaceNamePanel'
 
 // Lazy tab contents: Vizmapper alone drags in visx, d3 and react-color, so
@@ -236,6 +237,9 @@ export const NetworkBrowserPanel = ({
           }}
         >
           <WorkspaceNamePanel />
+        </Box>
+        <Box hidden={currentTabIndex !== 0} sx={{ width: '100%' }}>
+          <BackupReminder />
         </Box>
         <Box
           sx={{

--- a/src/features/Workspace/NetworkBrowserPanel/WorkspaceNamePanel.spec.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/WorkspaceNamePanel.spec.tsx
@@ -1,0 +1,85 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { usePersistenceStatusStore } from '@/data/hooks/stores/PersistenceStatusStore'
+import { useWorkspaceStore } from '@/data/hooks/stores/WorkspaceStore'
+import { WorkspaceNamePanel } from './WorkspaceNamePanel'
+
+const seedWorkspace = (isRemote: boolean): void => {
+  act(() => {
+    useWorkspaceStore.setState((state) => {
+      state.workspace.id = 'ws-1'
+      state.workspace.name = 'Untitled Workspace'
+      state.workspace.isRemote = isRemote
+      return state
+    })
+  })
+}
+
+describe('WorkspaceNamePanel', () => {
+  beforeEach(() => {
+    usePersistenceStatusStore.getState().reset()
+  })
+
+  it('marks a workspace that has never been to NDEx as local', () => {
+    seedWorkspace(false)
+    render(<WorkspaceNamePanel />)
+
+    expect(screen.getByText('Local workspace')).toBeTruthy()
+    expect(screen.getByText('Untitled Workspace')).toBeTruthy()
+  })
+
+  it('does not call a workspace loaded from NDEx a local workspace', () => {
+    // The working copy is in this browser either way, but the origin is not
+    // local — and claiming otherwise contradicts the NDEx chips on the rows.
+    seedWorkspace(true)
+    render(<WorkspaceNamePanel />)
+
+    expect(screen.getByText('From NDEx')).toBeTruthy()
+    expect(screen.queryByText('Local workspace')).toBeNull()
+  })
+
+  it('reports autosave working', () => {
+    seedWorkspace(false)
+    render(<WorkspaceNamePanel />)
+
+    expect(screen.getByTestId('workspace-autosave-line').textContent).toBe(
+      'Autosaved locally',
+    )
+
+    act(() => {
+      usePersistenceStatusStore.getState().writeStarted()
+    })
+    expect(screen.getByTestId('workspace-autosave-line').textContent).toBe(
+      'Saving locally…',
+    )
+  })
+
+  it('reports autosave failing', () => {
+    seedWorkspace(false)
+    render(<WorkspaceNamePanel />)
+
+    act(() => {
+      const store = usePersistenceStatusStore.getState()
+      store.writeStarted()
+      store.writeSettled(new Error('quota exceeded'))
+    })
+
+    expect(screen.getByTestId('workspace-autosave-line').textContent).toBe(
+      'Autosave failed',
+    )
+  })
+
+  it('renders nothing but a spacer before a workspace exists', () => {
+    act(() => {
+      useWorkspaceStore.setState((state) => {
+        state.workspace.id = ''
+        return state
+      })
+    })
+    render(<WorkspaceNamePanel />)
+
+    expect(screen.queryByTestId('workspace-origin-chip')).toBeNull()
+    expect(screen.queryByTestId('workspace-autosave-line')).toBeNull()
+  })
+})

--- a/src/features/Workspace/NetworkBrowserPanel/WorkspaceNamePanel.tsx
+++ b/src/features/Workspace/NetworkBrowserPanel/WorkspaceNamePanel.tsx
@@ -1,11 +1,57 @@
-import { Box, Tooltip, Typography } from '@mui/material'
+import { Box, Chip, Tooltip, Typography } from '@mui/material'
 
+import { usePersistenceStatusStore } from '../../../data/hooks/stores/PersistenceStatusStore'
 import { useWorkspaceStore } from '../../../data/hooks/stores/WorkspaceStore'
 import { Workspace } from '../../../models'
+import { PersistenceStatus } from '../../../models/StoreModel/PersistenceStatusStoreModel'
 import { dateFormatter } from '../../../utils/dateFormat'
 
+/**
+ * Second line under the workspace name: whether autosave is currently working.
+ *
+ * `idle` and `saved` read the same — the workspace is on disk either way, and
+ * the distinction (has this session written yet) is not one a user has a
+ * question about.
+ */
+const autosaveLine = (
+  status: PersistenceStatus,
+  lastSavedAt: number | undefined,
+): { text: string; warn: boolean } => {
+  if (status === 'saving') {
+    return { text: 'Saving locally…', warn: false }
+  }
+  if (status === 'failed') {
+    return { text: 'Autosave failed', warn: true }
+  }
+  if (lastSavedAt !== undefined) {
+    return {
+      text: `Autosaved locally: ${new Date(lastSavedAt).toLocaleTimeString(
+        'en-US',
+        { timeStyle: 'short' },
+      )}`,
+      warn: false,
+    }
+  }
+  return { text: 'Autosaved locally', warn: false }
+}
+
+/**
+ * Workspace name, where the workspace came from, and whether it is still
+ * reaching this browser's storage (#697).
+ *
+ * The origin chip reports `workspace.isRemote`, not "this is stored locally":
+ * a workspace loaded from NDEx has a working copy in this browser exactly like
+ * a local one, so a flat "Local workspace" label would be false for it — and
+ * would contradict the `NDEx` chips on the network rows below.
+ */
 export const WorkspaceNamePanel = () => {
   const workspace: Workspace = useWorkspaceStore((state) => state.workspace)
+  const status = usePersistenceStatusStore((state) => state.status)
+  const lastSavedAt = usePersistenceStatusStore((state) => state.lastSavedAt)
+
+  const isRemote = workspace.isRemote === true
+  const autosave = autosaveLine(status, lastSavedAt)
+  const named = workspace.id !== ''
 
   return (
     <Box
@@ -14,35 +60,79 @@ export const WorkspaceNamePanel = () => {
         width: '100%',
         p: (theme) => theme.spacing(1),
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+        flexDirection: 'column',
+        gap: 0.25,
       }}
     >
-      <Tooltip
-        title={`This workspace was created at ${dateFormatter(workspace.creationTime)}`}
-        placement="bottom"
-        sx={{ flexGrow: 1, width: '100%' }}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          gap: 1,
+          width: '100%',
+        }}
       >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
-            width: '100%',
-          }}
+        <Tooltip
+          title={
+            named
+              ? `This workspace was created at ${dateFormatter(workspace.creationTime)}`
+              : ''
+          }
+          placement="bottom"
         >
           <Typography
             sx={{
-              textAlign: 'center',
-              width: '100%',
               color: (theme) => theme.palette.text.secondary,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
             variant="subtitle2"
           >
-            {workspace.id !== '' ? workspace.name : <>&nbsp;</>}
+            {named ? workspace.name : <>&nbsp;</>}
           </Typography>
-        </Box>
-      </Tooltip>
+        </Tooltip>
+
+        {named && (
+          <Tooltip
+            title={
+              isRemote
+                ? 'Opened from NDEx. Your working copy is stored in this browser; NDEx is only updated when you save to it.'
+                : 'This workspace exists only in this browser. Save it to NDEx or export a workspace backup to keep a copy elsewhere.'
+            }
+            placement="bottom"
+          >
+            <Chip
+              data-testid="workspace-origin-chip"
+              size="small"
+              variant="outlined"
+              sx={{ height: 18, opacity: 0.8 }}
+              label={
+                <Typography sx={{ fontSize: 10 }} variant="caption">
+                  {isRemote ? 'From NDEx' : 'Local workspace'}
+                </Typography>
+              }
+            />
+          </Tooltip>
+        )}
+      </Box>
+
+      {named && (
+        <Typography
+          data-testid="workspace-autosave-line"
+          variant="caption"
+          sx={{
+            fontSize: 10,
+            color: (theme) =>
+              autosave.warn
+                ? theme.palette.warning.main
+                : theme.palette.text.disabled,
+          }}
+        >
+          {autosave.text}
+        </Typography>
+      )}
     </Box>
   )
 }

--- a/src/models/StoreModel/PersistenceStatusStoreModel.ts
+++ b/src/models/StoreModel/PersistenceStatusStoreModel.ts
@@ -1,0 +1,40 @@
+/**
+ * What the app can currently say about writing the workspace to IndexedDB.
+ *
+ * `idle` is the pre-first-write state: the workspace is already on disk from an
+ * earlier session, but nothing has been written since this tab loaded, so there
+ * is no outcome to report yet.
+ */
+export type PersistenceStatus = 'idle' | 'saving' | 'saved' | 'failed'
+
+export interface PersistenceStatusState {
+  readonly status: PersistenceStatus
+  /** Writes started and not yet settled. */
+  readonly pending: number
+  /**
+   * True when a write in the burst still settling has failed. Internal to the
+   * status rule below; the UI reads `status`.
+   */
+  readonly burstFailed: boolean
+  /**
+   * `Date.now()` when the current burst's first write started. Internal: the
+   * store holds `saving` for a readable minimum measured from here.
+   */
+  readonly burstStartedAt: number
+  /** `Date.now()` of the last burst that finished with every write succeeding. */
+  readonly lastSavedAt?: number
+  /** Message of the most recent failure. Cleared by the next clean burst. */
+  readonly lastError?: string
+}
+
+export interface PersistenceStatusActions {
+  /** One write has been handed to IndexedDB. */
+  writeStarted: () => void
+  /** That write finished. Pass the rejection value when it failed. */
+  writeSettled: (error?: unknown) => void
+  /** Back to `idle` with no history. For tests and a workspace reset. */
+  reset: () => void
+}
+
+export type PersistenceStatusStore = PersistenceStatusState &
+  PersistenceStatusActions

--- a/test/playwright/comprehensive-test-plan.md
+++ b/test/playwright/comprehensive-test-plan.md
@@ -98,7 +98,7 @@ The application uses a URL structure of `/:workspaceId/networks/:networkId?param
   - "Remove Current Network" (disabled if no network)
   - "Remove All Networks" (disabled if no networks)
   - Separator
-  - "Reset Local Workspace" → "Clear Local Database"
+  - "Reset Local Workspace" → "Clear Local Workspace"
 
 #### 2.2 Open Sample Networks
 **Steps:**
@@ -235,11 +235,11 @@ The application uses a URL structure of `/:workspaceId/networks/:networkId?param
 **Negative Test:**
 - Attempt download with no network → verify button disabled
 
-#### 2.8 Clear Local Database
+#### 2.8 Clear Local Workspace
 **Steps:**
 1. Load one or more networks
 2. Click "Data" menu
-3. Click "Reset Local Workspace" → "Clear Local Database"
+3. Click "Reset Local Workspace" → "Clear Local Workspace"
 4. Confirm action if prompted
 5. Refresh page
 

--- a/test/playwright/comprehensive-test-plan.md
+++ b/test/playwright/comprehensive-test-plan.md
@@ -98,7 +98,7 @@ The application uses a URL structure of `/:workspaceId/networks/:networkId?param
   - "Remove Current Network" (disabled if no network)
   - "Remove All Networks" (disabled if no networks)
   - Separator
-  - "Reset Local Workspace" → "Clear Local Workspace"
+  - "Clear Local Workspace..."
 
 #### 2.2 Open Sample Networks
 **Steps:**
@@ -239,7 +239,7 @@ The application uses a URL structure of `/:workspaceId/networks/:networkId?param
 **Steps:**
 1. Load one or more networks
 2. Click "Data" menu
-3. Click "Reset Local Workspace" → "Clear Local Workspace"
+3. Click "Clear Local Workspace..."
 4. Confirm action if prompted
 5. Refresh page
 

--- a/test/playwright/network-download.spec.ts
+++ b/test/playwright/network-download.spec.ts
@@ -10,9 +10,12 @@ test.describe('Network Download', () => {
   test('downloads the current network as a CX2 file', async ({ page }) => {
     await gotoAndSeedNetwork(page)
 
-    // Open Data ▸ Export ▸ Download Network File (.cx2)
+    // Data ▸ Local Workspace ▸ Download Network File (.cx2). The download entry
+    // sits at the top level; the `Export` submenu holds image export alone.
+    // Exact: `Export Workspace Backup...` is a sibling entry that a substring
+    // locator for `Export` also matches (#697).
     await page.locator('[data-testid="toolbar-data-menu-menu-button"]').click()
-    await page.getByRole('menuitem', { name: 'Export' }).click()
+    await page.getByRole('menuitem', { name: 'Export', exact: true }).click()
     const downloadPromise = page.waitForEvent('download')
     await page
       .getByRole('menuitem', { name: 'Download Network File (.cx2)' })

--- a/test/playwright/toolbar-menu.spec.ts
+++ b/test/playwright/toolbar-menu.spec.ts
@@ -21,18 +21,64 @@ test.describe('Toolbar Menus', () => {
   }) => {
     await page.locator('[data-testid="toolbar-data-menu-menu-button"]').click()
 
-    // TieredMenu root items: "Import" and "Export" are visible
-    await expect(page.getByRole('menuitem', { name: 'Import' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Export' })).toBeVisible()
+    // Exact: "Export Workspace Backup..." is a sibling entry that would
+    // otherwise also match a substring locator for "Export" (#697).
+    await expect(
+      page.getByRole('menuitem', { name: 'Import', exact: true }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: 'Export', exact: true }),
+    ).toBeVisible()
+  })
+
+  test('Data menu groups entries under local-first section headings', async ({
+    page,
+  }) => {
+    await page.locator('[data-testid="toolbar-data-menu-menu-button"]').click()
+
+    for (const section of [
+      'Open',
+      'Local Workspace',
+      'Publish / Share',
+      'Manage',
+    ]) {
+      await expect(
+        page.locator(`[data-testid="menu-section-${section}"]`),
+      ).toBeVisible()
+    }
+
+    // Workspace backup moved out of Help > Developer and was renamed for what
+    // it is to a user (#697).
+    await expect(
+      page.getByRole('menuitem', { name: 'Export Workspace Backup...' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: 'Open Workspace Backup...' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: 'Clear Local Workspace...' }),
+    ).toBeVisible()
+  })
+
+  test('Data menu section headings are not menu items', async ({ page }) => {
+    await page.locator('[data-testid="toolbar-data-menu-menu-button"]').click()
+
+    const heading = page.locator('[data-testid="menu-section-Manage"]')
+    await expect(heading).toBeVisible()
+    // No role="menuitem", which is what keeps arrow navigation from stopping
+    // on a heading that does nothing (see DropdownMenu.spec.tsx).
+    expect(await heading.getAttribute('role')).toBeNull()
   })
 
   test('Data menu closes on Escape', async ({ page }) => {
     await page.locator('[data-testid="toolbar-data-menu-menu-button"]').click()
-    await expect(page.getByRole('menuitem', { name: 'Import' })).toBeVisible()
+    await expect(
+      page.getByRole('menuitem', { name: 'Import', exact: true }),
+    ).toBeVisible()
 
     await page.keyboard.press('Escape')
     await expect(
-      page.getByRole('menuitem', { name: 'Import' }),
+      page.getByRole('menuitem', { name: 'Import', exact: true }),
     ).not.toBeVisible()
   })
 

--- a/test/test_docs/cytoscape-web-ai-test-script.md
+++ b/test/test_docs/cytoscape-web-ai-test-script.md
@@ -91,7 +91,7 @@ a) Data → Save Network to NDEx (overwrite). Expect success only when user owns
 
 b) Data → Save Copy to NDEx; confirm a new network in NDEx “My Networks” with distinct UUID.
 
-c) Data → Save Workspace; then modify something and Data → Save Workspace As…; confirm both appear under “My Workspaces”.
+c) Data → Save Workspace to NDEx; then modify something and Data → Save Workspace to NDEx As…; confirm both appear under “My Workspaces”.
 
 ### **1.7 Download Current Network (.cx2)**
 
@@ -111,9 +111,9 @@ d) Toggle “Export full network image” on/off; compare full vs viewport-only 
 
 a) Remove the current network and also remove multiple selections via Workspace; confirm removal from Workspace list.
 
-### **1.10 Clear Local Database**
+### **1.10 Clear Local Workspace**
 
-a) Data → Clear Local Database. Confirm the app resets (networks, apps/service apps, and local settings cleared).
+a) Data → Clear Local Workspace. Confirm the app resets (networks, apps/service apps, and local settings cleared).
 
 b) Reopen app and confirm a clean slate.
 
@@ -215,7 +215,7 @@ b) For a network with a node column containing gene symbols list(s), run enrichm
 
 a) Save Workspace; reload Cytoscape Web and open that workspace; confirm Apps and Service Apps are restored.
 
-b) Clear Local Database; confirm Apps/Service Apps are cleared.
+b) Clear Local Workspace; confirm Apps/Service Apps are cleared.
 
 ## **7\) Help Menu**
 
@@ -239,7 +239,7 @@ a) Data → Open Network(s) from NDEx → MY NETWORKS tab is available and corre
 
 b) Data → Open Workspace from NDEx shows your workspaces.
 
-c) Data → Save Network/Save Copy/Save Workspace/Save Workspace As… succeed.
+c) Data → Save Network/Save Copy/Save Workspace to NDEx/Save Workspace to NDEx As… succeed.
 
 ### **8.3 Sign Out**
 
@@ -495,9 +495,9 @@ a) Select a row; click SELECT NODES (or SELECT EDGES); verify network view selec
 
 \- Clear cache per browser docs; reopen Cytoscape Web; confirm normal operation resumes.
 
-### **16.3 Clear Local Database**
+### **16.3 Clear Local Workspace**
 
-\- As a last resort, Data → Clear Local Database; confirm the environment resets to a clean state.
+\- As a last resort, Data → Clear Local Workspace; confirm the environment resets to a clean state.
 
 ### **16.4 Bug Reporting**
 

--- a/test/test_docs/cytoscape-web-ai-test-script.md
+++ b/test/test_docs/cytoscape-web-ai-test-script.md
@@ -113,7 +113,7 @@ a) Remove the current network and also remove multiple selections via Workspace;
 
 ### **1.10 Clear Local Workspace**
 
-a) Data → Clear Local Workspace. Confirm the app resets (networks, apps/service apps, and local settings cleared).
+a) Data → Clear Local Workspace…. Confirm the app resets (networks, apps/service apps, and local settings cleared).
 
 b) Reopen app and confirm a clean slate.
 
@@ -497,7 +497,7 @@ a) Select a row; click SELECT NODES (or SELECT EDGES); verify network view selec
 
 ### **16.3 Clear Local Workspace**
 
-\- As a last resort, Data → Clear Local Workspace; confirm the environment resets to a clean state.
+\- As a last resort, Data → Clear Local Workspace…; confirm the environment resets to a clean state.
 
 ### **16.4 Bug Reporting**
 


### PR DESCRIPTION
Closes #697.

Nothing in the UI said the workspace lives in this browser. Five commits, each
independently reviewable.

## Persistence status (`91855103`)

There was no source to read one from. `persistenceScheduler` was the obvious
hook point but logged write failures and dropped them, and only three of
fourteen store write paths went through it — an indicator watching it alone
would read "Saved in this browser" while a style or summary write was failing.

- `PersistenceStatusStore` tracks status per burst of overlapping writes: any
  write in flight is `saving`, a clean burst ends `saved`, a burst with any
  failure ends `failed` and stays there until a later burst completes cleanly.
- `trackWrite` wraps one write and reports it, re-throwing so every existing
  `.catch` keeps working. Applied to the scheduler and all 14 direct puts.
- The store, not the component, owns the minimum display time for `saving`. A
  write settles within a frame of the 300ms coalescing delay, and when start
  and settle land in one React batch a component-level hold never observes
  `saving` at all.

## Connectivity (`91855103`, `b587f6a3`)

`navigator.onLine` appeared nowhere in `src/`. `useOnlineStatus` reads it
through `useSyncExternalStore`; `useNdexGate` folds it into the six Data-menu
entries that talk to NDEx. Offline wins over any other reason a control is
disabled — it is the one the user can act on, and it explains every NDEx entry
going grey at once. Nothing else is gated.

## Data menu (`0fbede95`)

| Was | Now |
| --- | --- |
| Bare separators, no headings | `Open` / `Local Workspace` / `Publish / Share` / `Manage` |
| Help › Developer › `Export Database Snapshot` | Data › Local Workspace › `Export Workspace Backup...` |
| Help › Developer › `Import Database Snapshot` | Data › Open › `Open Workspace Backup...` |
| `Clear Local Database` | `Clear Local Workspace...` |
| `Save Workspace` / `Save Workspace As...` | `Save Workspace to NDEx` / `Save Workspace to NDEx As...` |

`ToolbarMenuItem` gains `sectionHeader` and `staticContent` — rows with no
`role="menuitem"`, so `focusableRows()` skips them and arrow navigation never
stops on a heading that does nothing.

The `Clear Local Workspace...` confirmation was titled "(for developers)" and
spoke of "the local cache". It now names what is deleted and what survives.

**Correcting the issue's own audit:** it concluded no generic `Save` action
existed. `Save Workspace` and `Save Workspace As...` were exactly that —
neither named its destination, so both read as the save that keeps ordinary
edits. Renamed.

## Provenance (`71b3cea4`)

`workspace.networkModified` already tracked local edits but surfaced only as
the save icon's colour and a tooltip, so the most consequential fact about an
NDEx-backed network — that editing it here does not touch the copy in NDEx —
was visible on hover alone. `getNetworkProvenance` returns a visible label:
`Changes not saved to NDEx`, or `Modified locally` for a network that has
never been there. Origin stays independent of modification state.

`WorkspaceNamePanel` gains the workspace's origin chip and an autosave line.
The chip reports `workspace.isRemote`, not a flat "Local workspace": a
workspace loaded from NDEx keeps its working copy in this browser exactly like
a local one, so the flat label would be false for it and would contradict the
`NDEx` chips on the rows below. This is the one ask in the issue that needed
changing rather than implementing.

## Copy (`b587f6a3`)

The Welcome dialog already said the workspace is saved in this browser, but
not the two consequences: nothing reaches NDEx unless asked, and browser
storage is not a backup. `BackupReminder` says so once the workspace holds
three networks, and never again once dismissed (persisted through
`OnboardingStore.dismissHint`).

## Asks deliberately not implemented

Two already held and are unchanged:

- **Sharing/link behavior for local networks.** `ShareNetworkButton` already
  disables share for a local network and says why
  (`ShareNetworkButton.tsx:35,46-61`), as does the row menu
  (`networkRowActions.ts:58`).
- **Workspace backup buttons in the Workspace panel.** The issue floats this as
  a "consider"; neither mockup shows it, and the reminder already offers
  Export Backup inline.

The `BackupReminder` offers `Export Backup` but not `Save to NDEx`: that flow
carries HCX validation and its own sync dialogs, so it is named in the Data
menu rather than duplicated in an alert.

## Verification

- `npm run test:checks:quiet` — lint + 3941 unit tests pass. 27 new tests.
- `npm run e2e:spec -- toolbar-menu` (7), `dialog-dismiss` (7),
  `local-file-import` (1) — pass.
- `Export Workspace Backup...` made the existing substring locator for
  `Export` match two menu items; both root submenu assertions are now pinned
  to exact names.

Manual checks worth doing on review: DevTools → Network → Offline should leave
the storage chip reading `Saved in this browser` while the connectivity chip
flips and every NDEx entry greys out with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toolbar indicators for local save status and online/offline connectivity.
  * Added autosave status and workspace origin details to workspace headers.
  * Added reminders to export backups for larger local workspaces.
  * Added workspace backup export and open options.
  * Added clearer Data menu sections and improved NDEx availability messaging.
* **Bug Fixes**
  * Improved visibility and reporting of save failures.
  * Clarified unsaved changes for NDEx and local networks.
* **Documentation**
  * Updated onboarding and menu guidance for backups, saving, and clearing local workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->