### PR TITLE
fix(app-manager): stop offering Uninstall for apps.json apps (#699)

### DIFF
--- a/docs/design/module-federation/specifications/workspace-app-install-design.md
+++ b/docs/design/module-federation/specifications/workspace-app-install-design.md
@@ -780,11 +780,11 @@ orphan `removeOrphan` remains unconfirmed; only true uninstall is confirmed.)
 
 | File | Change |
 | --- | --- |
-| `AppListPanel.tsx` | `AppDisplayEntry` gains `source` and `removable`; `getAction()` is split into a primary-action selector and a `removable` predicate; add the overflow menu and the confirmation dialog |
+| `AppListPanel.tsx` | `AppDisplayEntry` gains `source` and `removable`; `getAction()` is split into a primary-action selector and a `removable` predicate; add the overflow menu and the confirmation dialog. `removable` reads `AppStore.manifestIds`, not `source` (§12.3) |
 | `AppSettingsDialog.tsx` | Add the **Install from URL** action on the Apps tab (§12.8), distinct from the existing manifest-source controls |
 | `useAppManager.ts` | Implement `uninstallApp(id)`; add `installApp`/`uninstallApp` to `AppManagerCommands` |
 | `WorkspaceStore.ts` | `removeInstalledApp(id)` / `setInstalledAppStatus(id, status)` actions (§10.2) |
-| catalog merge (§8.1) | Propagate `source` onto each merged catalog entry so the panel can decide removability |
+| catalog merge (§8.1) | Return `manifestIds` alongside `entries` and `sources`. The panel decides removability from `manifestIds` (§12.3); `source` only drives the provenance chip |
 
 `AppManagerCommandsContext` needs no change — it spreads the hook's command
 surface, so the new commands flow through automatically.

--- a/docs/design/module-federation/specifications/workspace-app-install-design.md
+++ b/docs/design/module-federation/specifications/workspace-app-install-design.md
@@ -709,15 +709,34 @@ Two distinct operations must be visually separated:
 Uninstall removes the app from the workspace and therefore from any future
 workspace snapshot, so it is treated as destructive and requires confirmation.
 
-### 12.3 Removability by source
+### 12.3 Removability by manifest membership
 
-Whether a row can be uninstalled is driven by `InstalledApp.source`:
+Whether a row can be uninstalled is driven by **manifest membership**, not by
+`InstalledApp.source`:
 
-| Source | Uninstall? | Rationale |
+| Row | Uninstall? | Rationale |
 | --- | --- | --- |
-| `manifest` | No — disable only | Removal is meaningless; `Refresh` would re-add it from `apps.json` |
-| `appstore` / `snapshot` | Yes | Lives in `workspace.installedApps`; removing it is a real uninstall |
+| id present in the resolved manifest | No — disable only | Removal is meaningless; `recomposeCatalog` re-adds it from `apps.json` |
+| id absent from the manifest, `source: appstore` / `snapshot` | Yes | Lives only in `workspace.installedApps`; removing it is a real uninstall |
 | orphan (legacy) | Yes (fallback) | Existing `removeOrphan` retained for pre-migration leftovers |
+
+`source` alone is the wrong test. On an id collision `composeCatalog` (§8.1)
+lets a pinned `appstore`/`snapshot` record win and overwrite the `'manifest'`
+tag, and both stamping sites apply their source unconditionally: a snapshot
+restore tags every restored entry `'snapshot'`, an App Store install tags every
+install `'appstore'`. Keying off `source` therefore offered **Uninstall** on
+`apps.json` apps, and confirming it only discarded the pinned URL before the
+manifest entry returned (issue #699).
+
+`composeCatalog` returns `manifestIds` alongside `entries` and `sources`;
+`AppStore.manifestIds` holds it, `AppListPanel` reads it, and `uninstallApp`
+refuses any id it contains.
+
+**Cost:** a pinned App Store version installed over a manifest id can no longer
+be reverted to the manifest version from the UI. Reverting was never labelled
+as such — it was an **Uninstall** that appeared to fail — so nothing
+discoverable is lost. A dedicated `Revert to manifest version` action is the
+place to add it back.
 
 ### 12.4 Row layout
 
@@ -736,15 +755,17 @@ through an **overflow (kebab) menu**:
                                                              • Report a bug  (future)
 ```
 
-- The overflow menu appears only when the row is removable (§12.3). Manifest
-  rows show the toggle alone.
+- The overflow menu appears only when the row is removable (§12.3). Rows the
+  manifest still ships show the toggle alone.
 - `Uninstall` works regardless of active/inactive: an active app is deactivated
   first, then removed.
 - The menu is the extension point for future App Store metadata actions
   (`App details`, `Report a bug` → `repository` issues link), per
   [app-store-design.md](./app-store-design.md) §13.
-- A small `App Store` indicator chip marks installed (non-manifest) rows so the
-  presence of the menu is self-explanatory (optional).
+- A small `App Store` / `Snapshot` indicator chip marks rows whose entry did not
+  come from the manifest. The chip tracks `source`, not removability, so a
+  pinned install shadowing a manifest id still shows where its URL came from
+  even though it has no menu.
 
 ### 12.5 Confirmation
 

--- a/src/data/hooks/stores/AppStore.ts
+++ b/src/data/hooks/stores/AppStore.ts
@@ -71,6 +71,7 @@ export const useAppStore = create(
     currentTask: undefined,
     catalog: {},
     catalogSources: {},
+    manifestIds: [],
     loadStates: {},
     manifestSource: undefined,
 
@@ -279,11 +280,18 @@ export const useAppStore = create(
     setCatalog: (
       entries: AppCatalogEntry[],
       sources?: Record<string, AppSource>,
+      manifestIds?: string[],
     ) => {
       set((state) => {
-        const newState = AppStoreImpl.setCatalog(state, entries, sources)
+        const newState = AppStoreImpl.setCatalog(
+          state,
+          entries,
+          sources,
+          manifestIds,
+        )
         state.catalog = newState.catalog
         state.catalogSources = newState.catalogSources
+        state.manifestIds = newState.manifestIds
         return state
       })
     },

--- a/src/data/hooks/stores/useAppManager.test.tsx
+++ b/src/data/hooks/stores/useAppManager.test.tsx
@@ -208,6 +208,29 @@ describe('useAppManager — install / uninstall', () => {
       expect(installed()).toHaveLength(0)
       expect(useAppStore.getState().catalog['hello']).toBeUndefined()
     })
+
+    // #699: uninstalling a manifest app cannot stick — recomposeCatalog
+    // re-adds it from the manifest — so the command refuses instead of
+    // silently discarding the pinned record.
+    it('refuses to uninstall an app the manifest still ships', async () => {
+      const { result } = await renderManager()
+
+      await act(async () => {
+        await result.current.installApp(entry('hello'), { activate: false })
+      })
+      act(() => {
+        useAppStore
+          .getState()
+          .setCatalog([entry('hello')], { hello: 'appstore' }, ['hello'])
+      })
+
+      await act(async () => {
+        await result.current.uninstallApp('hello')
+      })
+
+      expect(installed()).toHaveLength(1)
+      expect(useAppStore.getState().catalog['hello']).toBeDefined()
+    })
   })
 
   describe('status reconciliation', () => {

--- a/src/data/hooks/stores/useAppManager.ts
+++ b/src/data/hooks/stores/useAppManager.ts
@@ -139,11 +139,11 @@ export const useAppManager = (): AppManagerCommands => {
    */
   const recomposeCatalog = (): void => {
     const installed = useWorkspaceStore.getState().workspace.installedApps ?? []
-    const { entries, sources } = composeCatalog(
+    const { entries, sources, manifestIds } = composeCatalog(
       manifestEntriesRef.current,
       installed,
     )
-    setCatalog(entries, sources)
+    setCatalog(entries, sources, manifestIds)
   }
 
   /**
@@ -318,8 +318,11 @@ export const useAppManager = (): AppManagerCommands => {
     manifestEntriesRef.current = manifestEntries
     const installedApps =
       useWorkspaceStore.getState().workspace.installedApps ?? []
-    const { entries, sources } = composeCatalog(manifestEntries, installedApps)
-    setCatalog(entries, sources)
+    const { entries, sources, manifestIds } = composeCatalog(
+      manifestEntries,
+      installedApps,
+    )
+    setCatalog(entries, sources, manifestIds)
     logApp.info(
       `[useAppManager]: Catalog refreshed with ${entries.length} entries`,
     )
@@ -389,8 +392,19 @@ export const useAppManager = (): AppManagerCommands => {
    * Uninstall a workspace-installed app (§12.7). Deactivates it if running,
    * removes it from workspace.installedApps, clears session state, and drops
    * it from the catalog.
+   *
+   * Manifest apps are refused (§12.3): `recomposeCatalog` re-adds them from
+   * the manifest, so the uninstall would only discard the pinned URL and leave
+   * the row in place. `AppListPanel` hides the affordance; this guards the
+   * command for every other caller.
    */
   const uninstallApp = async (id: string): Promise<void> => {
+    if (useAppStore.getState().manifestIds.includes(id)) {
+      logApp.warn(
+        `[useAppManager]: uninstallApp refused "${id}" — it is provided by the manifest and can only be disabled`,
+      )
+      return
+    }
     await deactivateApp(id)
     useWorkspaceStore.getState().removeInstalledApp(id)
     removeApp(id)
@@ -443,11 +457,11 @@ export const useAppManager = (): AppManagerCommands => {
           useWorkspaceStore.getState().workspace.installedApps ?? []
 
         // 4. Populate catalog in AppStore as manifest ∪ installedApps (§8.1)
-        const { entries, sources } = composeCatalog(
+        const { entries, sources, manifestIds } = composeCatalog(
           manifestEntries,
           installedApps,
         )
-        setCatalog(entries, sources)
+        setCatalog(entries, sources, manifestIds)
         logApp.info(
           `[${useAppManager.name}]: Catalog loaded with ${entries.length} entries`,
         )

--- a/src/features/AppManager/AppListPanel.spec.tsx
+++ b/src/features/AppManager/AppListPanel.spec.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAppStore } from '../../data/hooks/stores/AppStore'
+import type { AppManagerCommands } from '../../data/hooks/stores/useAppManager'
+import { AppCatalogEntry } from '../../models/AppModel/AppCatalogEntry'
+import { AppStatus } from '../../models/AppModel/AppStatus'
+import { AppSource } from '../../models/AppModel/InstalledApp'
+import { AppListPanel } from './AppListPanel'
+import { AppManagerCommandsProvider } from './AppManagerCommandsContext'
+
+const entry = (id: string): AppCatalogEntry => ({
+  id,
+  url: `https://apps.cytoscape.org/web/${id}/1.0.0/remoteEntry.js`,
+  author: 'Test',
+  name: `${id} app`,
+  version: '1.0.0',
+})
+
+const commands = (): AppManagerCommands =>
+  ({
+    activateApp: vi.fn().mockResolvedValue(undefined),
+    deactivateApp: vi.fn().mockResolvedValue(undefined),
+    retryApp: vi.fn().mockResolvedValue(undefined),
+    refreshCatalog: vi.fn().mockResolvedValue(undefined),
+    setManifestSource: vi.fn(),
+    removeOrphan: vi.fn(),
+    installApp: vi.fn().mockResolvedValue(undefined),
+    uninstallApp: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as AppManagerCommands
+
+/**
+ * Seed the catalog with a single app and render the panel.
+ *
+ * @param source provenance recorded for the merged catalog entry
+ * @param inManifest whether the resolved manifest still ships the id
+ */
+const renderPanel = (
+  id: string,
+  source: AppSource,
+  inManifest: boolean,
+): AppManagerCommands => {
+  useAppStore
+    .getState()
+    .setCatalog([entry(id)], { [id]: source }, inManifest ? [id] : [])
+  useAppStore.setState({
+    apps: {
+      [id]: { id, name: `${id} app`, status: AppStatus.Inactive } as any,
+    },
+    loadStates: {},
+  })
+  const cmds = commands()
+  render(
+    <AppManagerCommandsProvider value={cmds}>
+      <AppListPanel />
+    </AppManagerCommandsProvider>,
+  )
+  return cmds
+}
+
+describe('AppListPanel — uninstall affordance', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      apps: {},
+      catalog: {},
+      catalogSources: {},
+      manifestIds: [],
+      loadStates: {},
+    })
+  })
+
+  it('hides the kebab for a plain manifest app and keeps the toggle', () => {
+    renderPanel('hello', 'manifest', true)
+
+    expect(screen.queryByTestId('app-kebab-hello')).toBeNull()
+    expect(screen.getByTestId('app-toggle-hello')).toBeTruthy()
+  })
+
+  // The #699 regression: a snapshot restore stamps source 'snapshot' on every
+  // entry, manifest ids included, and the pinned record wins the merge. Keying
+  // removability on `source` alone put Uninstall back on an apps.json app.
+  it('hides the kebab for a manifest app restored from a snapshot', () => {
+    renderPanel('hello', 'snapshot', true)
+
+    expect(screen.queryByTestId('app-kebab-hello')).toBeNull()
+    expect(screen.getByTestId('app-toggle-hello')).toBeTruthy()
+  })
+
+  it('hides the kebab for a manifest app pinned by an App Store install', () => {
+    renderPanel('hello', 'appstore', true)
+
+    expect(screen.queryByTestId('app-kebab-hello')).toBeNull()
+    expect(screen.getByTestId('app-toggle-hello')).toBeTruthy()
+  })
+
+  it('shows the kebab for an App Store app the manifest does not ship', () => {
+    renderPanel('remote', 'appstore', false)
+
+    expect(screen.getByTestId('app-kebab-remote')).toBeTruthy()
+  })
+
+  it('shows the kebab for a snapshot app the manifest does not ship', () => {
+    renderPanel('remote', 'snapshot', false)
+
+    expect(screen.getByTestId('app-kebab-remote')).toBeTruthy()
+  })
+
+  it('uninstalls a non-manifest app through the confirmation dialog', () => {
+    const cmds = renderPanel('remote', 'appstore', false)
+
+    fireEvent.click(screen.getByTestId('app-kebab-remote'))
+    fireEvent.click(screen.getByTestId('app-uninstall-menuitem'))
+    fireEvent.click(screen.getByTestId('app-uninstall-confirm-button'))
+
+    expect(cmds.uninstallApp).toHaveBeenCalledWith('remote')
+  })
+})
+
+describe('AppListPanel — source chip', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      apps: {},
+      catalog: {},
+      catalogSources: {},
+      manifestIds: [],
+      loadStates: {},
+    })
+  })
+
+  // The chip is the only signal that a row runs a pinned URL rather than the
+  // manifest version, so it survives the loss of the kebab.
+  it('marks a shadowed manifest row as Snapshot', () => {
+    renderPanel('hello', 'snapshot', true)
+
+    expect(screen.getByText('Snapshot')).toBeTruthy()
+    expect(screen.queryByTestId('app-kebab-hello')).toBeNull()
+  })
+
+  it('marks a shadowed manifest row as App Store', () => {
+    renderPanel('hello', 'appstore', true)
+
+    expect(screen.getByText('App Store')).toBeTruthy()
+  })
+
+  it('leaves a plain manifest row unchipped', () => {
+    renderPanel('hello', 'manifest', true)
+
+    expect(screen.queryByText('Snapshot')).toBeNull()
+    expect(screen.queryByText('App Store')).toBeNull()
+  })
+})

--- a/src/features/AppManager/AppListPanel.tsx
+++ b/src/features/AppManager/AppListPanel.tsx
@@ -47,6 +47,16 @@ interface AppDisplayEntry {
 }
 
 /**
+ * Chip marking where a row's entry came from. Manifest rows carry no chip —
+ * that is the default and needs no label.
+ */
+function sourceChipLabel(source: AppSource | undefined): string | undefined {
+  if (source === 'snapshot') return 'Snapshot'
+  if (source === 'appstore') return 'App Store'
+  return undefined
+}
+
+/**
  * Determine the primary action for an app based on its catalog/load/status.
  */
 function getAction(
@@ -76,6 +86,7 @@ export const AppListPanel = () => {
   const catalogSources: Record<string, AppSource> = useAppStore(
     (state) => state.catalogSources,
   )
+  const manifestIds: string[] = useAppStore((state) => state.manifestIds)
   const loadStates: Record<string, AppLoadState> = useAppStore(
     (state) => state.loadStates,
   )
@@ -92,12 +103,14 @@ export const AppListPanel = () => {
   // Build merged display list: catalog entries + orphan apps
   const displayEntries: AppDisplayEntry[] = []
   const seenIds = new Set<string>()
+  const manifestIdSet = new Set(manifestIds)
 
   // 1. All catalog entries
   for (const entry of Object.values(catalog)) {
     seenIds.add(entry.id)
     const app = apps[entry.id]
     const source = catalogSources[entry.id]
+    const inManifest = manifestIdSet.has(entry.id)
     displayEntries.push({
       id: entry.id,
       name: entry.name ?? entry.id,
@@ -108,9 +121,13 @@ export const AppListPanel = () => {
       loadState: loadStates[entry.id],
       status: app?.status,
       source,
-      // Only workspace-installed apps are uninstallable; manifest apps are
-      // disable-only (§12.3).
-      removable: source === 'appstore' || source === 'snapshot',
+      // Only workspace-installed apps are uninstallable; anything the manifest
+      // still ships is disable-only (§12.3). A pinned App Store or snapshot
+      // install shadows the manifest source tag, so `source` alone is not the
+      // test — uninstalling such a row would drop the pinned URL and
+      // immediately re-add the app from the manifest.
+      removable:
+        !inManifest && (source === 'appstore' || source === 'snapshot'),
     })
   }
 
@@ -152,6 +169,7 @@ export const AppListPanel = () => {
         >
           {displayEntries.map((entry) => {
             const action = getAction(entry)
+            const chipLabel = sourceChipLabel(entry.source)
             const isActive =
               entry.loadState === 'loaded' && entry.status === AppStatus.Active
             return (
@@ -209,11 +227,9 @@ export const AppListPanel = () => {
                         sx={{ height: 20, fontSize: '0.7rem' }}
                       />
                     )}
-                    {entry.removable && (
+                    {chipLabel !== undefined && (
                       <Chip
-                        label={
-                          entry.source === 'snapshot' ? 'Snapshot' : 'App Store'
-                        }
+                        label={chipLabel}
                         size="small"
                         variant="outlined"
                         sx={{ height: 20, fontSize: '0.7rem' }}

--- a/src/features/AppManager/manifest/composeCatalog.test.ts
+++ b/src/features/AppManager/manifest/composeCatalog.test.ts
@@ -82,4 +82,44 @@ describe('composeCatalog', () => {
     )
     expect(entries.filter((e) => e.id === 'hello')).toHaveLength(1)
   })
+
+  describe('manifestIds', () => {
+    it('lists every manifest id', () => {
+      const { manifestIds } = composeCatalog([entry('a'), entry('b')], [])
+      expect(manifestIds.sort()).toEqual(['a', 'b'])
+    })
+
+    it('is empty when the manifest is empty', () => {
+      const { manifestIds } = composeCatalog([], [installed('z', 'appstore')])
+      expect(manifestIds).toEqual([])
+    })
+
+    it('excludes installed-only ids', () => {
+      const { manifestIds } = composeCatalog(
+        [entry('a')],
+        [installed('z', 'snapshot')],
+      )
+      expect(manifestIds).toEqual(['a'])
+    })
+
+    it('keeps a manifest id that a pinned appstore install shadows', () => {
+      const { sources, manifestIds } = composeCatalog(
+        [entry('hello', '1.0.0')],
+        [installed('hello', 'appstore', '2.0.0')],
+      )
+      // The pinned entry wins the merge, so `sources` no longer says
+      // 'manifest' — but the manifest still ships the app.
+      expect(sources.hello).toBe('appstore')
+      expect(manifestIds).toEqual(['hello'])
+    })
+
+    it('keeps a manifest id that a snapshot restore shadows', () => {
+      const { sources, manifestIds } = composeCatalog(
+        [entry('hello', '1.0.0')],
+        [installed('hello', 'snapshot', '2.0.0')],
+      )
+      expect(sources.hello).toBe('snapshot')
+      expect(manifestIds).toEqual(['hello'])
+    })
+  })
 })

--- a/src/features/AppManager/manifest/composeCatalog.ts
+++ b/src/features/AppManager/manifest/composeCatalog.ts
@@ -14,12 +14,22 @@ import { AppSource, InstalledApp } from '../../../models/AppModel/InstalledApp'
  *
  * Manifest-only ids are tagged `'manifest'` in the sources map.
  *
- * @returns the merged entries and a parallel `sources` map keyed by id.
+ * `manifestIds` records which ids the manifest itself carries, independent of
+ * which entry won the collision. A pinned install shadows the manifest source
+ * tag, so `sources` alone cannot answer "does the manifest still ship this
+ * app?" — which is what removability turns on (§12.3).
+ *
+ * @returns the merged entries, a parallel `sources` map keyed by id, and the
+ * ids present in the manifest.
  */
 export function composeCatalog(
   manifestEntries: AppCatalogEntry[],
   installedApps: InstalledApp[] = [],
-): { entries: AppCatalogEntry[]; sources: Record<string, AppSource> } {
+): {
+  entries: AppCatalogEntry[]
+  sources: Record<string, AppSource>
+  manifestIds: string[]
+} {
   const entryById = new Map<string, AppCatalogEntry>()
   const sources: Record<string, AppSource> = {}
 
@@ -28,6 +38,8 @@ export function composeCatalog(
     entryById.set(entry.id, entry)
     sources[entry.id] = 'manifest'
   }
+
+  const manifestIds = Array.from(entryById.keys())
 
   // Overlay the workspace's installed apps
   for (const installed of installedApps) {
@@ -49,5 +61,5 @@ export function composeCatalog(
     }
   }
 
-  return { entries: Array.from(entryById.values()), sources }
+  return { entries: Array.from(entryById.values()), sources, manifestIds }
 }

--- a/src/models/StoreModel/AppStoreModel.ts
+++ b/src/models/StoreModel/AppStoreModel.ts
@@ -20,8 +20,13 @@ export interface AppState {
   catalog: Record<string, AppCatalogEntry>
 
   // Provenance of each merged catalog entry (manifest | appstore | snapshot),
-  // session-local; consumed by the App Manager UI to decide removability
+  // session-local; records which entry won the merge, not whether the manifest
+  // still ships the app
   catalogSources: Record<string, AppSource>
+
+  // Ids the resolved manifest carries, independent of which entry won the
+  // merge; consumed by the App Manager UI to decide removability (§12.3)
+  manifestIds: string[]
 
   // Per-app runtime load state (session-local, not persisted)
   loadStates: Record<string, AppLoadState>
@@ -123,10 +128,13 @@ export interface AppAction {
   /**
    * Replace the entire catalog with new entries plus their provenance.
    * When `sources` is omitted, every entry defaults to `'manifest'`.
+   * When `manifestIds` is omitted, it falls back to the entries whose
+   * resolved source is `'manifest'`.
    */
   setCatalog: (
     entries: AppCatalogEntry[],
     sources?: Record<string, AppSource>,
+    manifestIds?: string[],
   ) => void
 
   /**

--- a/src/models/StoreModel/impl/appStoreImpl.test.ts
+++ b/src/models/StoreModel/impl/appStoreImpl.test.ts
@@ -14,6 +14,7 @@ import {
   clearCurrentTask,
   removeService,
   restore,
+  setCatalog,
   setCurrentTask,
   setStatus,
   updateInputColumn,
@@ -27,6 +28,7 @@ const createDefaultState = (): AppState => {
     currentTask: undefined,
     catalog: {},
     catalogSources: {},
+    manifestIds: [],
     loadStates: {},
     manifestSource: undefined,
   }
@@ -434,6 +436,48 @@ describe('AppStoreImpl', () => {
       expect(original.apps).toEqual({})
       expect(original.serviceApps).toEqual({})
       expect(original.currentTask).toBeUndefined()
+    })
+  })
+  describe('setCatalog', () => {
+    const catalogEntry = (id: string) => ({
+      id,
+      url: `https://apps.cytoscape.org/web/${id}/remoteEntry.js`,
+      author: 'Test',
+    })
+
+    it('defaults every source to manifest when sources is omitted', () => {
+      const state = setCatalog(createDefaultState(), [
+        catalogEntry('a'),
+        catalogEntry('b'),
+      ])
+      expect(state.catalogSources).toEqual({ a: 'manifest', b: 'manifest' })
+    })
+
+    it('derives manifestIds from the manifest sources when omitted', () => {
+      const state = setCatalog(
+        createDefaultState(),
+        [catalogEntry('a'), catalogEntry('z')],
+        { a: 'manifest', z: 'appstore' },
+      )
+      expect(state.manifestIds).toEqual(['a'])
+    })
+
+    it('keeps an explicit manifestIds even when the source is shadowed', () => {
+      const state = setCatalog(
+        createDefaultState(),
+        [catalogEntry('hello')],
+        { hello: 'snapshot' },
+        ['hello'],
+      )
+      expect(state.catalogSources.hello).toBe('snapshot')
+      expect(state.manifestIds).toEqual(['hello'])
+    })
+
+    it('replaces the previous catalog and manifestIds', () => {
+      const first = setCatalog(createDefaultState(), [catalogEntry('a')])
+      const second = setCatalog(first, [catalogEntry('b')], undefined, ['b'])
+      expect(Object.keys(second.catalog)).toEqual(['b'])
+      expect(second.manifestIds).toEqual(['b'])
     })
   })
 })

--- a/src/models/StoreModel/impl/appStoreImpl.ts
+++ b/src/models/StoreModel/impl/appStoreImpl.ts
@@ -51,6 +51,7 @@ export interface AppState {
   currentTask?: ServiceAppTask
   catalog: Record<string, AppCatalogEntry>
   catalogSources: Record<string, AppSource>
+  manifestIds: string[]
   loadStates: Record<string, AppLoadState>
   manifestSource?: ManifestSource
 }
@@ -332,11 +333,17 @@ export const updateInputColumn = (
  * Replace the entire catalog with entries keyed by id, along with each
  * entry's provenance. When `sources` is omitted, every entry defaults to
  * `'manifest'`.
+ *
+ * `manifestIds` is the set of ids the manifest itself carries. It is kept
+ * apart from `catalogSources` because a pinned install shadows the manifest
+ * source tag on a collision (composeCatalog §8.1). When omitted it falls back
+ * to the entries whose resolved source is `'manifest'`.
  */
 export const setCatalog = (
   state: AppState,
   entries: AppCatalogEntry[],
   sources?: Record<string, AppSource>,
+  manifestIds?: string[],
 ): AppState => {
   const catalog: Record<string, AppCatalogEntry> = {}
   const catalogSources: Record<string, AppSource> = {}
@@ -348,6 +355,11 @@ export const setCatalog = (
     ...state,
     catalog,
     catalogSources,
+    manifestIds:
+      manifestIds ??
+      Object.keys(catalogSources).filter(
+        (id) => catalogSources[id] === 'manifest',
+      ),
   }
 }
 


### PR DESCRIPTION
Fixes #699.

## What was wrong

Removability keyed off `InstalledApp.source` (`AppListPanel.tsx:113`), but `composeCatalog` lets a pinned `appstore`/`snapshot` record win an id collision and overwrite the `'manifest'` tag (`composeCatalog.ts:46`). Both stamping sites apply their source unconditionally:

| Path | Site |
| --- | --- |
| Restore a workspace snapshot | `useLoadWorkspace.ts:154` — `source: 'snapshot'` for every restored entry |
| App Store / `?installApp=` | `useAppManager.ts:372` — `source: 'appstore'` for every install |

So an app shipped in `apps.json` got the kebab menu and **Uninstall** back. Confirming it discarded the pinned URL, then `recomposeCatalog` re-added the manifest entry — the row returned and the dialog's "It will be removed from this workspace" did not hold.

## The fix

Gate removability on manifest membership, not on `source`.

- `composeCatalog` returns `manifestIds` alongside `entries` and `sources`.
- `AppStore.manifestIds` holds it; `setCatalog(entries, sources?, manifestIds?)` falls back to the `'manifest'`-sourced ids when the argument is omitted, so existing two-argument callers keep their behavior.
- `AppListPanel` hides the kebab for any id the manifest still ships.
- `uninstallApp` refuses those ids, guarding every caller outside the panel.

The source chip now tracks `source` rather than removability. A pinned install shadowing a manifest id keeps its `App Store` / `Snapshot` chip — otherwise losing the kebab would also lose the only signal that the row runs a pinned URL.

## Cost

A pinned App Store version installed over a manifest id can no longer be reverted to the manifest version from the UI. That was never a labelled action — it was an **Uninstall** that appeared to fail — so nothing discoverable is lost. Spec §12.3 now records `Revert to manifest version` as the place to add it back if wanted.

This resolves both open questions on the issue: hide the affordance entirely, and guard the command as well as the UI.

## Tests

| File | Coverage |
| --- | --- |
| `AppListPanel.spec.tsx` (new) | 9 cases: kebab hidden for manifest / snapshot-shadowed / appstore-shadowed rows, shown for non-manifest rows, full uninstall flow, chip behavior |
| `composeCatalog.test.ts` | `manifestIds` under both collision sources |
| `appStoreImpl.test.ts` | `setCatalog` fallback and explicit `manifestIds` |
| `useAppManager.test.tsx` | `uninstallApp` refuses a manifest id |

The new panel spec fails 3/9 against the old `removable` rule and passes against the fix.

`npm run test:checks:quiet` — lint, tsc, 317 files / 3922 tests, all passing. No e2e spec touches the uninstall affordance; port 5500 had a dev server running, so no local e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented uninstalling apps provided by the workspace manifest.
  * Preserved manifest-provided apps when App Store or snapshot installations use the same ID.
  * Updated app list controls to show uninstall options only when removal is supported.

* **UI Improvements**
  * Source indicators now accurately show whether an app comes from the App Store or a snapshot, including apps overriding manifest entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->