### PR TITLE
feat(toolbar): roving tabindex for the menubar

### DIFF
--- a/src/features/ToolBar/DropdownMenu.tsx
+++ b/src/features/ToolBar/DropdownMenu.tsx
@@ -404,6 +404,17 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     isOpenRef.current = isOpen
   }, [isOpen])
 
+  // Roving tabindex: the menubar needs to know this trigger exists (in
+  // mount order) and whether it can take the tab stop. Registration and the
+  // enabled flag are separate effects so a disabled toggle keeps the
+  // trigger's position in the bar.
+  const registerTrigger = menuBar?.registerTrigger
+  const setTriggerEnabled = menuBar?.setTriggerEnabled
+  useEffect(() => registerTrigger?.(id), [registerTrigger, id])
+  useEffect(() => {
+    setTriggerEnabled?.(id, !disabled)
+  }, [setTriggerEnabled, id, disabled])
+
   // A menu that becomes disabled while open closes rather than lingering
   // behind a disabled trigger.
   useEffect(() => {
@@ -492,6 +503,13 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
             // keeps its native role, since a menuitem outside a menubar is
             // invalid ARIA.
             role={menuBar === null ? undefined : 'menuitem'}
+            // Roving tabindex: the bar is one Tab stop, on the trigger last used.
+            tabIndex={
+              menuBar === null ? undefined : menuBar.tabStopId === id ? 0 : -1
+            }
+            onFocus={() => {
+              menuBar?.setActiveId(id)
+            }}
             disabled={disabled}
             sx={{
               color: darkPalette.text.primary,

--- a/src/features/ToolBar/DropdownMenu.tsx
+++ b/src/features/ToolBar/DropdownMenu.tsx
@@ -472,6 +472,9 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = ({
     }
     const nextId = next.getAttribute(MENU_BAR_TRIGGER_ATTR)
     if (openTarget && nextId !== null) {
+      // Focus goes into the new menu, not onto its trigger, so the trigger's
+      // focus handler never runs: hand it the tab stop here.
+      menuBar.setActiveId(nextId)
       menuBar.openMenu(nextId, 'keyboard')
     } else {
       next.focus()

--- a/src/features/ToolBar/MenuBar.spec.tsx
+++ b/src/features/ToolBar/MenuBar.spec.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { DropdownMenu } from './DropdownMenu'
@@ -135,6 +136,62 @@ describe('MenuBar', () => {
     )
     fireEvent.keyDown(menu, { key: 'ArrowDown' })
     expect(document.activeElement).toBe(menuOf('Data'))
+  })
+
+  it('is a single tab stop whose position follows focus (roving tabindex)', () => {
+    renderMenuBar()
+    // The first enabled trigger starts as the tab stop; a disabled trigger is
+    // never one.
+    expect(button('data').tabIndex).toBe(0)
+    expect(button('edit').tabIndex).toBe(-1)
+    expect(button('layout').tabIndex).toBe(-1)
+    expect(button('help').tabIndex).toBe(-1)
+
+    // Whichever trigger takes focus (click, or Tab back into the bar) becomes
+    // the tab stop, so leaving and re-entering the bar lands where the user
+    // was.
+    act(() => button('help').focus())
+    expect(button('help').tabIndex).toBe(0)
+    expect(button('data').tabIndex).toBe(-1)
+
+    // The arrow keys move focus, and the tab stop with it.
+    fireEvent.keyDown(button('help'), { key: 'ArrowLeft' })
+    expect(document.activeElement).toBe(button('layout'))
+    expect(button('layout').tabIndex).toBe(0)
+    expect(button('help').tabIndex).toBe(-1)
+  })
+
+  it('moves the tab stop to the first enabled trigger when its own is disabled', () => {
+    const Harness = () => {
+      const [layoutDisabled, setLayoutDisabled] = useState(false)
+      return (
+        <>
+          <MenuBar>
+            <TestMenu id="data" label="Data" />
+            <TestMenu id="layout" label="Layout" disabled={layoutDisabled} />
+            <TestMenu id="help" label="Help" />
+          </MenuBar>
+          <button
+            data-testid="toggle"
+            onClick={() => setLayoutDisabled((value) => !value)}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    act(() => button('layout').focus())
+    expect(button('layout').tabIndex).toBe(0)
+
+    fireEvent.click(screen.getByTestId('toggle'))
+    expect(button('layout').tabIndex).toBe(-1)
+    expect(button('data').tabIndex).toBe(0)
+    expect(button('help').tabIndex).toBe(-1)
+
+    // Re-enabling it does not steal the tab stop back.
+    fireEvent.click(screen.getByTestId('toggle'))
+    expect(button('data').tabIndex).toBe(0)
+    expect(button('layout').tabIndex).toBe(-1)
   })
 
   it('opens the next menu from a closed trigger with ArrowDown', () => {

--- a/src/features/ToolBar/MenuBar.spec.tsx
+++ b/src/features/ToolBar/MenuBar.spec.tsx
@@ -161,6 +161,24 @@ describe('MenuBar', () => {
     expect(button('help').tabIndex).toBe(-1)
   })
 
+  it('moves the tab stop with an arrow-key switch between open menus', () => {
+    renderMenuBar()
+    fireEvent.click(button('data'))
+    expect(button('data').tabIndex).toBe(0)
+
+    // The switch puts focus on Layout's first row, never on its trigger, so
+    // the trigger's own focus handler cannot claim the stop.
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(menuOf('Layout'))
+    expect(button('layout').tabIndex).toBe(0)
+    expect(button('data').tabIndex).toBe(-1)
+
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowLeft' })
+    expect(document.activeElement).toBe(menuOf('Data'))
+    expect(button('data').tabIndex).toBe(0)
+    expect(button('layout').tabIndex).toBe(-1)
+  })
+
   it('moves the tab stop to the first enabled trigger when its own is disabled', () => {
     const Harness = () => {
       const [layoutDisabled, setLayoutDisabled] = useState(false)

--- a/src/features/ToolBar/MenuBar.tsx
+++ b/src/features/ToolBar/MenuBar.tsx
@@ -34,6 +34,22 @@ export interface MenuBarContextValue {
   setOpenIntent: (intent: MenuOpenIntent) => void
   /** Enabled top-level triggers, in menubar order. */
   getTriggers: () => HTMLButtonElement[]
+  /**
+   * Id of the one trigger in the Tab order (roving tabindex): the menubar is
+   * a single tab stop, and the arrow keys move between its triggers. Null
+   * until a trigger has registered.
+   */
+  tabStopId: string | null
+  /** A trigger took focus, so it becomes the tab stop. */
+  setActiveId: (id: string) => void
+  /**
+   * Triggers announce themselves (in mount order, which is menubar order)
+   * and whether they are enabled, so the tab stop can start on the first
+   * enabled trigger and leave one that becomes disabled. Returns the
+   * unregister function.
+   */
+  registerTrigger: (id: string) => () => void
+  setTriggerEnabled: (id: string, enabled: boolean) => void
 }
 
 const MenuBarContext = createContext<MenuBarContextValue | null>(null)
@@ -77,11 +93,25 @@ export const useMenuBarMenu = (
   }
 }
 
+/** Registered triggers in menubar order, with whether each is enabled. */
+type TriggerRegistry = Map<string, boolean>
+
+const firstEnabled = (triggers: TriggerRegistry): string | null => {
+  for (const [id, enabled] of triggers) {
+    if (enabled) {
+      return id
+    }
+  }
+  return null
+}
+
 /**
  * Container for the toolbar's top-level menus. It owns which menu is open,
  * which is what makes the bar behave like a desktop menubar: one click opens
  * a menu, and from then on hovering or arrowing across the other triggers
  * moves the open menu with the pointer instead of asking for another click.
+ * It also owns the bar's single Tab stop (roving tabindex), so Tab treats the
+ * whole bar as one control and lands on the trigger last used.
  */
 export const MenuBar = ({ children, ...boxProps }: BoxProps): JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -94,6 +124,14 @@ export const MenuBar = ({ children, ...boxProps }: BoxProps): JSX.Element => {
     openId: string | null
     openIntent: MenuOpenIntent
   }>({ openId: null, openIntent: 'pointer' })
+
+  // Roving tabindex: the registry keeps menubar order (a Map keeps insertion
+  // order, and triggers register in mount order), `activeId` is the trigger
+  // that last had focus. The tab stop is the active trigger while it is
+  // enabled; a trigger that becomes disabled hands the stop to the first
+  // enabled one for good, so re-enabling it does not yank the stop back.
+  const [triggers, setTriggers] = useState<TriggerRegistry>(() => new Map())
+  const [activeId, setActiveId] = useState<string | null>(null)
 
   const setOpenIntent = useCallback((intent: MenuOpenIntent): void => {
     pendingIntentRef.current = intent
@@ -123,6 +161,55 @@ export const MenuBar = ({ children, ...boxProps }: BoxProps): JSX.Element => {
     )
   }, [])
 
+  const registerTrigger = useCallback((id: string): (() => void) => {
+    setTriggers((current) => {
+      if (current.has(id)) {
+        return current
+      }
+      const next = new Map(current)
+      // Enabled until the trigger reports otherwise; setTriggerEnabled runs
+      // right after registration.
+      next.set(id, true)
+      return next
+    })
+    return () => {
+      setTriggers((current) => {
+        if (!current.has(id)) {
+          return current
+        }
+        const next = new Map(current)
+        next.delete(id)
+        return next
+      })
+      setActiveId((current) => (current === id ? null : current))
+    }
+  }, [])
+
+  const setTriggerEnabled = useCallback(
+    (id: string, enabled: boolean): void => {
+      setTriggers((current) => {
+        if (current.get(id) === enabled) {
+          return current
+        }
+        const next = new Map(current)
+        next.set(id, enabled)
+        return next
+      })
+      if (!enabled) {
+        setActiveId((current) => (current === id ? null : current))
+      }
+    },
+    [],
+  )
+
+  const tabStopId = useMemo(
+    () =>
+      activeId !== null && triggers.get(activeId) === true
+        ? activeId
+        : firstEnabled(triggers),
+    [activeId, triggers],
+  )
+
   const value = useMemo<MenuBarContextValue>(
     () => ({
       openId: state.openId,
@@ -131,8 +218,21 @@ export const MenuBar = ({ children, ...boxProps }: BoxProps): JSX.Element => {
       closeMenu,
       setOpenIntent,
       getTriggers,
+      tabStopId,
+      setActiveId,
+      registerTrigger,
+      setTriggerEnabled,
     }),
-    [state, openMenu, closeMenu, setOpenIntent, getTriggers],
+    [
+      state,
+      openMenu,
+      closeMenu,
+      setOpenIntent,
+      getTriggers,
+      tabStopId,
+      registerTrigger,
+      setTriggerEnabled,
+    ],
   )
 
   return (

--- a/src/features/ToolBar/ToolBar_docs/ToolBar.md
+++ b/src/features/ToolBar/ToolBar_docs/ToolBar.md
@@ -43,6 +43,7 @@ The ToolBar is organized into menu categories, each with its own submenu system.
 - The bar behaves like a desktop menubar: a click opens a menu, and while any menu is open, hovering another trigger (mouse only, not touch) or pressing ArrowLeft/ArrowRight moves the open menu there in one step
 - `MenuBar` is the single source of truth for which menu is open; each menu reads its flag through `useMenuBarMenu(id)` and keeps `setOpen(false)` for its own close paths
 - Dropdowns are `Popper`s, not `Popover`s: a Popover is a modal whose invisible backdrop ate the click on the next trigger, so every switch used to cost two clicks
+- The bar is a single Tab stop (roving tabindex): Tab lands on the trigger last used (initially the first enabled one), and ArrowLeft/ArrowRight move between triggers; a trigger that becomes disabled hands the stop to the first enabled one
 - Keyboard: ArrowDown/Enter/Space open a menu with focus on its first row; ArrowUp/Down, Home/End move within a level; ArrowRight opens a submenu or moves to the next menu; ArrowLeft closes a submenu or moves to the previous menu; Escape closes and returns focus to the trigger; Tab or a click elsewhere closes
 - Submenus open on hover and support nested structures
 - Menu items can be enabled/disabled based on context


### PR DESCRIPTION
Follow-up to #709 (fixed by #710): the menubar becomes a single Tab stop, per the [WAI-ARIA menubar pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/#keyboardinteraction).

## Summary

- **One Tab stop.** Exactly one trigger carries `tabIndex=0`, the rest `-1`, so Tab treats the bar as one control and ArrowLeft/ArrowRight move between menus. Before this, every trigger was its own Tab stop.
- **`MenuBar` owns the stop** (`src/features/ToolBar/MenuBar.tsx`). Triggers register in mount order (menubar order) and report whether they are enabled. The stop is the trigger that last had focus while it stays enabled, initially the first enabled one (Data). A trigger that becomes disabled hands the stop to the first enabled trigger for good; re-enabling it does not yank the stop back.
- **`DropdownMenu`** takes `tabIndex` from the menubar and reports focus, so the stop follows clicks, the arrow keys and Tab re-entry. Outside a `MenuBar` the trigger keeps its native tab order, so standalone use is unchanged.
- Docs: `ToolBar.md` menu-system section.
- **Review follow-up (6fa567fb).** An ArrowLeft/ArrowRight switch from an open menu opens the neighbour with focus on its first row, never on its trigger, so the trigger's focus handler could not claim the stop and Shift+Tab back into the bar landed on the previous menu. `navigateMenuBar` now hands the stop to the neighbour before opening it.

## Test plan

- [x] Two new `MenuBar.spec.tsx` tests, both failing before the change: the stop starts on the first enabled trigger and follows focus and the arrow keys; it moves to the first enabled trigger when its own is disabled and stays there on re-enable.
- [x] Regression test for the follow-up: ArrowRight then ArrowLeft between open menus, asserting the newly opened menu's trigger is the only `tabIndex=0` each time (failed before the fix).
- [x] 94 toolbar unit tests, lint, typecheck and Prettier green; the same five e2e specs re-run green after the follow-up.
- [x] e2e (chromium, against the dev server): `undo-redo`, `onboarding-flow`, `local-file-import`, `dialog-dismiss`, `remote-app-load` — 15 passed.
- [x] Manual in the browser: click Help → Help is the stop; ArrowLeft → focus and stop move to Apps; Tab leaves the bar in one step to the search box; Shift+Tab returns to Apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved toolbar keyboard navigation with a single Tab stop.
  * Arrow keys now move focus between menu triggers while preserving the active tab stop.
  * If the active trigger is disabled, focus moves to the first enabled trigger.
  * Re-enabled triggers no longer automatically reclaim the tab stop.

* **Documentation**
  * Documented the toolbar’s updated keyboard navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
