### PR TITLE
feat(vizmapper): rename "Style Library" to "Workspace Styles" (#704)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,7 +225,7 @@ Read these before working in related areas:
 
 - `docs/specifications/STARTUP_SPECIFICATION.md` — boot phase contract, failure policy, timing milestones
 - `docs/specifications/ROUTING_SPECIFICATION.md` — URL routing rules, navigation patterns, search parameter handling
-- `docs/specifications/MULTIPLE_VISUAL_STYLES.md` — Named visual style sets per network, `cyWebVisualStyles` CX2 aspect, style library
+- `docs/specifications/MULTIPLE_VISUAL_STYLES.md` — Named visual style sets per network, `cyWebVisualStyles` CX2 aspect, workspace styles (style library)
 - `docs/specifications/EXTERNAL_INPUT_VALIDATION_POLICY.md` — CX2 validation requirements for external data
 - `docs/specifications/DIALOG_DISMISS_POLICY.md` — button-only dialog dismissal, the `CyDialog` wrapper, modal form popovers
 - `docs/specifications/DEBUG_GUIDE.MD` — Structured logging policy and debug namespace usage

--- a/docs/specifications/MULTIPLE_VISUAL_STYLES.md
+++ b/docs/specifications/MULTIPLE_VISUAL_STYLES.md
@@ -11,8 +11,9 @@
   Invariants: at least one entry; `activeStyleId` resolves; entry keys match
   entry ids.
 - **Style template** (`StyleTemplate`) — a reusable style in the
-  workspace-level **style library**. Applying a template **copies** it into a
-  network's style set (copy-on-assign). There are no live references between
+  workspace-level **style library**, labelled **Workspace Styles** in the UI
+  (#704; code and DB names keep "library"). Applying a template **copies** it
+  into a network's style set (copy-on-assign). There are no live references between
   the library and networks, so there is nothing to reconcile on import/export
   and no cross-network edit surprises. Templates never contain bypasses
   (bypass entries reference element ids of a specific network).
@@ -197,10 +198,10 @@ per-style, matching current behavior.
 
 `src/features/Vizmapper/StyleManager/` — a row at the top of the Vizmapper
 panel showing the active style's **thumbnail and name**, plus a management menu
-(New (copy of current) / Duplicate / Rename / Delete; Save Style to Library /
-Apply Style from Library). All operations mark the network modified — the
+(New (copy of current) / Duplicate / Rename / Delete; Save Style to Workspace /
+Apply Style from Workspace). All operations mark the network modified — the
 undoable ones through `postEdit`, the rest through an explicit
-`setNetworkModified` in `StyleManager` (#680). "Save Style to Library" is the
+`setNetworkModified` in `StyleManager` (#680). "Save Style to Workspace" is the
 exception: it writes only the browser-local style library and leaves the
 network untouched.
 
@@ -209,11 +210,11 @@ three sections. The sections exist because a style belongs to one network and
 moving one across networks copies it (§1) — they are what tell the user whether a
 click switches or copies:
 
-| Section        | Source                                  | A click…                    |
-| -------------- | --------------------------------------- | --------------------------- |
-| This Network   | `styleSets[networkId]`                  | switches (undoable)         |
-| Other Networks | `getStyleSetMetadataFromDb` (IndexedDB) | copies in via `importStyle` |
-| Library        | `useStyleLibraryStore`                  | copies in via `importStyle` |
+| Section          | Source                                  | A click…                    |
+| ---------------- | --------------------------------------- | --------------------------- |
+| This Network     | `styleSets[networkId]`                  | switches (undoable)         |
+| Other Networks   | `getStyleSetMetadataFromDb` (IndexedDB) | copies in via `importStyle` |
+| Workspace Styles | `useStyleLibraryStore`                  | copies in via `importStyle` |
 
 Cytoscape Desktop pools every style into one flat list instead; it can only do
 that because its styles are session-global and shared live.

--- a/docs/specifications/MULTIPLE_VISUAL_STYLES.md
+++ b/docs/specifications/MULTIPLE_VISUAL_STYLES.md
@@ -206,7 +206,7 @@ exception: it writes only the browser-local style library and leaves the
 network untouched.
 
 Clicking the row opens **`StylePickerDialog`**, a modal grid of style previews in
-three sections. The sections exist because a style belongs to one network and
+four sections. The sections exist because a style belongs to one network and
 moving one across networks copies it (§1) — they are what tell the user whether a
 click switches or copies:
 
@@ -215,6 +215,7 @@ click switches or copies:
 | This Network     | `styleSets[networkId]`                  | switches (undoable)         |
 | Other Networks   | `getStyleSetMetadataFromDb` (IndexedDB) | copies in via `importStyle` |
 | Workspace Styles | `useStyleLibraryStore`                  | copies in via `importStyle` |
+| General Styles   | `PRESET_VISUAL_STYLES`                  | copies in via `importStyle` |
 
 Cytoscape Desktop pools every style into one flat list instead; it can only do
 that because its styles are session-global and shared live.

--- a/src/features/Vizmapper/StyleManager/StyleLibraryDialog.tsx
+++ b/src/features/Vizmapper/StyleManager/StyleLibraryDialog.tsx
@@ -66,7 +66,7 @@ export const StyleLibraryDialog = (
         maxWidth="sm"
         data-testid="style-library-dialog"
       >
-        <DialogTitle>Style Library</DialogTitle>
+        <DialogTitle>Workspace Styles</DialogTitle>
         <DialogContent>
           {templateList.length === 0 ? (
             <Typography
@@ -74,8 +74,9 @@ export const StyleLibraryDialog = (
               sx={{ color: 'text.secondary', py: 2 }}
               data-testid="style-library-empty-message"
             >
-              No styles in the library yet. Use &ldquo;Save Style to
-              Library&rdquo; in the style menu to add the current style.
+              No workspace styles yet. Use &ldquo;Save Style to Workspace&rdquo;
+              in the style menu to add the current style. Workspace styles stay
+              in this browser and are available to every network here.
             </Typography>
           ) : (
             <List dense data-testid="style-library-list">
@@ -128,7 +129,7 @@ export const StyleLibraryDialog = (
       </CyDialog>
       <StyleNameDialog
         open={renameTarget !== undefined}
-        title="Rename Library Style"
+        title="Rename Workspace Style"
         confirmLabel="Rename"
         initialName={renameTarget?.name ?? ''}
         onConfirm={(name) => {
@@ -147,10 +148,10 @@ export const StyleLibraryDialog = (
         open={deleteTarget !== undefined}
         data-testid="style-library-delete-dialog"
       >
-        <DialogTitle>Delete Library Style</DialogTitle>
+        <DialogTitle>Delete Workspace Style</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Delete the library style &ldquo;{deleteTarget?.name}&rdquo;? This
+            Delete the workspace style &ldquo;{deleteTarget?.name}&rdquo;? This
             cannot be undone. Networks already using a copy of it are not
             affected.
           </DialogContentText>

--- a/src/features/Vizmapper/StyleManager/StyleManager.tsx
+++ b/src/features/Vizmapper/StyleManager/StyleManager.tsx
@@ -378,7 +378,7 @@ export const StyleManager = (props: {
           }}
           data-testid="style-manager-save-to-library-menu-item"
         >
-          <ListItemText>Save Style to Library…</ListItemText>
+          <ListItemText>Save Style to Workspace…</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -387,7 +387,7 @@ export const StyleManager = (props: {
           }}
           data-testid="style-manager-open-library-menu-item"
         >
-          <ListItemText>Apply Style from Library…</ListItemText>
+          <ListItemText>Apply Style from Workspace…</ListItemText>
         </MenuItem>
       </Menu>
 
@@ -423,7 +423,7 @@ export const StyleManager = (props: {
       />
       <StyleNameDialog
         open={dialog === 'saveToLibrary'}
-        title="Save Style to Library"
+        title="Save Style to Workspace"
         confirmLabel="Save"
         initialName={activeEntry.name}
         onConfirm={handleSaveToLibrary}

--- a/src/features/Vizmapper/StyleManager/StylePickerDialog.tsx
+++ b/src/features/Vizmapper/StyleManager/StylePickerDialog.tsx
@@ -390,7 +390,7 @@ export const StylePickerDialog = (
 
         {visibleTemplates.length > 0 && (
           <Section
-            title="Library"
+            title="Workspace Styles"
             hint="Click to copy into this network"
             testId="style-picker-section-library"
           >

--- a/src/features/Vizmapper/Vizmapper_docs/Vizmapper.md
+++ b/src/features/Vizmapper/Vizmapper_docs/Vizmapper.md
@@ -52,12 +52,13 @@ The Vizmapper is organized around visual properties, which are grouped into thre
 - **StyleManager/StyleManager.tsx**: Selector row rendered above the tabs
   - Dropdown to switch the network's active named style
   - Menu: New Style (copy of current), Duplicate, Rename, Delete,
-    Save Style to Library, Apply Style from Library
+    Save Style to Workspace, Apply Style from Workspace
   - Every operation marks the network as modified
   - Switching styles clears the network's undo/redo history (recorded edits
     reference the previous style)
 - **StyleManager/StyleNameDialog.tsx**: Name prompt shared by create/rename/save
-- **StyleManager/StyleLibraryDialog.tsx**: Workspace-level style library browser;
+- **StyleManager/StyleLibraryDialog.tsx**: Workspace-level style library browser,
+  titled "Workspace Styles" in the UI (#704);
   applying a template copies it into the network's style set (copy-on-assign)
 - See `docs/specifications/MULTIPLE_VISUAL_STYLES.md` for the full model,
   IndexedDB, and CX2/NDEx persistence design


### PR DESCRIPTION
Closes #704.

## What this changes

The saved-style UI never said where those styles live. A user could not tell whether saving a style affected one network, the workspace, or their NDEx account. This renames the nine user-facing strings so the label carries the scope, matching the vocabulary the onboarding tour (#697) already teaches for local browser storage.

| Surface | Today | Now |
| --- | --- | --- |
| Style menu item | `Save Style to Library…` | `Save Style to Workspace…` |
| Style menu item | `Apply Style from Library…` | `Apply Style from Workspace…` |
| Save dialog title | `Save Style to Library` | `Save Style to Workspace` |
| Browser dialog title | `Style Library` | `Workspace Styles` |
| Empty state | `No styles in the library yet…` | `No workspace styles yet… Workspace styles stay in this browser and are available to every network here.` |
| Rename dialog title | `Rename Library Style` | `Rename Workspace Style` |
| Delete dialog title | `Delete Library Style` | `Delete Workspace Style` |
| Delete confirmation body | `Delete the library style “{name}”?…` | `Delete the workspace style “{name}”?…` |
| Picker section heading | `Library` | `Workspace Styles` |

The picker's four headings now read as one scope axis: `This Network`, `Other Networks`, `Workspace Styles`, `General Styles`.

## What keeps the name "library"

These are persisted or load-bearing. Renaming them costs a DB migration and buys the user nothing.

| Name | Why it stays |
| --- | --- |
| `cyStyleLibrary` IndexedDB store | Shipped in DB v10; a rename needs a version bump plus a copy-rows `upgradeFn`. |
| `cyStyleLibrary` snapshot key | Exported workspace backups already contain this key. |
| `data-testid` values (15) | Not user-visible; renaming forces spec edits for no behavior change. |
| Filenames and TS identifiers | `StyleLibraryDialog`, `useStyleLibraryStore`, `StyleLibraryState`. Not federated, not persisted. |

Nothing in CX2 contains "library" — the library never travels in a network document. `src/app-api/` exports no "library" name, so no plugin contract breaks. The docs now record the divergence between the UI label and the code name.

Renaming the internal identifiers is separable and optional; worth a follow-up only if the divergence becomes confusing.

## Verification

- `npm run lint` — clean (tsc + oxlint).
- `npx vitest run StylePickerDialog StyleManagerUndo StyleLibraryStore StyleLibraryDialog` — 39 passed. No spec needed editing; test ids are unchanged.
- `grep -rn "Style Library\|to Library\|from Library\|Library Style" src/ docs/` returns only the two DB-internal mentions in the excluded set above.

The full `npm run test:checks:quiet` run reported 12 failures in 6 unrelated files (`VisualStyleStore`, `MenuBar`, `ListPastePanel`, `AppListPanel`, `AppSettingsDialog`, `ListValueEditorDialog`). All six pass in isolation — 94 tests in 3.9s versus 173s for the full suite. They are 1-second-timeout flakes under worker contention, not regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated specification and feature documentation to use the “Workspace Styles” terminology.
  - Clarified that workspace-level reusable style collections appear as “Workspace Styles” in the interface.

- **Style**
  - Renamed style management labels and dialogs from “Library” to “Workspace.”
  - Updated save, apply, empty-state, rename, deletion, and picker text for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->