### PR TITLE
feat(app-api): apply an existing visual style to a network (#702)

### DIFF
--- a/docs/specifications/MULTIPLE_VISUAL_STYLES.md
+++ b/docs/specifications/MULTIPLE_VISUAL_STYLES.md
@@ -114,6 +114,40 @@ The style library lives in `useStyleLibraryStore`
 mutation, `hydrate()` loads once on first use (called when the library dialog
 opens).
 
+### App API surface
+
+External apps reach the feature through two methods on `visualStyleApi`
+(#702) — `src/app-api/core/visualStyleApi.ts`:
+
+- `getVisualStyle(networkId)` returns a detached deep copy of the ACTIVE
+  style. Only a network whose style is registered in memory can answer; a
+  workspace network never opened reports `APP1`.
+- `applyVisualStyle(networkId, visualStyle, options?)` runs the same two
+  store actions as `StyleManager.handleCopyIn` — `importStyle` then
+  `switchStyle` — and records the same `SWITCH_STYLE` undo entry, so an app's
+  apply is indistinguishable from the user's.
+
+Two things the in-app path gets for free and the API has to do itself:
+
+- **Validate the style.** An app passes an arbitrary object, so
+  `isValidVisualStyle` (`impl/visualStyleSetImpl.ts`) checks it before
+  anything is stored. Without it a malformed style becomes the active one and
+  fails later inside `CyjsRenderer` with nothing naming the caller.
+- **Establish WHY an import failed.** `importStyle` reports both an unknown
+  network and a full set as `undefined`, so the API reads the set size against
+  `MAX_STYLES_PER_NETWORK` itself and returns `APP14` rather than guessing.
+
+Copy semantics are stated in `api_docs/Api.md` because they diverge from
+Desktop: `VisualMappingManager.setVisualStyle` attaches one shared style object
+to a view, while CW deep-copies (§1), so developers arriving from Desktop
+expect live sharing that does not exist here.
+
+The `style:switched` event (`{ networkId, styleId, previousStyleId }`) comes
+from the `styleSets` half of the VisualStyleStore subscription in
+`initEventBus`, so it covers the in-app switch too. It exists because
+replacing the active style fires one `style:changed` per differing property —
+up to ~60 events with nothing marking them as one operation.
+
 ## 3. IndexedDB persistence
 
 DB version 10 (`src/data/db/index.ts`).

--- a/docs/specifications/MULTIPLE_VISUAL_STYLES.md
+++ b/docs/specifications/MULTIPLE_VISUAL_STYLES.md
@@ -116,16 +116,29 @@ opens).
 
 ### App API surface
 
-External apps reach the feature through two methods on `visualStyleApi`
+External apps reach the feature through four methods on `visualStyleApi`
 (#702) — `src/app-api/core/visualStyleApi.ts`:
 
 - `getVisualStyle(networkId)` returns a detached deep copy of the ACTIVE
   style. Only a network whose style is registered in memory can answer; a
   workspace network never opened reports `APP1`.
+- `getStyles(networkId)` lists the set as `{ id, name, active }` — metadata
+  only, since the active entry's content is the working copy and the rest
+  hold theirs inline.
+- `switchStyle(networkId, styleId)` wraps the store action, records the
+  `SWITCH_STYLE` undo entry, and treats a switch to the already-active style
+  as a successful no-op (an app re-asserting a style must not dirty a clean
+  network). `APP15` for an id the network does not own.
 - `applyVisualStyle(networkId, visualStyle, options?)` runs the same two
   store actions as `StyleManager.handleCopyIn` — `importStyle` then
   `switchStyle` — and records the same `SWITCH_STYLE` undo entry, so an app's
   apply is indistinguishable from the user's.
+
+Not exposed: `createStyle`, `duplicateStyle`, `renameStyle`, `deleteStyle`.
+Each needs care the four above do not — `deleteStyle` clears the network's
+whole undo history and is confirmation-gated in the UI, and the other three
+return `void`, so the API would have to pre-check what the store only warns
+about.
 
 Two things the in-app path gets for free and the API has to do itself:
 

--- a/docs/specifications/MULTIPLE_VISUAL_STYLES.md
+++ b/docs/specifications/MULTIPLE_VISUAL_STYLES.md
@@ -143,9 +143,16 @@ about.
 Two things the in-app path gets for free and the API has to do itself:
 
 - **Validate the style.** An app passes an arbitrary object, so
-  `isValidVisualStyle` (`impl/visualStyleSetImpl.ts`) checks it before
-  anything is stored. Without it a malformed style becomes the active one and
-  fails later inside `CyjsRenderer` with nothing naming the caller.
+  `visualStyleProblem` (`impl/visualStyleSetImpl.ts`) checks it before anything
+  is stored, and its reason string becomes the `APP9` message. Without it a
+  malformed style becomes the active one and fails later inside `CyjsRenderer`
+  with nothing naming the caller. `VisualStyle` is a TOTAL record over
+  `VisualPropertyName`, so a PARTIAL style is rejected too rather than merged
+  over the defaults — applying one would silently drop every property it omits,
+  and "make B look like A" is not served by substituting CW defaults for what A
+  did not mention. Every style the host produces is complete: `createVisualStyle`,
+  the presets, and `createVisualStyleFromCx` (which starts from the default
+  style) all carry the full set.
 - **Establish WHY an import failed.** `importStyle` reports both an unknown
   network and a full set as `undefined`, so the API reads the set size against
   `MAX_STYLES_PER_NETWORK` itself and returns `APP14` rather than guessing.

--- a/packages/api-types/CHANGELOG.md
+++ b/packages/api-types/CHANGELOG.md
@@ -23,6 +23,24 @@ All notable changes to `@cytoscape-web/api-types` are documented here.
 
 ### Added
 
+- **`VisualStyleApi.applyVisualStyle(networkId, visualStyle, options?)` and
+  `getVisualStyle(networkId)`** (#702) — give a network a whole visual style
+  instead of replaying every default, mapping and bypass by hand. Pair the two
+  to copy a style from one network to another. New type
+  `ApplyVisualStyleOptions` (`{ name?: string }`), new error code `APP14`
+  `STYLE_SET_FULL`, and `MAX_STYLES_PER_NETWORK` (50) is now exported.
+  **Copy, not a shared reference:** unlike Desktop's
+  `VisualMappingManager.setVisualStyle`, which attaches one style object to a
+  view, this deep-copies the style into the network's named-style set and makes
+  it active, so later edits to either side are independent. Bypasses are
+  dropped (they name the source network's elements). `getVisualStyle` likewise
+  returns a detached deep copy.
+- **`style:switched` event** — `{ networkId, styleId, previousStyleId }`, fired
+  when a network's active named style changes (the Vizmapper's style picker,
+  `applyVisualStyle`, an undone switch, or deleting the active style). A switch
+  replaces the whole style, so it also fires one `style:changed` per differing
+  property, up to ~60; `style:switched` arrives first and tells one switch
+  apart from N property edits.
 - **Dialog API** — `AppContextApis.dialog` (`DialogApi`, `OpenDialogOptions`,
   `DialogRenderProps`). `apis.dialog.open({ title, render, id?, maxWidth?,
   fullWidth? })` shows a modal whose frame (title bar, Close "X", dismissal

--- a/packages/api-types/CHANGELOG.md
+++ b/packages/api-types/CHANGELOG.md
@@ -35,6 +35,14 @@ All notable changes to `@cytoscape-web/api-types` are documented here.
   it active, so later edits to either side are independent. Bypasses are
   dropped (they name the source network's elements). `getVisualStyle` likewise
   returns a detached deep copy.
+- **`VisualStyleApi.getStyles(networkId)` and `switchStyle(networkId, styleId)`**
+  (#702) — a network owns a set of named styles; these list it and move between
+  them. New type `NamedStyleInfo` (`{ id, name, active }`) and new error code
+  `APP15` `STYLE_NOT_FOUND`. Style ids are unique within one network's set and
+  mean nothing outside it, so an id from another network reports `APP15` —
+  copy across networks with `getVisualStyle` + `applyVisualStyle`. Switching to
+  the already-active style succeeds and does nothing, so re-asserting a style
+  does not dirty a clean network.
 - **`style:switched` event** — `{ networkId, styleId, previousStyleId }`, fired
   when a network's active named style changes (the Vizmapper's style picker,
   `applyVisualStyle`, an undone switch, or deleting the active style). A switch

--- a/packages/api-types/CHANGELOG.md
+++ b/packages/api-types/CHANGELOG.md
@@ -34,7 +34,10 @@ All notable changes to `@cytoscape-web/api-types` are documented here.
   view, this deep-copies the style into the network's named-style set and makes
   it active, so later edits to either side are independent. Bypasses are
   dropped (they name the source network's elements). `getVisualStyle` likewise
-  returns a detached deep copy.
+  returns a detached deep copy. `applyVisualStyle` requires a **complete**
+  style — every `VisualPropertyName` present — and reports `APP9` with what is
+  wrong otherwise; a partial style is rejected rather than merged over the
+  defaults, since applying one would silently drop the properties it omits.
 - **`VisualStyleApi.getStyles(networkId)` and `switchStyle(networkId, styleId)`**
   (#702) — a network owns a set of named styles; these list it and move between
   them. New type `NamedStyleInfo` (`{ id, name, active }`) and new error code

--- a/packages/api-types/src/events.ts
+++ b/packages/api-types/src/events.ts
@@ -64,6 +64,18 @@ export interface CyWebEvents {
   'style:changed': { networkId: IdType; property: string }
 
   /**
+   * Fired when a network's ACTIVE named style changes — the Vizmapper's
+   * style picker, `visualStyleApi.applyVisualStyle`, an undone switch, or
+   * deleting the active style. One event per switch, ahead of the
+   * `style:changed` burst the replacement causes.
+   */
+  'style:switched': {
+    networkId: IdType
+    styleId: IdType
+    previousStyleId: IdType
+  }
+
+  /**
    * Fired when table data is written to a network's node or edge table.
    * `rowIds` is the set of node/edge IDs whose data changed in this write.
    * `addedColumns`/`removedColumns` carry schema changes (a rename appears

--- a/src/app-api/AGENTS.md
+++ b/src/app-api/AGENTS.md
@@ -39,7 +39,7 @@ src/app-api/
 │   ├── scopedApi.ts            ← forNetwork(id?): network-scoped domains with networkId pre-bound
 │   └── index.ts                 ← Assembles CyWebApi object (incl. forNetwork); assigned to window.CyWebApi
 ├── event-bus/                   ← Typed event bus (Step 2, after Phase 1e)
-│   ├── CyWebEvents.ts           ← CyWebEvents interface (9 event types + detail shapes)
+│   ├── CyWebEvents.ts           ← CyWebEvents interface (10 event types + detail shapes)
 │   ├── dispatchCyWebEvent.ts    ← Generic dispatch helper — sole place new CustomEvent() is called
 │   └── initEventBus.ts          ← Zustand subscribeWithSelector → window.dispatchEvent
 ├── useElementApi.ts             ← React Hook: returns elementApi (thin wrapper)
@@ -79,7 +79,7 @@ src/app-api/
 6. **Hide `skipUndo`** — Hardcode to `false`; external apps must not corrupt the undo stack.
 7. **No React imports in `core/`** — ESLint should flag any `import ... from 'react'` inside
    `src/app-api/core/`.
-8. **`dispatchCyWebEvent` is the only dispatch site** — All 6 store-subscription-driven events go
+8. **`dispatchCyWebEvent` is the only dispatch site** — Every store-subscription-driven event goes
    through `event-bus/dispatchCyWebEvent.ts`. Never call `window.dispatchEvent(new CustomEvent(...))`
    directly anywhere else.
 9. **`initEventBus()` is called once after hydration** — `window.CyWebApi = CyWebApi` is assigned

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -892,7 +892,7 @@ All methods in this API return `APP1` if the table record for `networkId` is not
 
 ## VisualStyleApi (`cyweb/VisualStyleApi`)
 
-Reads and modifies visual style properties.
+Reads and modifies visual style properties, one at a time or as a whole style.
 
 ```typescript
 import { useVisualStyleApi } from 'cyweb/VisualStyleApi'
@@ -901,6 +901,19 @@ import { VisualPropertyName } from 'cyweb/ApiTypes'
 
 All write methods trigger `style:changed` via the Event Bus (the VisualStyleStore
 subscription in `initEventBus` fires on any property change).
+`applyVisualStyle` also fires `style:switched`.
+
+### A network owns several named styles
+
+A network's visual style is one entry in a set of named styles it owns; the
+active entry is the one rendered and edited, and it is what every method here
+reads and writes. `applyVisualStyle` adds a style to that set and makes it
+active. The set holds at most `MAX_STYLES_PER_NETWORK` (50) entries.
+
+Only a network whose style is loaded in memory can be read or written — a
+workspace network that has never been opened reports `APP1`.
+
+See `docs/specifications/MULTIPLE_VISUAL_STYLES.md` for the model.
 
 ### Types
 
@@ -911,6 +924,11 @@ interface VisualPropertyInfo {
   group: 'node' | 'edge' | 'network'
   type: VisualPropertyValueTypeName // e.g. 'color', 'number', 'string'
   hasMapping: boolean // true when the property has a mapping
+}
+
+/** Options bundle for applyVisualStyle. */
+interface ApplyVisualStyleOptions {
+  name?: string // name of the new named-style entry; default "Imported style"
 }
 
 /** Options bundle for createContinuousMapping. */
@@ -951,6 +969,29 @@ object when the property has no bypasses.
 
 Reads the mapping installed on a property. `mapping` is `undefined` when the
 property has no mapping.
+
+#### `getVisualStyle(networkId): ApiResult<{ visualStyle: VisualStyle }>`
+
+Reads the network's active visual style as one object — every default, mapping
+and bypass, in the shape `applyVisualStyle` accepts. Pair the two to copy a
+style from one network to another.
+
+The returned style is a **detached deep copy**: mutating it changes nothing in
+the network, and later edits to the network do not reach it. Bypass entries
+survive this read; they are stripped by `applyVisualStyle`, not here.
+
+Note that a `VisualStyle` carries `bypassMap` as a `Map`, so the object does
+not survive `JSON.stringify`. Pass it straight to `applyVisualStyle`, or read
+bypasses through `getBypasses`, which returns a plain `Record`.
+
+```typescript
+const read = visualStyleApi.getVisualStyle(sourceNetworkId)
+if (read.success) {
+  visualStyleApi.applyVisualStyle(targetNetworkId, read.data.visualStyle, {
+    name: 'Copied from source',
+  })
+}
+```
 
 **Common errors for read methods:**
 
@@ -1071,6 +1112,74 @@ Creates a passthrough mapping (attribute value used directly as the visual value
 #### `deleteMapping(networkId, vpName): ApiResult`
 
 Removes any mapping for the specified visual property.
+
+#### `applyVisualStyle(networkId, visualStyle, options?): ApiResult<{ styleId }>`
+
+Gives the network a whole visual style, rather than one property at a time.
+The Cytoscape Web equivalent of Desktop's
+`VisualMappingManager.setVisualStyle(style, view)`, and of the Vizmapper's
+"Apply Style".
+
+**A copy, not a shared reference.** This is where Cytoscape Web differs from
+Desktop, and the difference matters. In Desktop a `VisualStyle` is an object
+the `VisualMappingManager` owns; `setVisualStyle` attaches that one object to a
+view, so several views can follow the same style and a later edit to it changes
+all of them. In Cytoscape Web a style has no existence outside a network, so
+applying one always takes a snapshot: the network gets its own deep copy of
+`visualStyle` as it is at the moment of the call, and from then on edits to the
+passed object and edits to the network's copy do not affect each other. There
+is no way to make two networks follow one live style.
+
+What the call does, in order:
+
+1. Validates the network and the shape of `visualStyle`.
+2. Deep-copies the style into the network's named-style set, under
+   `options.name` (default `"Imported style"`, de-duplicated against its
+   siblings — a second copy of "Blue" is stored as "Blue 2").
+   **Bypasses are dropped**: bypass entries are keyed by the source network's
+   node and edge ids, which name nothing in the target.
+3. Makes the copy the active style, so the network re-renders with it.
+4. Records the switch as one undo entry and marks the network modified.
+
+Undo reverts which style is active and leaves the copy in the set, inert until
+selected and deletable — the same behavior as the in-app apply path. The
+style's content is deliberately not carried on the undo stack, which is
+persisted to IndexedDB.
+
+Fires `style:switched`, then one `style:changed` per property that differs from
+the previously active style.
+
+```typescript
+const read = visualStyleApi.getVisualStyle(sourceNetworkId)
+if (read.success) {
+  const applied = visualStyleApi.applyVisualStyle(
+    subnetworkId,
+    read.data.visualStyle,
+  )
+  if (applied.success) {
+    console.log(applied.data.styleId) // the new named-style entry
+  }
+}
+```
+
+| Error Code | Condition                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| `APP1`     | `networkId` has no visual style in memory                                                |
+| `APP9`     | `visualStyle` is not a visual style object (see below)                                   |
+| `APP14`    | the network already owns `MAX_STYLES_PER_NETWORK` (50) styles                            |
+
+Nothing is applied when the call fails; every check runs before the store is
+touched.
+
+`APP9` covers the structural check on `visualStyle`: it must be an object with
+at least one entry keyed by a `VisualPropertyName`, and every such entry must
+carry a valid `group` (`'node'`/`'edge'`/`'network'`), a `type`, a
+`defaultValue`, and — when present — a `mapping` with a known `type`
+(`'passthrough'`/`'discrete'`/`'continuous'`) and an `attribute`. Unknown keys
+are ignored, and `bypassMap` is not checked since bypasses are stripped anyway.
+Property **values** are not validated here — a style read from
+`getVisualStyle` is already valid, and per-property validation belongs to
+`setDefault`, which can say which property failed.
 
 All methods in this API return `APP1` if the visual style for `networkId` is not found.
 
@@ -2310,6 +2419,27 @@ detail: {
 
 Source: VisualStyleStore subscription (full-state diff, no `subscribeWithSelector`).
 
+#### `style:switched`
+
+Fired when a network's **active named style** changes — the Vizmapper's style
+picker, `visualStyleApi.applyVisualStyle`, an undone or redone switch, or
+deleting the active style.
+
+```typescript
+detail: {
+  networkId: IdType
+  styleId: IdType
+  previousStyleId: IdType
+}
+```
+
+A switch replaces the whole active style, so it also produces one
+`style:changed` per property that differs between the two styles — up to ~60
+events. `style:switched` is dispatched first, from the same store update, so a
+listener can tell one switch from N separate property edits.
+
+Source: VisualStyleStore subscription (same callback as `style:changed`).
+
 #### `data:changed`
 
 Fired when table data or schema changes in a network's node or edge table.
@@ -2344,6 +2474,7 @@ Also triggered by TableApi write methods.
 | `selectionApi.exclusiveSelect` / `additiveSelect` / `additiveDeselect` / `toggleSelected` / `clearSelection`               | `selection:changed`                                                                      |
 | `layoutApi.applyLayout`                                                                                                    | `layout:started`, `layout:completed`                                                     |
 | `visualStyleApi.setDefault` / `setBypass` / `deleteBypass` / `create*Mapping` / `deleteMapping`                            | `style:changed` (×per property)                                                          |
+| `visualStyleApi.applyVisualStyle`                                                                                          | `style:switched`, then `style:changed` (×per property differing between the two styles) |
 | `tableApi.setValue` / `setValues` / `editRows` / `createColumn` / `deleteColumn` / `renameColumn` / `applyValueToElements` | `data:changed`                                                                           |
 | `contextMenuApi.addContextMenuItem` / `removeContextMenuItem`                                                              | _(no events — synchronous store mutation only)_                                          |
 

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -1199,6 +1199,26 @@ if (read.success) {
 Nothing is applied when the call fails; every check runs before the store is
 touched.
 
+`APP9` covers the structural check on `visualStyle`. It must be a **complete**
+style: every `VisualPropertyName` present, each one an object carrying a valid
+`group` (`'node'`/`'edge'`/`'network'`), a `type`, a `defaultValue`, and — when
+present — a `mapping` with a known `type`
+(`'passthrough'`/`'discrete'`/`'continuous'`) and an `attribute`. The message
+names what is wrong (`"visualStyle missing 65 of 66 visual properties (…)"`,
+`"visualStyle edgeWidth has no defaultValue"`).
+
+A partial style is rejected rather than merged over the defaults. This method
+is "make B look like A", and quietly substituting Cytoscape Web defaults for
+the properties A did not mention would not do that. Every style the host
+produces is complete, so `getVisualStyle` output always passes; build a style
+from scratch with `setDefault` and `create*Mapping` instead of hand-assembling
+one to pass here.
+
+Keys that are not visual property names are ignored, and `bypassMap` is not
+checked since bypasses are stripped anyway. Property **values** are not
+validated here — per-property validation belongs to `setDefault`, which can say
+which property failed.
+
 #### `switchStyle(networkId, styleId): ApiResult`
 
 Makes one of the network's own named styles the active one. Ids come from
@@ -1218,16 +1238,6 @@ between the two styles.
 | ---------- | ---------------------------------------------------- |
 | `APP1`     | `networkId` has no style set in memory               |
 | `APP15`    | the network owns no style with that `styleId`        |
-
-`APP9` covers the structural check on `visualStyle`: it must be an object with
-at least one entry keyed by a `VisualPropertyName`, and every such entry must
-carry a valid `group` (`'node'`/`'edge'`/`'network'`), a `type`, a
-`defaultValue`, and — when present — a `mapping` with a known `type`
-(`'passthrough'`/`'discrete'`/`'continuous'`) and an `attribute`. Unknown keys
-are ignored, and `bypassMap` is not checked since bypasses are stripped anyway.
-Property **values** are not validated here — a style read from
-`getVisualStyle` is already valid, and per-property validation belongs to
-`setDefault`, which can say which property failed.
 
 All methods in this API return `APP1` if the visual style for `networkId` is not found.
 

--- a/src/app-api/api_docs/Api.md
+++ b/src/app-api/api_docs/Api.md
@@ -906,9 +906,14 @@ subscription in `initEventBus` fires on any property change).
 ### A network owns several named styles
 
 A network's visual style is one entry in a set of named styles it owns; the
-active entry is the one rendered and edited, and it is what every method here
-reads and writes. `applyVisualStyle` adds a style to that set and makes it
-active. The set holds at most `MAX_STYLES_PER_NETWORK` (50) entries.
+active entry is the one rendered and edited, and it is what every per-property
+method here reads and writes. `getStyles` lists the set, `switchStyle` moves
+between styles the network already has, and `applyVisualStyle` adds one it does
+not. The set holds at most `MAX_STYLES_PER_NETWORK` (50) entries.
+
+Style ids are unique within one network's set and mean nothing outside it.
+There is no workspace-wide registry of styles, and no way to make two networks
+follow one live style — see the copy semantics under `applyVisualStyle`.
 
 Only a network whose style is loaded in memory can be read or written — a
 workspace network that has never been opened reports `APP1`.
@@ -929,6 +934,13 @@ interface VisualPropertyInfo {
 /** Options bundle for applyVisualStyle. */
 interface ApplyVisualStyleOptions {
   name?: string // name of the new named-style entry; default "Imported style"
+}
+
+/** One named style a network owns, from getStyles(). */
+interface NamedStyleInfo {
+  id: IdType // unique within this network's style set only
+  name: string // unique within the set, but not across networks
+  active: boolean // true for the one style rendered and edited
 }
 
 /** Options bundle for createContinuousMapping. */
@@ -990,6 +1002,22 @@ if (read.success) {
   visualStyleApi.applyVisualStyle(targetNetworkId, read.data.visualStyle, {
     name: 'Copied from source',
   })
+}
+```
+
+#### `getStyles(networkId): ApiResult<{ styles: NamedStyleInfo[] }>`
+
+Lists the named styles the network owns, in the order the style set holds
+them. Exactly one entry is `active`. Metadata only — read the active style's
+content with `getVisualStyle`.
+
+```typescript
+const listed = visualStyleApi.getStyles(networkId)
+if (listed.success) {
+  const publication = listed.data.styles.find((s) => s.name === 'Publication')
+  if (publication !== undefined) {
+    visualStyleApi.switchStyle(networkId, publication.id)
+  }
 }
 ```
 
@@ -1170,6 +1198,26 @@ if (read.success) {
 
 Nothing is applied when the call fails; every check runs before the store is
 touched.
+
+#### `switchStyle(networkId, styleId): ApiResult`
+
+Makes one of the network's own named styles the active one. Ids come from
+`getStyles` or from `applyVisualStyle`, and mean nothing outside this network's
+style set — an id read from another network reports `APP15`, not a
+cross-network apply. Use `getVisualStyle` + `applyVisualStyle` for that.
+
+Recorded as one undo entry, like the Vizmapper's style picker. Switching to the
+style that is **already active** succeeds and does nothing: no undo entry, and
+the network is not marked modified, so an app that re-asserts a style on every
+event cannot dirty a clean network.
+
+Fires `style:switched`, then one `style:changed` per property that differs
+between the two styles.
+
+| Error Code | Condition                                            |
+| ---------- | ---------------------------------------------------- |
+| `APP1`     | `networkId` has no style set in memory               |
+| `APP15`    | the network owns no style with that `styleId`        |
 
 `APP9` covers the structural check on `visualStyle`: it must be an object with
 at least one entry keyed by a `VisualPropertyName`, and every such entry must
@@ -2474,7 +2522,7 @@ Also triggered by TableApi write methods.
 | `selectionApi.exclusiveSelect` / `additiveSelect` / `additiveDeselect` / `toggleSelected` / `clearSelection`               | `selection:changed`                                                                      |
 | `layoutApi.applyLayout`                                                                                                    | `layout:started`, `layout:completed`                                                     |
 | `visualStyleApi.setDefault` / `setBypass` / `deleteBypass` / `create*Mapping` / `deleteMapping`                            | `style:changed` (×per property)                                                          |
-| `visualStyleApi.applyVisualStyle`                                                                                          | `style:switched`, then `style:changed` (×per property differing between the two styles) |
+| `visualStyleApi.applyVisualStyle` / `switchStyle`                                                                          | `style:switched`, then `style:changed` (×per property differing between the two styles) |
 | `tableApi.setValue` / `setValues` / `editRows` / `createColumn` / `deleteColumn` / `renameColumn` / `applyValueToElements` | `data:changed`                                                                           |
 | `contextMenuApi.addContextMenuItem` / `removeContextMenuItem`                                                              | _(no events — synchronous store mutation only)_                                          |
 

--- a/src/app-api/api_docs/ErrorCodes.md
+++ b/src/app-api/api_docs/ErrorCodes.md
@@ -473,3 +473,18 @@ read in full at boot to keep `appData.get()` synchronous, and because the
 failure it replaces — IndexedDB quota exhaustion on a fire-and-forget write —
 is invisible to the calling app. The message reports the actual size and the
 limit.
+
+### APP14 — `STYLE_SET_FULL`
+
+**Severity:** error
+**Returned by:** `visualStyle.applyVisualStyle`
+
+The target network already owns `MAX_STYLES_PER_NETWORK` (50) named visual
+styles, so no copy can be added. The cap exists so that any style set built
+locally can round-trip through NDEx: the `cyWebVisualStyles` CX2 aspect
+importer rejects an oversized set. Delete a style the network no longer needs,
+or read the count first — `MAX_STYLES_PER_NETWORK` is exported from
+`cyweb/ApiTypes`.
+
+An `APP*` code rather than a `StyleCodes` one: the cap is a Cytoscape Web
+runtime limit with no corresponding CX2 validation rule.

--- a/src/app-api/api_docs/ErrorCodes.md
+++ b/src/app-api/api_docs/ErrorCodes.md
@@ -488,3 +488,14 @@ or read the count first — `MAX_STYLES_PER_NETWORK` is exported from
 
 An `APP*` code rather than a `StyleCodes` one: the cap is a Cytoscape Web
 runtime limit with no corresponding CX2 validation rule.
+
+### APP15 — `STYLE_NOT_FOUND`
+
+**Severity:** error
+**Returned by:** `visualStyle.switchStyle`
+
+The network owns no named style with that id. Style ids are unique within one
+network's style set and mean nothing outside it, so an id read from one
+network cannot be used against another — copy the style with
+`getVisualStyle` + `applyVisualStyle` instead. Read the network's own ids with
+`getStyles`.

--- a/src/app-api/core/visualStyleApi.styleSet.test.ts
+++ b/src/app-api/core/visualStyleApi.styleSet.test.ts
@@ -1,0 +1,409 @@
+// src/app-api/core/visualStyleApi.styleSet.test.ts
+//
+// applyVisualStyle / getVisualStyle against the REAL VisualStyleStore.
+//
+// Separate from visualStyleApi.test.ts, which replaces the whole store with
+// hand-written fakes: the properties these methods have to guarantee — the
+// style is deep-copied, bypasses are stripped, the copy becomes active — are
+// properties of `importStyle` and `switchStyle` themselves, so a faked store
+// would only test the fake. Only WorkspaceStore (the modified flag) and
+// UndoStore (the undo entry) are mocked here, because those are what the
+// assertions read.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { IdType } from '../../models/IdType'
+import { UndoCommandType } from '../../models/StoreModel/UndoStoreModel'
+import {
+  MAX_STYLES_PER_NETWORK,
+  VisualPropertyName,
+  VisualStyle,
+  VisualStyleSet,
+} from '../../models/VisualStyleModel'
+import { createVisualStyle } from '../../models/VisualStyleModel/impl/visualStyleFnImpl'
+import { AppCodes } from '../types/ApiResult'
+
+vi.mock('../../data/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../data/db')>()
+  return {
+    ...actual,
+    putVisualStyleSetToDb: vi.fn().mockResolvedValue(undefined),
+    putUndoRedoStackToDb: vi.fn().mockResolvedValue(undefined),
+    deleteVisualStyleFromDb: vi.fn().mockResolvedValue(undefined),
+    clearVisualStyleFromDb: vi.fn().mockResolvedValue(undefined),
+  }
+})
+
+const mockSetNetworkModified = vi.fn()
+const mockNetworkModified: Record<string, boolean> = {}
+
+vi.mock('../../data/hooks/stores/WorkspaceStore', () => ({
+  useWorkspaceStore: {
+    getState: vi.fn(() => ({
+      workspace: {
+        currentNetworkId: 'net1',
+        networkModified: mockNetworkModified,
+      },
+      setNetworkModified: mockSetNetworkModified,
+    })),
+  },
+}))
+
+const mockSetUndoStack = vi.fn()
+const mockSetRedoStack = vi.fn()
+const mockAddStack = vi.fn()
+
+vi.mock('../../data/hooks/stores/UndoStore', () => ({
+  useUndoStore: {
+    getState: vi.fn(() => ({
+      undoRedoStacks: {},
+      setUndoStack: mockSetUndoStack,
+      setRedoStack: mockSetRedoStack,
+      addStack: mockAddStack,
+    })),
+  },
+}))
+
+// Imported after the mocks so the store picks them up
+const { useVisualStyleStore } = await import(
+  '../../data/hooks/stores/VisualStyleStore'
+)
+const { visualStyleApi } = await import('./visualStyleApi')
+
+const VPN = VisualPropertyName
+
+/** Register a network with a single default style, as network loading does. */
+const registerNetwork = (networkId: IdType): void => {
+  useVisualStyleStore.getState().add(networkId, createVisualStyle())
+}
+
+const activeStyleOf = (networkId: IdType): VisualStyle =>
+  useVisualStyleStore.getState().visualStyles[networkId]
+
+const styleSetOf = (networkId: IdType) =>
+  useVisualStyleStore.getState().styleSets[networkId]
+
+/**
+ * A style distinguishable from the default one, with a bypass and a mapping,
+ * so a copy can be told apart from what it replaced.
+ */
+const sourceStyle = (): VisualStyle => {
+  const style = createVisualStyle()
+  return {
+    ...style,
+    [VPN.NodeBackgroundColor]: {
+      ...style[VPN.NodeBackgroundColor],
+      defaultValue: '#123456',
+      bypassMap: new Map([['n1', '#ff0000']]),
+    },
+    [VPN.NodeLabel]: {
+      ...style[VPN.NodeLabel],
+      mapping: {
+        type: 'passthrough',
+        attribute: 'name',
+        visualPropertyType: 'string',
+        defaultValue: '',
+      },
+    },
+  } as VisualStyle
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.keys(mockNetworkModified).forEach((k) => delete mockNetworkModified[k])
+  useVisualStyleStore.getState().deleteAll()
+})
+
+describe('getVisualStyle', () => {
+  it('fails with APP1 for a network with no style in memory', () => {
+    const result = visualStyleApi.getVisualStyle('nope')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.NETWORK_NOT_FOUND.code)
+    }
+  })
+
+  it('returns the active style, bypasses included', () => {
+    registerNetwork('net1')
+    useVisualStyleStore
+      .getState()
+      .setBypass('net1', VPN.NodeBackgroundColor, ['n1'], '#ff0000')
+
+    const result = visualStyleApi.getVisualStyle('net1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(
+        result.data.visualStyle[VPN.NodeBackgroundColor].bypassMap.get('n1'),
+      ).toBe('#ff0000')
+    }
+  })
+
+  it('returns a detached copy — mutating it does not reach the network', () => {
+    registerNetwork('net1')
+    const before = activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue
+
+    const result = visualStyleApi.getVisualStyle('net1')
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    // The stored style is deeply frozen by Immer; the copy must not be
+    result.data.visualStyle[VPN.NodeBackgroundColor].defaultValue = '#abcdef'
+    result.data.visualStyle[VPN.NodeBackgroundColor].bypassMap.set(
+      'n9',
+      '#abcdef',
+    )
+
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      before,
+    )
+    expect(
+      activeStyleOf('net1')[VPN.NodeBackgroundColor].bypassMap.has('n9'),
+    ).toBe(false)
+  })
+})
+
+describe('applyVisualStyle', () => {
+  it('fails with APP1 for a network with no style in memory', () => {
+    const result = visualStyleApi.applyVisualStyle('nope', sourceStyle())
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.NETWORK_NOT_FOUND.code)
+    }
+  })
+
+  it.each([
+    ['null', null],
+    ['an array', []],
+    ['an object with no visual property', { notAProperty: 1 }],
+    [
+      'a property with no group',
+      { [VPN.NodeLabel]: { type: 'string', defaultValue: '' } },
+    ],
+    [
+      'a property with an unknown group',
+      {
+        [VPN.NodeLabel]: {
+          group: 'hyperedge',
+          type: 'string',
+          defaultValue: '',
+        },
+      },
+    ],
+    [
+      'a property with no defaultValue',
+      { [VPN.NodeLabel]: { group: 'node', type: 'string' } },
+    ],
+    [
+      'a mapping with an unknown type',
+      {
+        [VPN.NodeLabel]: {
+          group: 'node',
+          type: 'string',
+          defaultValue: '',
+          mapping: { type: 'quadratic', attribute: 'name' },
+        },
+      },
+    ],
+  ])('fails with APP9 for %s', (_label, malformed) => {
+    registerNetwork('net1')
+    const styleCountBefore = Object.keys(styleSetOf('net1').styles).length
+
+    const result = visualStyleApi.applyVisualStyle(
+      'net1',
+      malformed as unknown as VisualStyle,
+    )
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.INVALID_INPUT.code)
+    }
+    // Rejected before the store was touched
+    expect(Object.keys(styleSetOf('net1').styles)).toHaveLength(
+      styleCountBefore,
+    )
+  })
+
+  it('adds the style to the set and makes it active', () => {
+    registerNetwork('net1')
+    const previousStyleId = styleSetOf('net1').activeStyleId
+
+    const result = visualStyleApi.applyVisualStyle('net1', sourceStyle())
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    const { styleId } = result.data
+
+    expect(Object.keys(styleSetOf('net1').styles)).toHaveLength(2)
+    expect(styleSetOf('net1').activeStyleId).toBe(styleId)
+    expect(styleId).not.toBe(previousStyleId)
+    // The working copy is now the applied style's content
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      '#123456',
+    )
+    expect(activeStyleOf('net1')[VPN.NodeLabel].mapping?.attribute).toBe('name')
+  })
+
+  it('leaves the previously active style in the set, unchanged', () => {
+    registerNetwork('net1')
+    const previousStyleId = styleSetOf('net1').activeStyleId
+    const previousColor =
+      activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue
+
+    visualStyleApi.applyVisualStyle('net1', sourceStyle())
+
+    const parked = styleSetOf('net1').styles[previousStyleId]
+    expect(parked).toBeDefined()
+    expect(parked.visualStyle?.[VPN.NodeBackgroundColor].defaultValue).toBe(
+      previousColor,
+    )
+  })
+
+  it('copies on assign — later edits to the passed object do not reach the network', () => {
+    registerNetwork('net1')
+    const passed = sourceStyle()
+
+    visualStyleApi.applyVisualStyle('net1', passed)
+    passed[VPN.NodeBackgroundColor].defaultValue = '#999999'
+
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      '#123456',
+    )
+  })
+
+  it('copies on assign — later edits to the network do not reach the passed object', () => {
+    registerNetwork('net1')
+    const passed = sourceStyle()
+
+    visualStyleApi.applyVisualStyle('net1', passed)
+    visualStyleApi.setDefault('net1', VPN.NodeBackgroundColor, '#999999')
+
+    expect(passed[VPN.NodeBackgroundColor].defaultValue).toBe('#123456')
+  })
+
+  it('strips bypasses — they name the source network s elements', () => {
+    registerNetwork('net1')
+
+    visualStyleApi.applyVisualStyle('net1', sourceStyle())
+
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].bypassMap.size).toBe(
+      0,
+    )
+  })
+
+  it('names the entry "Imported style" by default and de-duplicates a second copy', () => {
+    registerNetwork('net1')
+
+    const first = visualStyleApi.applyVisualStyle('net1', sourceStyle())
+    const second = visualStyleApi.applyVisualStyle('net1', sourceStyle())
+
+    expect(first.success && second.success).toBe(true)
+    if (!first.success || !second.success) return
+    expect(styleSetOf('net1').styles[first.data.styleId].name).toBe(
+      'Imported style',
+    )
+    expect(styleSetOf('net1').styles[second.data.styleId].name).toBe(
+      'Imported style 2',
+    )
+  })
+
+  it('honors the name option', () => {
+    registerNetwork('net1')
+
+    const result = visualStyleApi.applyVisualStyle('net1', sourceStyle(), {
+      name: 'MCODE cluster',
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(styleSetOf('net1').styles[result.data.styleId].name).toBe(
+      'MCODE cluster',
+    )
+  })
+
+  it('records one SWITCH_STYLE undo entry on the target network s stack', () => {
+    registerNetwork('net1')
+    const previousStyleId = styleSetOf('net1').activeStyleId
+
+    const result = visualStyleApi.applyVisualStyle('net1', sourceStyle())
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(mockSetUndoStack).toHaveBeenCalledTimes(1)
+    const [networkId, stack] = mockSetUndoStack.mock.calls[0]
+    expect(networkId).toBe('net1')
+    expect(stack).toHaveLength(1)
+    expect(stack[0].undoCommand).toBe(UndoCommandType.SWITCH_STYLE)
+    expect(stack[0].undoParams).toEqual(['net1', previousStyleId])
+    expect(stack[0].redoParams).toEqual(['net1', result.data.styleId])
+  })
+
+  it('describes the undo entry with the STORED name, not the requested one', () => {
+    registerNetwork('net1')
+    visualStyleApi.applyVisualStyle('net1', sourceStyle(), { name: 'Blue' })
+    mockSetUndoStack.mockClear()
+
+    visualStyleApi.applyVisualStyle('net1', sourceStyle(), { name: 'Blue' })
+
+    const [, stack] = mockSetUndoStack.mock.calls[0]
+    expect(stack[0].description).toBe('Switch style to "Blue 2"')
+  })
+
+  it('marks the target network modified', () => {
+    registerNetwork('net1')
+
+    visualStyleApi.applyVisualStyle('net1', sourceStyle())
+
+    expect(mockSetNetworkModified).toHaveBeenCalledWith('net1', true)
+  })
+
+  it('fails with APP14 once the network owns MAX_STYLES_PER_NETWORK styles', () => {
+    // Built directly rather than by calling createStyle 49 times: every
+    // entry can share one style object, so the fixture costs one clone.
+    const shared = createVisualStyle()
+    const styles: VisualStyleSet['styles'] = {}
+    for (let i = 0; i < MAX_STYLES_PER_NETWORK; i += 1) {
+      const id = `style-${i}`
+      styles[id] = { id, name: `Style ${i}`, visualStyle: shared }
+    }
+    useVisualStyleStore
+      .getState()
+      .add('net1', shared, { activeStyleId: 'style-0', styles })
+
+    const result = visualStyleApi.applyVisualStyle('net1', sourceStyle())
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.STYLE_SET_FULL.code)
+      expect(result.error.message).toContain(String(MAX_STYLES_PER_NETWORK))
+    }
+    expect(Object.keys(styleSetOf('net1').styles)).toHaveLength(
+      MAX_STYLES_PER_NETWORK,
+    )
+    expect(styleSetOf('net1').activeStyleId).toBe('style-0')
+  })
+
+  it('carries a style from one network to another', () => {
+    registerNetwork('net1')
+    registerNetwork('net2')
+    useVisualStyleStore
+      .getState()
+      .setDefault('net1', VPN.NodeBackgroundColor, '#abcdef')
+
+    const read = visualStyleApi.getVisualStyle('net1')
+    expect(read.success).toBe(true)
+    if (!read.success) return
+    const applied = visualStyleApi.applyVisualStyle(
+      'net2',
+      read.data.visualStyle,
+    )
+
+    expect(applied.success).toBe(true)
+    expect(activeStyleOf('net2')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      '#abcdef',
+    )
+    // net1 is untouched: its own set still holds exactly one style
+    expect(Object.keys(styleSetOf('net1').styles)).toHaveLength(1)
+  })
+})

--- a/src/app-api/core/visualStyleApi.styleSet.test.ts
+++ b/src/app-api/core/visualStyleApi.styleSet.test.ts
@@ -173,41 +173,50 @@ describe('applyVisualStyle', () => {
     }
   })
 
+  /** A complete style with one property replaced by `vp`. */
+  const styleWith = (vpName: string, vp: unknown): unknown => {
+    const style: any = sourceStyle()
+    style[vpName] = vp
+    return style
+  }
+
   it.each([
     ['null', null],
     ['an array', []],
     ['an object with no visual property', { notAProperty: 1 }],
     [
+      'a partial style, however well-formed',
+      { [VPN.NodeShape]: createVisualStyle()[VPN.NodeShape] },
+    ],
+    ['a property that is not an object', styleWith(VPN.NodeShape, 'diamond')],
+    [
       'a property with no group',
-      { [VPN.NodeLabel]: { type: 'string', defaultValue: '' } },
+      styleWith(VPN.NodeLabel, { type: 'string', defaultValue: '' }),
     ],
     [
       'a property with an unknown group',
-      {
-        [VPN.NodeLabel]: {
-          group: 'hyperedge',
-          type: 'string',
-          defaultValue: '',
-        },
-      },
+      styleWith(VPN.NodeLabel, {
+        group: 'hyperedge',
+        type: 'string',
+        defaultValue: '',
+      }),
     ],
     [
       'a property with no defaultValue',
-      { [VPN.NodeLabel]: { group: 'node', type: 'string' } },
+      styleWith(VPN.NodeLabel, { group: 'node', type: 'string' }),
     ],
     [
       'a mapping with an unknown type',
-      {
-        [VPN.NodeLabel]: {
-          group: 'node',
-          type: 'string',
-          defaultValue: '',
-          mapping: { type: 'quadratic', attribute: 'name' },
-        },
-      },
+      styleWith(VPN.NodeLabel, {
+        group: 'node',
+        type: 'string',
+        defaultValue: '',
+        mapping: { type: 'quadratic', attribute: 'name' },
+      }),
     ],
   ])('fails with APP9 for %s', (_label, malformed) => {
     registerNetwork('net1')
+    const activeStyleId = styleSetOf('net1').activeStyleId
     const styleCountBefore = Object.keys(styleSetOf('net1').styles).length
 
     const result = visualStyleApi.applyVisualStyle(
@@ -223,6 +232,31 @@ describe('applyVisualStyle', () => {
     expect(Object.keys(styleSetOf('net1').styles)).toHaveLength(
       styleCountBefore,
     )
+    expect(styleSetOf('net1').activeStyleId).toBe(activeStyleId)
+  })
+
+  it('names the problem in the APP9 message', () => {
+    registerNetwork('net1')
+
+    const partial = visualStyleApi.applyVisualStyle('net1', {
+      [VPN.NodeShape]: createVisualStyle()[VPN.NodeShape],
+    } as unknown as VisualStyle)
+    const broken = visualStyleApi.applyVisualStyle(
+      'net1',
+      styleWith(VPN.EdgeWidth, {
+        group: 'edge',
+        type: 'number',
+      }) as VisualStyle,
+    )
+
+    expect(partial.success).toBe(false)
+    if (!partial.success) {
+      expect(partial.error.message).toContain('missing 65 of 66')
+    }
+    expect(broken.success).toBe(false)
+    if (!broken.success) {
+      expect(broken.error.message).toContain('edgeWidth has no defaultValue')
+    }
   })
 
   it('adds the style to the set and makes it active', () => {

--- a/src/app-api/core/visualStyleApi.styleSet.test.ts
+++ b/src/app-api/core/visualStyleApi.styleSet.test.ts
@@ -407,3 +407,155 @@ describe('applyVisualStyle', () => {
     expect(Object.keys(styleSetOf('net1').styles)).toHaveLength(1)
   })
 })
+
+describe('getStyles', () => {
+  it('fails with APP1 for a network with no style set in memory', () => {
+    const result = visualStyleApi.getStyles('nope')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.NETWORK_NOT_FOUND.code)
+    }
+  })
+
+  it('lists one active style for a freshly registered network', () => {
+    registerNetwork('net1')
+
+    const result = visualStyleApi.getStyles('net1')
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.styles).toEqual([
+      { id: styleSetOf('net1').activeStyleId, name: 'Default', active: true },
+    ])
+  })
+
+  it('marks exactly one style active after an apply', () => {
+    registerNetwork('net1')
+    const applied = visualStyleApi.applyVisualStyle('net1', sourceStyle(), {
+      name: 'Blue',
+    })
+    expect(applied.success).toBe(true)
+    if (!applied.success) return
+
+    const result = visualStyleApi.getStyles('net1')
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.styles).toHaveLength(2)
+    expect(result.data.styles.filter((s) => s.active)).toEqual([
+      { id: applied.data.styleId, name: 'Blue', active: true },
+    ])
+  })
+})
+
+describe('switchStyle', () => {
+  /** A network with a second, non-active style named "Blue". */
+  const withTwoStyles = (): { originalId: IdType; blueId: IdType } => {
+    registerNetwork('net1')
+    const originalId = styleSetOf('net1').activeStyleId
+    const applied = visualStyleApi.applyVisualStyle('net1', sourceStyle(), {
+      name: 'Blue',
+    })
+    if (!applied.success) throw new Error('fixture failed')
+    // Back to the original, so "Blue" is present but not active
+    visualStyleApi.switchStyle('net1', originalId)
+    vi.clearAllMocks()
+    return { originalId, blueId: applied.data.styleId }
+  }
+
+  it('fails with APP1 for a network with no style set in memory', () => {
+    const result = visualStyleApi.switchStyle('nope', 'whatever')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.NETWORK_NOT_FOUND.code)
+    }
+  })
+
+  it('fails with APP15 for a style the network does not own', () => {
+    registerNetwork('net1')
+    const activeStyleId = styleSetOf('net1').activeStyleId
+
+    const result = visualStyleApi.switchStyle('net1', 'not-my-style')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.STYLE_NOT_FOUND.code)
+    }
+    expect(styleSetOf('net1').activeStyleId).toBe(activeStyleId)
+  })
+
+  it('fails with APP15 for an id belonging to another network', () => {
+    registerNetwork('net1')
+    registerNetwork('net2')
+
+    const result = visualStyleApi.switchStyle(
+      'net2',
+      styleSetOf('net1').activeStyleId,
+    )
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe(AppCodes.STYLE_NOT_FOUND.code)
+    }
+  })
+
+  it('makes the target style active and restores its content', () => {
+    const { blueId } = withTwoStyles()
+
+    const result = visualStyleApi.switchStyle('net1', blueId)
+
+    expect(result.success).toBe(true)
+    expect(styleSetOf('net1').activeStyleId).toBe(blueId)
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      '#123456',
+    )
+  })
+
+  it('records one SWITCH_STYLE undo entry and marks the network modified', () => {
+    const { originalId, blueId } = withTwoStyles()
+
+    visualStyleApi.switchStyle('net1', blueId)
+
+    expect(mockSetUndoStack).toHaveBeenCalledTimes(1)
+    const [networkId, stack] = mockSetUndoStack.mock.calls[0]
+    expect(networkId).toBe('net1')
+    expect(stack[0].undoCommand).toBe(UndoCommandType.SWITCH_STYLE)
+    expect(stack[0].description).toBe('Switch style to "Blue"')
+    expect(stack[0].undoParams).toEqual(['net1', originalId])
+    expect(stack[0].redoParams).toEqual(['net1', blueId])
+    expect(mockSetNetworkModified).toHaveBeenCalledWith('net1', true)
+  })
+
+  it('succeeds and does nothing when the style is already active', () => {
+    const { originalId } = withTwoStyles()
+
+    const result = visualStyleApi.switchStyle('net1', originalId)
+
+    expect(result.success).toBe(true)
+    // No undo entry and no modified mark: an app re-asserting a style must
+    // not dirty a clean network.
+    expect(mockSetUndoStack).not.toHaveBeenCalled()
+    expect(mockSetNetworkModified).not.toHaveBeenCalled()
+  })
+
+  it('switches back and forth without losing either style s edits', () => {
+    const { originalId, blueId } = withTwoStyles()
+    const originalColor =
+      activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue
+
+    visualStyleApi.switchStyle('net1', blueId)
+    visualStyleApi.setDefault('net1', VPN.NodeBackgroundColor, '#0000ff')
+    visualStyleApi.switchStyle('net1', originalId)
+
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      originalColor,
+    )
+
+    visualStyleApi.switchStyle('net1', blueId)
+    expect(activeStyleOf('net1')[VPN.NodeBackgroundColor].defaultValue).toBe(
+      '#0000ff',
+    )
+  })
+})

--- a/src/app-api/core/visualStyleApi.ts
+++ b/src/app-api/core/visualStyleApi.ts
@@ -25,7 +25,7 @@ import {
 } from '../../models/VisualStyleModel'
 import {
   cloneVisualStyle,
-  isValidVisualStyle,
+  visualStyleProblem,
 } from '../../models/VisualStyleModel/impl/visualStyleSetImpl'
 import {
   AppCodes,
@@ -856,13 +856,11 @@ export const visualStyleApi: VisualStyleApi = {
       }
       // The one place an arbitrary object from an app becomes what the
       // renderer reads. Without this check a malformed style fails later,
-      // inside CyjsRenderer, with nothing naming the caller.
-      if (!isValidVisualStyle(visualStyle)) {
-        return fail(
-          AppCodes.INVALID_INPUT,
-          'visualStyle is not a visual style: expected an object keyed by ' +
-            'VisualPropertyName whose entries carry group, type and defaultValue',
-        )
+      // inside CyjsRenderer, with nothing naming the caller — hence the
+      // reason string rather than a bare boolean.
+      const problem = visualStyleProblem(visualStyle)
+      if (problem !== undefined) {
+        return fail(AppCodes.INVALID_INPUT, `visualStyle ${problem}`)
       }
       const styleSet = store.styleSets[networkId]
       if (styleSet === undefined) {

--- a/src/app-api/core/visualStyleApi.ts
+++ b/src/app-api/core/visualStyleApi.ts
@@ -4,6 +4,7 @@
 
 import { useVisualStyleStore } from '../../data/hooks/stores/VisualStyleStore'
 import { IdType } from '../../models/IdType'
+import { UndoCommandType } from '../../models/StoreModel/UndoStoreModel'
 import {
   AttributeName,
   ValueType,
@@ -13,13 +14,19 @@ import {
   ContinuousFunctionControlPoint,
   ContinuousMappingFunction,
   MappingFunctionType,
+  MAX_STYLES_PER_NETWORK,
   VisualMappingFunction,
   VisualProperty,
   VisualPropertyGroup,
   VisualPropertyName,
   VisualPropertyValueType,
   VisualPropertyValueTypeName,
+  VisualStyle,
 } from '../../models/VisualStyleModel'
+import {
+  cloneVisualStyle,
+  isValidVisualStyle,
+} from '../../models/VisualStyleModel/impl/visualStyleSetImpl'
 import {
   AppCodes,
   ApiFailure,
@@ -28,7 +35,7 @@ import {
   fail,
   ok,
 } from '../types/ApiResult'
-import { markNetworkModified } from './undo'
+import { corePostEdit, markNetworkModified } from './undo'
 import {
   validateBypassTargetScope,
   validateContinuousMappingBounds,
@@ -59,6 +66,17 @@ export interface CreateContinuousMappingOptions {
   ltMinVpValue?: VisualPropertyValueType
   /** Value applied above the maximum anchor. */
   gtMaxVpValue?: VisualPropertyValueType
+}
+
+/** Options for applyVisualStyle. */
+export interface ApplyVisualStyleOptions {
+  /**
+   * Name of the new named-style entry in the target network's style set.
+   * De-duplicated against its siblings ("X" → "X 2").
+   *
+   * @default "Imported style"
+   */
+  name?: string
 }
 
 /** One visual property's identity and scope, from getVisualProperties(). */
@@ -114,6 +132,21 @@ export interface VisualStyleApi {
     networkId: IdType,
     vpName: VisualPropertyName,
   ): ApiResult<{ mapping: VisualMappingFunction | undefined }>
+
+  /**
+   * Read the network's active visual style as one object — every default,
+   * mapping and bypass in the shape `applyVisualStyle` accepts.
+   *
+   * The returned style is a detached deep copy: mutating it changes
+   * nothing in the network, and later edits to the network do not reach
+   * it. Bypass entries survive here (they are stripped by
+   * `applyVisualStyle`, not by this read).
+   *
+   * Only a network whose style is loaded in memory can answer — a
+   * workspace network that has never been opened reports
+   * `APP1 NETWORK_NOT_FOUND`.
+   */
+  getVisualStyle(networkId: IdType): ApiResult<{ visualStyle: VisualStyle }>
 
   // --- Write ---
 
@@ -182,6 +215,37 @@ export interface VisualStyleApi {
 
   /** Remove any mapping from a visual property. */
   deleteMapping(networkId: IdType, vpName: VisualPropertyName): ApiResult
+
+  /**
+   * Give the network a whole visual style — the equivalent of Cytoscape
+   * Desktop's `VisualMappingManager.setVisualStyle(style, view)`, and of
+   * the in-app "Apply Style" paths.
+   *
+   * **Copy, not a shared reference.** Desktop attaches one `VisualStyle`
+   * object to a view, so several views can follow it and a later edit to
+   * it changes all of them. In Cytoscape Web a style has no existence
+   * outside a network, so this takes a snapshot: the network gets its own
+   * deep copy of `visualStyle` as it is at this moment, and afterwards
+   * edits to the passed object and to the network's copy are independent.
+   *
+   * The copy is added to the network's named-style set (as if by the
+   * Vizmapper's "Apply Style") and made active. Bypasses are dropped —
+   * they are keyed by the source network's node and edge ids, which name
+   * nothing in the target. The switch is recorded as one undo entry, so
+   * the user can undo it like any other style switch; the copy stays in
+   * the style set after an undo, inert until selected.
+   *
+   * Fires `style:switched`, plus one `style:changed` per property that
+   * differs from the previously active style.
+   *
+   * @returns the id of the new named-style entry within the target
+   *   network's style set.
+   */
+  applyVisualStyle(
+    networkId: IdType,
+    visualStyle: VisualStyle,
+    options?: ApplyVisualStyleOptions,
+  ): ApiResult<{ styleId: IdType }>
 }
 
 // ── Private helpers ──────────────────────────────────────────────────────────
@@ -215,6 +279,9 @@ function checkMappingPreconditions(
     { requireNumeric },
   )
 }
+
+/** Name given to a style copied in by `applyVisualStyle` with no `name`. */
+const DEFAULT_IMPORTED_STYLE_NAME = 'Imported style'
 
 // ── Core implementation ──────────────────────────────────────────────────────
 
@@ -332,6 +399,21 @@ export const visualStyleApi: VisualStyleApi = {
       const resolved = resolveVisualProperty(networkId, vpName)
       if ('failure' in resolved) return resolved.failure
       return ok({ mapping: resolved.property.mapping })
+    } catch (e) {
+      return fail(AppCodes.OPERATION_FAILED, String(e))
+    }
+  },
+
+  getVisualStyle(networkId): ApiResult<{ visualStyle: VisualStyle }> {
+    try {
+      const style = useVisualStyleStore.getState().visualStyles[networkId]
+      if (style === undefined) {
+        return fail(AppCodes.NETWORK_NOT_FOUND, networkId)
+      }
+      // Detached on purpose. The stored object is deeply frozen by Immer,
+      // so handing it back would give the caller something it cannot touch
+      // (the `appData.get` problem) and would keep changing under it.
+      return ok({ visualStyle: cloneVisualStyle(style) })
     } catch (e) {
       return fail(AppCodes.OPERATION_FAILED, String(e))
     }
@@ -704,6 +786,78 @@ export const visualStyleApi: VisualStyleApi = {
         markNetworkModified(networkId)
       }
       return ok()
+    } catch (e) {
+      return fail(AppCodes.OPERATION_FAILED, String(e))
+    }
+  },
+
+  applyVisualStyle(
+    networkId,
+    visualStyle,
+    options,
+  ): ApiResult<{ styleId: IdType }> {
+    try {
+      const store = useVisualStyleStore.getState()
+      if (store.visualStyles[networkId] === undefined) {
+        return fail(AppCodes.NETWORK_NOT_FOUND, networkId)
+      }
+      // The one place an arbitrary object from an app becomes what the
+      // renderer reads. Without this check a malformed style fails later,
+      // inside CyjsRenderer, with nothing naming the caller.
+      if (!isValidVisualStyle(visualStyle)) {
+        return fail(
+          AppCodes.INVALID_INPUT,
+          'visualStyle is not a visual style: expected an object keyed by ' +
+            'VisualPropertyName whose entries carry group, type and defaultValue',
+        )
+      }
+      const styleSet = store.styleSets[networkId]
+      if (styleSet === undefined) {
+        return fail(AppCodes.NETWORK_NOT_FOUND, networkId)
+      }
+      // Checked here rather than read off importStyle's return value:
+      // importStyle reports both an unknown network and a full set as
+      // `undefined`, so the reason has to be established before the call.
+      if (Object.keys(styleSet.styles).length >= MAX_STYLES_PER_NETWORK) {
+        return fail(AppCodes.STYLE_SET_FULL, networkId, MAX_STYLES_PER_NETWORK)
+      }
+
+      const previousStyleId = styleSet.activeStyleId
+      const styleId = store.importStyle(
+        networkId,
+        options?.name ?? DEFAULT_IMPORTED_STYLE_NAME,
+        visualStyle,
+      )
+      if (styleId === undefined) {
+        return fail(
+          AppCodes.OPERATION_FAILED,
+          `Could not add a visual style to network ${networkId}`,
+        )
+      }
+
+      // Same two steps, in the same order, as the Vizmapper's copy-in path
+      // (StyleManager.handleCopyIn).
+      if (useVisualStyleStore.getState().switchStyle(networkId, styleId)) {
+        // The STORED name, read fresh: importStyle de-duplicates, so a
+        // second copy from the same source is "X 2" and the undo
+        // description has to match what the user sees in the style list.
+        const storedName =
+          useVisualStyleStore.getState().styleSets[networkId]?.styles[styleId]
+            ?.name ?? options?.name
+        corePostEdit(
+          networkId,
+          UndoCommandType.SWITCH_STYLE,
+          `Switch style to "${storedName ?? DEFAULT_IMPORTED_STYLE_NAME}"`,
+          [networkId, previousStyleId],
+          [networkId, styleId],
+        )
+      } else {
+        // corePostEdit marks the network itself, so this only covers the
+        // case where the switch failed: the copy still landed in the style
+        // set and has to be saveable.
+        markNetworkModified(networkId)
+      }
+      return ok({ styleId })
     } catch (e) {
       return fail(AppCodes.OPERATION_FAILED, String(e))
     }

--- a/src/app-api/core/visualStyleApi.ts
+++ b/src/app-api/core/visualStyleApi.ts
@@ -79,6 +79,16 @@ export interface ApplyVisualStyleOptions {
   name?: string
 }
 
+/** One named style a network owns, from getStyles(). */
+export interface NamedStyleInfo {
+  /** Unique within this network's style set, and meaningless outside it. */
+  id: IdType
+  /** Display name. Unique within the set, but not across networks. */
+  name: string
+  /** True for the one style that is rendered and edited. */
+  active: boolean
+}
+
 /** One visual property's identity and scope, from getVisualProperties(). */
 export interface VisualPropertyInfo {
   name: VisualPropertyName
@@ -147,6 +157,15 @@ export interface VisualStyleApi {
    * `APP1 NETWORK_NOT_FOUND`.
    */
   getVisualStyle(networkId: IdType): ApiResult<{ visualStyle: VisualStyle }>
+
+  /**
+   * List the named styles the network owns, in the order the style set
+   * holds them. Exactly one is `active`.
+   *
+   * Pair with `switchStyle` to move between styles the network already
+   * has, and with `applyVisualStyle` to add one it does not.
+   */
+  getStyles(networkId: IdType): ApiResult<{ styles: NamedStyleInfo[] }>
 
   // --- Write ---
 
@@ -246,6 +265,20 @@ export interface VisualStyleApi {
     visualStyle: VisualStyle,
     options?: ApplyVisualStyleOptions,
   ): ApiResult<{ styleId: IdType }>
+
+  /**
+   * Make one of the network's own named styles the active one. Ids come
+   * from `getStyles` or from `applyVisualStyle`, and mean nothing outside
+   * this network's style set.
+   *
+   * Recorded as one undo entry, like the Vizmapper's style picker.
+   * Switching to the style that is already active succeeds and does
+   * nothing — no undo entry, and the network is not marked modified.
+   *
+   * Fires `style:switched`, plus one `style:changed` per property that
+   * differs between the two styles.
+   */
+  switchStyle(networkId: IdType, styleId: IdType): ApiResult
 }
 
 // ── Private helpers ──────────────────────────────────────────────────────────
@@ -414,6 +447,26 @@ export const visualStyleApi: VisualStyleApi = {
       // so handing it back would give the caller something it cannot touch
       // (the `appData.get` problem) and would keep changing under it.
       return ok({ visualStyle: cloneVisualStyle(style) })
+    } catch (e) {
+      return fail(AppCodes.OPERATION_FAILED, String(e))
+    }
+  },
+
+  getStyles(networkId): ApiResult<{ styles: NamedStyleInfo[] }> {
+    try {
+      const styleSet = useVisualStyleStore.getState().styleSets[networkId]
+      if (styleSet === undefined) {
+        return fail(AppCodes.NETWORK_NOT_FOUND, networkId)
+      }
+      // Metadata only. The inactive entries hold their content inline and
+      // the active one's lives in the working copy, so returning content
+      // here would mean cloning the whole set to list two fields of it.
+      const styles = Object.values(styleSet.styles).map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        active: entry.id === styleSet.activeStyleId,
+      }))
+      return ok({ styles })
     } catch (e) {
       return fail(AppCodes.OPERATION_FAILED, String(e))
     }
@@ -858,6 +911,46 @@ export const visualStyleApi: VisualStyleApi = {
         markNetworkModified(networkId)
       }
       return ok({ styleId })
+    } catch (e) {
+      return fail(AppCodes.OPERATION_FAILED, String(e))
+    }
+  },
+
+  switchStyle(networkId, styleId): ApiResult {
+    try {
+      const styleSet = useVisualStyleStore.getState().styleSets[networkId]
+      if (styleSet === undefined) {
+        return fail(AppCodes.NETWORK_NOT_FOUND, networkId)
+      }
+      const target = styleSet.styles[styleId]
+      if (target === undefined) {
+        return fail(AppCodes.STYLE_NOT_FOUND, styleId, networkId)
+      }
+      // Already active: nothing changed, so no undo entry and no modified
+      // mark. An app that re-asserts a style on every event must not dirty
+      // a clean network — same reasoning as deleteBypass.
+      const previousStyleId = styleSet.activeStyleId
+      if (styleId === previousStyleId) {
+        return ok()
+      }
+
+      if (!useVisualStyleStore.getState().switchStyle(networkId, styleId)) {
+        // Both of the store's other refusals — unknown network, unknown
+        // style — are already ruled out above, so this is the entry whose
+        // content is missing: a set that broke its own invariant.
+        return fail(
+          AppCodes.OPERATION_FAILED,
+          `Style ${styleId} of network ${networkId} has no content`,
+        )
+      }
+      corePostEdit(
+        networkId,
+        UndoCommandType.SWITCH_STYLE,
+        `Switch style to "${target.name}"`,
+        [networkId, previousStyleId],
+        [networkId, styleId],
+      )
+      return ok()
     } catch (e) {
       return fail(AppCodes.OPERATION_FAILED, String(e))
     }

--- a/src/app-api/event-bus/CyWebEvents.ts
+++ b/src/app-api/event-bus/CyWebEvents.ts
@@ -52,6 +52,18 @@ export interface CyWebEvents {
   'style:changed': { networkId: IdType; property: string }
 
   /**
+   * Fired when a network's ACTIVE named style changes — the Vizmapper's
+   * style picker, `visualStyleApi.applyVisualStyle`, an undone switch, or
+   * deleting the active style. One event per switch, ahead of the
+   * `style:changed` burst the replacement causes.
+   */
+  'style:switched': {
+    networkId: IdType
+    styleId: IdType
+    previousStyleId: IdType
+  }
+
+  /**
    * Fired when table data is written to a network's node or edge table.
    * `rowIds` is the set of node/edge IDs whose data changed in this write.
    * `addedColumns`/`removedColumns` carry schema changes: a column create

--- a/src/app-api/event-bus/initEventBus.test.ts
+++ b/src/app-api/event-bus/initEventBus.test.ts
@@ -133,8 +133,16 @@ function triggerViewModelSub(curr: any, prev: any): void {
   callback(curr, prev)
 }
 
+/**
+ * The VisualStyleStore subscription reads two slices — `styleSets` for
+ * style:switched and `visualStyles` for style:changed. Fixtures name only
+ * the one under test, so the other defaults to empty.
+ */
 function triggerVisualStyleSub(curr: any, prev: any): void {
-  visualStyleSubs[0](curr, prev)
+  visualStyleSubs[0](
+    { styleSets: {}, visualStyles: {}, ...curr },
+    { styleSets: {}, visualStyles: {}, ...prev },
+  )
 }
 
 function triggerTableSub(curr: any, prev: any): void {
@@ -396,6 +404,75 @@ describe('selection:changed', () => {
     triggerViewModelSub(curr, prev)
 
     expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ── style:switched ────────────────────────────────────────────────────────────
+
+describe('style:switched', () => {
+  it('dispatches when the active style of a network changes', () => {
+    triggerVisualStyleSub(
+      { styleSets: { net1: { activeStyleId: 's2', styles: {} } } },
+      { styleSets: { net1: { activeStyleId: 's1', styles: {} } } },
+    )
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1)
+    expect(dispatchedTypes()).toEqual(['style:switched'])
+    expect(dispatchedDetails()[0]).toEqual({
+      networkId: 'net1',
+      styleId: 's2',
+      previousStyleId: 's1',
+    })
+  })
+
+  it('does not dispatch when the active style is unchanged', () => {
+    triggerVisualStyleSub(
+      { styleSets: { net1: { activeStyleId: 's1', styles: {} } } },
+      { styleSets: { net1: { activeStyleId: 's1', styles: {} } } },
+    )
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch for a newly registered network (network:created covers it)', () => {
+    triggerVisualStyleSub(
+      { styleSets: { net1: { activeStyleId: 's1', styles: {} } } },
+      { styleSets: {} },
+    )
+
+    expect(dispatchSpy).not.toHaveBeenCalled()
+  })
+
+  it('arrives before the style:changed burst the switch causes', () => {
+    // A switch replaces the whole working copy, so every differing property
+    // also fires style:changed. The coarse event has to come first, or an app
+    // handling the burst cannot tell it apart from N separate property edits.
+    triggerVisualStyleSub(
+      {
+        styleSets: { net1: { activeStyleId: 's2', styles: {} } },
+        visualStyles: {
+          net1: {
+            NODE_BACKGROUND_COLOR: { value: '#000' },
+            EDGE_WIDTH: { value: 2 },
+          },
+        },
+      },
+      {
+        styleSets: { net1: { activeStyleId: 's1', styles: {} } },
+        visualStyles: {
+          net1: {
+            NODE_BACKGROUND_COLOR: { value: '#fff' },
+            EDGE_WIDTH: { value: 1 },
+          },
+        },
+      },
+    )
+
+    expect(dispatchedTypes()).toEqual([
+      'style:switched',
+      'style:changed',
+      'style:changed',
+    ])
   })
 })
 

--- a/src/app-api/event-bus/initEventBus.ts
+++ b/src/app-api/event-bus/initEventBus.ts
@@ -148,10 +148,29 @@ export function initEventBus(): void {
     { equalityFn: selectionEqual },
   )
 
-  // --- style:changed ---
+  // --- style:switched + style:changed ---
   // VisualStyleStore does not use subscribeWithSelector, so we use the
-  // basic two-argument subscribe form (state, prevState).
+  // basic two-argument subscribe form (state, prevState). Both events come
+  // from one callback so their order is fixed: the coarse signal that the
+  // whole style was replaced arrives before the per-property burst it causes.
   useVisualStyleStore.subscribe((curr, prev) => {
+    // A style switch replaces the active style wholesale, so the loop below
+    // reports it as one style:changed per differing property — up to ~60 of
+    // them, with nothing saying they are one operation. This is that signal.
+    for (const networkId of Object.keys(curr.styleSets) as IdType[]) {
+      const activeStyleId = curr.styleSets[networkId]?.activeStyleId
+      const previousStyleId = prev.styleSets[networkId]?.activeStyleId
+      // A network's first style set (network just registered) is covered by
+      // network:created
+      if (previousStyleId === undefined || activeStyleId === undefined) continue
+      if (activeStyleId === previousStyleId) continue
+      dispatchCyWebEvent('style:switched', {
+        networkId,
+        styleId: activeStyleId,
+        previousStyleId,
+      })
+    }
+
     for (const networkId of Object.keys(curr.visualStyles) as IdType[]) {
       const style = curr.visualStyles[networkId]
       const prevStyle = prev.visualStyles[networkId]

--- a/src/app-api/types/ApiResult.ts
+++ b/src/app-api/types/ApiResult.ts
@@ -348,6 +348,13 @@ export const AppCodes = {
       `Value for app data key "${key}" is ${size} bytes, over the ` +
       `${limit}-byte per-entry limit`,
   },
+  /** @see src/app-api/api_docs/ErrorCodes.md#app14 */
+  STYLE_SET_FULL: {
+    code: 'APP14',
+    severity: 'error',
+    message: (networkId: string, limit: number) =>
+      `Network ${networkId} already owns the maximum of ${limit} visual styles`,
+  },
 } as const satisfies Record<string, ApiErrorCodeDef>
 
 /**

--- a/src/app-api/types/ApiResult.ts
+++ b/src/app-api/types/ApiResult.ts
@@ -355,6 +355,13 @@ export const AppCodes = {
     message: (networkId: string, limit: number) =>
       `Network ${networkId} already owns the maximum of ${limit} visual styles`,
   },
+  /** @see src/app-api/api_docs/ErrorCodes.md#app15 */
+  STYLE_NOT_FOUND: {
+    code: 'APP15',
+    severity: 'error',
+    message: (styleId: string, networkId: string) =>
+      `Network ${networkId} owns no visual style "${styleId}"`,
+  },
 } as const satisfies Record<string, ApiErrorCodeDef>
 
 /**

--- a/src/app-api/types/ElementTypes.ts
+++ b/src/app-api/types/ElementTypes.ts
@@ -24,6 +24,8 @@ export type { NetworkSummary } from '../../models/NetworkSummaryModel/NetworkSum
 export { VisualPropertyName } from '../../models/VisualStyleModel/VisualPropertyName'
 export type { VisualPropertyValueType } from '../../models/VisualStyleModel/VisualPropertyValue/VisualPropertyValueType'
 export type { VisualStyle } from '../../models/VisualStyleModel/VisualStyle'
+// The cap applyVisualStyle enforces, so an app can check before it calls.
+export { MAX_STYLES_PER_NETWORK } from '../../models/VisualStyleModel/VisualStyleSet'
 
 // ── View model types ────────────────────────────────────────────
 export type { NetworkView } from '../../models/ViewModel/NetworkView'

--- a/src/app-api/types/index.ts
+++ b/src/app-api/types/index.ts
@@ -61,6 +61,7 @@ export type {
 } from '../core/tableApi'
 export type { PositionRecord, ViewportApi } from '../core/viewportApi'
 export type {
+  ApplyVisualStyleOptions,
   CreateContinuousMappingOptions,
   VisualPropertyInfo,
   VisualStyleApi,
@@ -149,6 +150,7 @@ export type {
 } from './ElementTypes'
 export {
   ComponentType,
+  MAX_STYLES_PER_NETWORK,
   ValueTypeName,
   VisualPropertyName,
 } from './ElementTypes'

--- a/src/app-api/types/index.ts
+++ b/src/app-api/types/index.ts
@@ -63,6 +63,7 @@ export type { PositionRecord, ViewportApi } from '../core/viewportApi'
 export type {
   ApplyVisualStyleOptions,
   CreateContinuousMappingOptions,
+  NamedStyleInfo,
   VisualPropertyInfo,
   VisualStyleApi,
 } from '../core/visualStyleApi'

--- a/src/models/VisualStyleModel/impl/visualStyleSetImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/visualStyleSetImpl.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest'
 
+import { MappingFunctionType } from '../VisualMappingFunction/MappingFunctionType'
 import { DEFAULT_STYLE_NAME, VisualStyleSet } from '../VisualStyleSet'
 import { createVisualStyle } from './visualStyleFnImpl'
 import {
@@ -9,6 +10,7 @@ import {
   createStyleSet,
   getActiveStyle,
   isValidStyleSet,
+  isValidVisualStyle,
   stripBypasses,
   uniqueStyleName,
 } from './visualStyleSetImpl'
@@ -152,5 +154,105 @@ describe('uniqueStyleName', () => {
 
   it('should trim whitespace', () => {
     expect(uniqueStyleName('  My Style  ', [])).toBe('My Style')
+  })
+})
+
+describe('isValidVisualStyle', () => {
+  it('should accept a style built by the host', () => {
+    expect(isValidVisualStyle(createVisualStyle())).toBe(true)
+  })
+
+  it('should accept a style carrying a mapping', () => {
+    const style = createVisualStyle()
+    style.nodeLabel.mapping = {
+      type: MappingFunctionType.Passthrough,
+      attribute: 'name',
+      visualPropertyType: 'string',
+      defaultValue: '',
+    }
+    expect(isValidVisualStyle(style)).toBe(true)
+  })
+
+  it('should accept a style carrying unknown extra fields', () => {
+    // A runtime style object does carry fields the VisualStyle type does not
+    // describe; visualStyleApi.getVisualProperties skips them the same way.
+    const style: any = createVisualStyle()
+    style.someInternalField = { whatever: true }
+    expect(isValidVisualStyle(style)).toBe(true)
+  })
+
+  it('should reject non-objects', () => {
+    expect(isValidVisualStyle(undefined)).toBe(false)
+    expect(isValidVisualStyle(null)).toBe(false)
+    expect(isValidVisualStyle('nodeShape')).toBe(false)
+    expect(isValidVisualStyle(42)).toBe(false)
+    expect(isValidVisualStyle([])).toBe(false)
+  })
+
+  it('should reject an object holding no visual property at all', () => {
+    expect(isValidVisualStyle({})).toBe(false)
+    expect(isValidVisualStyle({ someInternalField: 1 })).toBe(false)
+  })
+
+  it('should reject a property that is not an object', () => {
+    expect(isValidVisualStyle({ nodeShape: 'diamond' })).toBe(false)
+  })
+
+  it('should reject a property with a missing or unknown group', () => {
+    expect(
+      isValidVisualStyle({
+        nodeShape: { type: 'nodeShape', defaultValue: 'ellipse' },
+      }),
+    ).toBe(false)
+    expect(
+      isValidVisualStyle({
+        nodeShape: {
+          group: 'hyperedge',
+          type: 'nodeShape',
+          defaultValue: 'ellipse',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('should reject a property with no type or no defaultValue', () => {
+    expect(
+      isValidVisualStyle({
+        nodeShape: { group: 'node', defaultValue: 'ellipse' },
+      }),
+    ).toBe(false)
+    expect(
+      isValidVisualStyle({ nodeShape: { group: 'node', type: 'nodeShape' } }),
+    ).toBe(false)
+  })
+
+  it('should reject a malformed mapping', () => {
+    const base = {
+      group: 'node',
+      type: 'string',
+      defaultValue: '',
+    }
+    expect(
+      isValidVisualStyle({ nodeLabel: { ...base, mapping: 'passthrough' } }),
+    ).toBe(false)
+    expect(
+      isValidVisualStyle({
+        nodeLabel: { ...base, mapping: { type: 'quadratic', attribute: 'x' } },
+      }),
+    ).toBe(false)
+    expect(
+      isValidVisualStyle({
+        nodeLabel: {
+          ...base,
+          mapping: { type: MappingFunctionType.Discrete },
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('should ignore bypassMap, which every consumer strips', () => {
+    const style: any = createVisualStyle()
+    style.nodeShape.bypassMap = { 'not-a': 'map' }
+    expect(isValidVisualStyle(style)).toBe(true)
   })
 })

--- a/src/models/VisualStyleModel/impl/visualStyleSetImpl.test.ts
+++ b/src/models/VisualStyleModel/impl/visualStyleSetImpl.test.ts
@@ -13,6 +13,7 @@ import {
   isValidVisualStyle,
   stripBypasses,
   uniqueStyleName,
+  visualStyleProblem,
 } from './visualStyleSetImpl'
 
 describe('cloneVisualStyle', () => {
@@ -158,6 +159,13 @@ describe('uniqueStyleName', () => {
 })
 
 describe('isValidVisualStyle', () => {
+  /** A complete style with one property replaced by `vp`. */
+  const styleWith = (vpName: string, vp: unknown): any => {
+    const style: any = createVisualStyle()
+    style[vpName] = vp
+    return style
+  }
+
   it('should accept a style built by the host', () => {
     expect(isValidVisualStyle(createVisualStyle())).toBe(true)
   })
@@ -174,8 +182,8 @@ describe('isValidVisualStyle', () => {
   })
 
   it('should accept a style carrying unknown extra fields', () => {
-    // A runtime style object does carry fields the VisualStyle type does not
-    // describe; visualStyleApi.getVisualProperties skips them the same way.
+    // A stored style can carry fields the VisualStyle type does not describe;
+    // visualStyleApi.getVisualProperties skips them the same way.
     const style: any = createVisualStyle()
     style.someInternalField = { whatever: true }
     expect(isValidVisualStyle(style)).toBe(true)
@@ -194,59 +202,77 @@ describe('isValidVisualStyle', () => {
     expect(isValidVisualStyle({ someInternalField: 1 })).toBe(false)
   })
 
+  it('should reject a PARTIAL style, however well-formed', () => {
+    // VisualStyle is a total record over VisualPropertyName. Applying a
+    // partial one would silently drop every property it omits from the
+    // network's style, with no way back except switching styles.
+    const complete: any = createVisualStyle()
+    const onlyNodeShape = { nodeShape: complete.nodeShape }
+
+    expect(isValidVisualStyle(onlyNodeShape)).toBe(false)
+    expect(visualStyleProblem(onlyNodeShape)).toContain('missing')
+
+    delete complete.edgeWidth
+    expect(isValidVisualStyle(complete)).toBe(false)
+    expect(visualStyleProblem(complete)).toContain('edgeWidth')
+  })
+
   it('should reject a property that is not an object', () => {
-    expect(isValidVisualStyle({ nodeShape: 'diamond' })).toBe(false)
+    expect(isValidVisualStyle(styleWith('nodeShape', 'diamond'))).toBe(false)
   })
 
   it('should reject a property with a missing or unknown group', () => {
     expect(
-      isValidVisualStyle({
-        nodeShape: { type: 'nodeShape', defaultValue: 'ellipse' },
-      }),
+      isValidVisualStyle(
+        styleWith('nodeShape', { type: 'nodeShape', defaultValue: 'ellipse' }),
+      ),
     ).toBe(false)
     expect(
-      isValidVisualStyle({
-        nodeShape: {
+      isValidVisualStyle(
+        styleWith('nodeShape', {
           group: 'hyperedge',
           type: 'nodeShape',
           defaultValue: 'ellipse',
-        },
-      }),
+        }),
+      ),
     ).toBe(false)
   })
 
   it('should reject a property with no type or no defaultValue', () => {
     expect(
-      isValidVisualStyle({
-        nodeShape: { group: 'node', defaultValue: 'ellipse' },
-      }),
+      isValidVisualStyle(
+        styleWith('nodeShape', { group: 'node', defaultValue: 'ellipse' }),
+      ),
     ).toBe(false)
     expect(
-      isValidVisualStyle({ nodeShape: { group: 'node', type: 'nodeShape' } }),
+      isValidVisualStyle(
+        styleWith('nodeShape', { group: 'node', type: 'nodeShape' }),
+      ),
     ).toBe(false)
   })
 
   it('should reject a malformed mapping', () => {
-    const base = {
-      group: 'node',
-      type: 'string',
-      defaultValue: '',
-    }
+    const base = { group: 'node', type: 'string', defaultValue: '' }
     expect(
-      isValidVisualStyle({ nodeLabel: { ...base, mapping: 'passthrough' } }),
+      isValidVisualStyle(
+        styleWith('nodeLabel', { ...base, mapping: 'passthrough' }),
+      ),
     ).toBe(false)
     expect(
-      isValidVisualStyle({
-        nodeLabel: { ...base, mapping: { type: 'quadratic', attribute: 'x' } },
-      }),
+      isValidVisualStyle(
+        styleWith('nodeLabel', {
+          ...base,
+          mapping: { type: 'quadratic', attribute: 'x' },
+        }),
+      ),
     ).toBe(false)
     expect(
-      isValidVisualStyle({
-        nodeLabel: {
+      isValidVisualStyle(
+        styleWith('nodeLabel', {
           ...base,
           mapping: { type: MappingFunctionType.Discrete },
-        },
-      }),
+        }),
+      ),
     ).toBe(false)
   })
 
@@ -254,5 +280,26 @@ describe('isValidVisualStyle', () => {
     const style: any = createVisualStyle()
     style.nodeShape.bypassMap = { 'not-a': 'map' }
     expect(isValidVisualStyle(style)).toBe(true)
+  })
+})
+
+describe('visualStyleProblem', () => {
+  it('should return undefined for a valid style', () => {
+    expect(visualStyleProblem(createVisualStyle())).toBeUndefined()
+  })
+
+  it('should name the offending property', () => {
+    const style: any = createVisualStyle()
+    style.edgeWidth = { group: 'edge', type: 'number' }
+    expect(visualStyleProblem(style)).toBe('edgeWidth has no defaultValue')
+  })
+
+  it('should report how many properties are missing, and name a few', () => {
+    const problem = visualStyleProblem({
+      nodeShape: createVisualStyle().nodeShape,
+    })
+    expect(problem).toMatch(/missing 65 of 66 visual properties \(/)
+    // Truncated rather than listing all 65
+    expect(problem).toContain('…')
   })
 })

--- a/src/models/VisualStyleModel/impl/visualStyleSetImpl.ts
+++ b/src/models/VisualStyleModel/impl/visualStyleSetImpl.ts
@@ -135,14 +135,11 @@ export const uniqueStyleName = (
 }
 
 /**
- * Every key the runtime treats as a visual property. A style object can also
- * carry fields the VisualStyle type does not describe (see
- * `visualStyleApi.getVisualProperties`, which filters them out the same way),
- * so validation ignores unknown keys instead of rejecting them.
+ * Every key a `VisualStyle` must carry. `VisualStyle` is a TOTAL record over
+ * `VisualPropertyName`, so a style missing any of these is not one — the
+ * network would silently lose the properties it omits.
  */
-const KNOWN_VP_NAMES: ReadonlySet<string> = new Set(
-  Object.values(VisualPropertyName),
-)
+const REQUIRED_VP_NAMES: readonly string[] = Object.values(VisualPropertyName)
 
 const VP_GROUPS: ReadonlySet<string> = new Set(
   Object.values(VisualPropertyGroup),
@@ -152,63 +149,101 @@ const MAPPING_TYPES: ReadonlySet<string> = new Set(
   Object.values(MappingFunctionType),
 )
 
+/** How many missing property names a rejection message lists before "…". */
+const MAX_NAMES_IN_PROBLEM = 5
+
 const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
 /**
- * Structural check on a visual style supplied from outside the host —
- * an app passing one to `visualStyleApi.applyVisualStyle`, say.
+ * Explain why a value is not a usable `VisualStyle`, or return undefined when
+ * it is one. `isValidVisualStyle` is the boolean form; callers that report the
+ * failure to someone (the app API's `applyVisualStyle`) use this one, so the
+ * error names what is actually wrong instead of restating the contract.
  *
- * Without it a malformed object becomes a network's active style and the
- * failure surfaces later, in the renderer, with nothing naming the caller.
+ * The check exists because a style supplied from outside the host — an app
+ * passing one to `applyVisualStyle` — becomes what the renderer reads. Without
+ * it a malformed object fails later, inside `CyjsRenderer`, with nothing
+ * naming the caller.
  *
- * What is checked: every entry whose key is a known `VisualPropertyName`
- * must be an object with a valid `group`, a `type`, a `defaultValue`, and —
- * when present — a `mapping` with a known `type` and an `attribute`. At
- * least one such entry must exist. Unknown keys are ignored (a real style
- * object carries some).
+ * What is checked:
+ *
+ * - Every `VisualPropertyName` is present. A partial style is rejected rather
+ *   than merged over the defaults: this API is "make B look like A", and
+ *   quietly substituting Cytoscape Web defaults for the properties A did not
+ *   mention would not do that. Every style the host produces is complete —
+ *   `createVisualStyle`, the presets, and `createVisualStyleFromCx` (which
+ *   starts from the default style) all carry the full set.
+ * - Every such entry is an object with a valid `group`, a `type`, a
+ *   `defaultValue`, and — when present — a `mapping` with a known `type` and
+ *   an `attribute`.
+ *
+ * Keys that are not visual property names are ignored, not rejected: a stored
+ * style can carry fields the `VisualStyle` type does not describe, and
+ * `visualStyleApi.getVisualProperties` skips them the same way.
  *
  * What is NOT checked: `bypassMap`, because every consumer of an external
- * style strips bypasses first (they are keyed by the source network's
- * element ids), and property VALUES, because `validateVisualPropertyValue`
- * in the app API owns that per-property and reports which one failed.
+ * style strips bypasses first (they are keyed by the source network's element
+ * ids), and property VALUES, because `validateVisualPropertyValue` in the app
+ * API owns that per-property and reports which one failed.
  */
-export const isValidVisualStyle = (value: unknown): value is VisualStyle => {
+export const visualStyleProblem = (value: unknown): string | undefined => {
   if (!isPlainRecord(value)) {
-    return false
+    return 'expected an object keyed by VisualPropertyName'
   }
-  let knownCount = 0
-  for (const [vpName, vp] of Object.entries(value)) {
-    if (!KNOWN_VP_NAMES.has(vpName)) {
-      continue
-    }
-    knownCount += 1
+
+  const missing = REQUIRED_VP_NAMES.filter(
+    (vpName) => value[vpName] === undefined,
+  )
+  if (missing.length > 0) {
+    const listed = missing.slice(0, MAX_NAMES_IN_PROBLEM).join(', ')
+    const rest = missing.length > MAX_NAMES_IN_PROBLEM ? ', …' : ''
+    return (
+      `missing ${missing.length} of ${REQUIRED_VP_NAMES.length} visual ` +
+      `properties (${listed}${rest})`
+    )
+  }
+
+  for (const vpName of REQUIRED_VP_NAMES) {
+    const vp = value[vpName]
     if (!isPlainRecord(vp)) {
-      return false
+      return `${vpName} is not a visual property object`
     }
     if (typeof vp.group !== 'string' || !VP_GROUPS.has(vp.group)) {
-      return false
+      return `${vpName} has no valid group (node, edge or network)`
     }
     if (typeof vp.type !== 'string' || vp.type === '') {
-      return false
+      return `${vpName} has no type`
     }
     if (vp.defaultValue === undefined) {
-      return false
+      return `${vpName} has no defaultValue`
     }
-    if (vp.mapping !== undefined) {
-      if (!isPlainRecord(vp.mapping)) {
-        return false
-      }
-      if (
-        typeof vp.mapping.type !== 'string' ||
-        !MAPPING_TYPES.has(vp.mapping.type)
-      ) {
-        return false
-      }
-      if (typeof vp.mapping.attribute !== 'string') {
-        return false
-      }
+    if (vp.mapping === undefined) {
+      continue
+    }
+    if (!isPlainRecord(vp.mapping)) {
+      return `${vpName} has a mapping that is not an object`
+    }
+    if (
+      typeof vp.mapping.type !== 'string' ||
+      !MAPPING_TYPES.has(vp.mapping.type)
+    ) {
+      return (
+        `${vpName} has a mapping with no valid type ` +
+        '(passthrough, discrete or continuous)'
+      )
+    }
+    if (typeof vp.mapping.attribute !== 'string') {
+      return `${vpName} has a mapping with no attribute`
     }
   }
-  return knownCount > 0
+
+  return undefined
 }
+
+/**
+ * True when `value` is a complete, well-formed `VisualStyle`.
+ * See {@link visualStyleProblem} for what that means and why.
+ */
+export const isValidVisualStyle = (value: unknown): value is VisualStyle =>
+  visualStyleProblem(value) === undefined

--- a/src/models/VisualStyleModel/impl/visualStyleSetImpl.ts
+++ b/src/models/VisualStyleModel/impl/visualStyleSetImpl.ts
@@ -7,6 +7,9 @@
 import { v4 as uuidv4 } from 'uuid'
 
 import { IdType } from '../../IdType'
+import { MappingFunctionType } from '../VisualMappingFunction/MappingFunctionType'
+import { VisualPropertyGroup } from '../VisualPropertyGroup'
+import { VisualPropertyName } from '../VisualPropertyName'
 import { VisualStyle } from '../VisualStyle'
 import {
   DEFAULT_STYLE_NAME,
@@ -129,4 +132,83 @@ export const uniqueStyleName = (
     counter += 1
   }
   return `${trimmed} ${counter}`
+}
+
+/**
+ * Every key the runtime treats as a visual property. A style object can also
+ * carry fields the VisualStyle type does not describe (see
+ * `visualStyleApi.getVisualProperties`, which filters them out the same way),
+ * so validation ignores unknown keys instead of rejecting them.
+ */
+const KNOWN_VP_NAMES: ReadonlySet<string> = new Set(
+  Object.values(VisualPropertyName),
+)
+
+const VP_GROUPS: ReadonlySet<string> = new Set(
+  Object.values(VisualPropertyGroup),
+)
+
+const MAPPING_TYPES: ReadonlySet<string> = new Set(
+  Object.values(MappingFunctionType),
+)
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Structural check on a visual style supplied from outside the host —
+ * an app passing one to `visualStyleApi.applyVisualStyle`, say.
+ *
+ * Without it a malformed object becomes a network's active style and the
+ * failure surfaces later, in the renderer, with nothing naming the caller.
+ *
+ * What is checked: every entry whose key is a known `VisualPropertyName`
+ * must be an object with a valid `group`, a `type`, a `defaultValue`, and —
+ * when present — a `mapping` with a known `type` and an `attribute`. At
+ * least one such entry must exist. Unknown keys are ignored (a real style
+ * object carries some).
+ *
+ * What is NOT checked: `bypassMap`, because every consumer of an external
+ * style strips bypasses first (they are keyed by the source network's
+ * element ids), and property VALUES, because `validateVisualPropertyValue`
+ * in the app API owns that per-property and reports which one failed.
+ */
+export const isValidVisualStyle = (value: unknown): value is VisualStyle => {
+  if (!isPlainRecord(value)) {
+    return false
+  }
+  let knownCount = 0
+  for (const [vpName, vp] of Object.entries(value)) {
+    if (!KNOWN_VP_NAMES.has(vpName)) {
+      continue
+    }
+    knownCount += 1
+    if (!isPlainRecord(vp)) {
+      return false
+    }
+    if (typeof vp.group !== 'string' || !VP_GROUPS.has(vp.group)) {
+      return false
+    }
+    if (typeof vp.type !== 'string' || vp.type === '') {
+      return false
+    }
+    if (vp.defaultValue === undefined) {
+      return false
+    }
+    if (vp.mapping !== undefined) {
+      if (!isPlainRecord(vp.mapping)) {
+        return false
+      }
+      if (
+        typeof vp.mapping.type !== 'string' ||
+        !MAPPING_TYPES.has(vp.mapping.type)
+      ) {
+        return false
+      }
+      if (typeof vp.mapping.attribute !== 'string') {
+        return false
+      }
+    }
+  }
+  return knownCount > 0
 }


### PR DESCRIPTION
Closes #702.

`VisualStyleApi` was entirely per-property, so an app that wanted network B to
look like network A had to read every default, mapping and bypass and replay
them through the `create*Mapping` methods, translating between the read and
write shapes as it went. MCODE works around it today by exporting the source
network to CX2 and slicing it, purely to keep the style.

## What's new

Four methods on `visualStyleApi`, all picked up automatically by
`forNetwork()` and published through `@cytoscape-web/api-types`:

| Method | Behavior |
| --- | --- |
| `getVisualStyle(networkId)` | Detached deep copy of the active style |
| `applyVisualStyle(networkId, visualStyle, options?)` | Deep-copies a style into the network's named-style set and makes it active |
| `getStyles(networkId)` | Lists the set as `{ id, name, active }` |
| `switchStyle(networkId, styleId)` | Activates one of the network's own styles |

`applyVisualStyle` runs the same two store actions as the Vizmapper's copy-in
path (`StyleManager.handleCopyIn`) — `importStyle` then `switchStyle` — and
records the same `SWITCH_STYLE` undo entry, so an app's apply is
indistinguishable from the user's.

```typescript
const read = visualStyleApi.getVisualStyle(sourceNetworkId)
if (read.success) {
  visualStyleApi.applyVisualStyle(subnetworkId, read.data.visualStyle)
}
```

## Copy semantics differ from Desktop

Desktop's `VisualMappingManager.setVisualStyle(style, view)` attaches one shared
style object to a view, so several views can follow it and a later edit changes
all of them. In Cytoscape Web a style has no existence outside a network, so
applying one always takes a snapshot: the target gets its own deep copy, and
afterwards edits to either side are independent. Bypasses are dropped — they
are keyed by the source network's element ids.

`api_docs/Api.md` states this explicitly, since developers arriving from Desktop
will expect the shared-object behavior.

## Two things the in-app path gets for free

- **Validating the style.** `applyVisualStyle` is where an arbitrary object from
  an app becomes what the renderer reads, so `isValidVisualStyle()` gates it.
  Without the check a malformed style becomes the active one and fails later
  inside `CyjsRenderer` with nothing naming the caller.
- **Establishing why an import failed.** `importStyle` reports both an unknown
  network and a full style set as `undefined`, so the cap is read before the
  call rather than inferred from its return value.

## New error codes

`APP14 STYLE_SET_FULL` and `APP15 STYLE_NOT_FOUND`, both in `AppCodes` rather
than `StyleCodes`: per the rule stated at the top of `ErrorCodes.md`, codes that
enforce a CX2 validation requirement reuse the CX2 code string, and codes with
no CX2 equivalent use `APP*`. The 50-style cap and the per-network style
registry are Cytoscape Web runtime concepts with no CX2 rule behind them.

`MAX_STYLES_PER_NETWORK` is now exported so an app can check before it calls.

## New `style:switched` event

`{ networkId, styleId, previousStyleId }`, dispatched from the `styleSets` half
of the `VisualStyleStore` subscription in `initEventBus`, so it covers the
in-app style picker too.

This resolves the open question in the ticket. Replacing the active style
already fired `style:changed`, but once per differing property — up to ~60
synchronous events with nothing marking them as one operation. Rather than
change that event's shape, `style:switched` is added as the coarse signal and
ordered ahead of the burst.

## Not exposed

`createStyle`, `duplicateStyle`, `renameStyle`, `deleteStyle`. `deleteStyle`
clears the network's entire undo history and is confirmation-gated in the UI;
the other three return `void` and only warn on refusal, so the API would have
to pre-check everything the store silently swallows. Recorded in
`MULTIPLE_VISUAL_STYLES.md` with the reasoning.

## Tests

`npm run test:checks:quiet`: lint and tsc clean, 4212 passed, 1 skipped.

`applyVisualStyle` / `getVisualStyle` / `getStyles` / `switchStyle` are tested
against the **real** store in a new `visualStyleApi.styleSet.test.ts` (33
cases). The existing `visualStyleApi.test.ts` replaces the whole store with
hand-written fakes, and deep-copying and bypass-stripping are properties of
`importStyle` itself — a faked store would only test the fake.

Covered: both copy directions, bypass stripping, name de-duplication, the
50-style cap, the undo entry's params and its stored-name description, a
net1→net2 round trip, the foreign-style-id case, and a back-and-forth switch
proving each style keeps its own edits. Plus 9 `isValidVisualStyle` cases and
4 `style:switched` cases.

No e2e run: no UI change, and no spec covers the style picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Visual Style API support for retrieving, applying, listing, and switching named visual styles.
  - Added validation, undo support, style limits, and clear errors for invalid, missing, or full style sets.
  - Added a `style:switched` event with current and previous style details.

- **Documentation**
  - Documented the Visual Style API, event behavior, limits, error codes, and usage semantics.

- **Tests**
  - Added comprehensive coverage for style operations, validation, switching, undo behavior, and event dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->