### PR TITLE
Drop the claudeBridge entry from the dev app registry

### DIFF
--- a/src/assets/apps.local.json
+++ b/src/assets/apps.local.json
@@ -46,22 +46,6 @@
     "repository": "https://github.com/cytoscape/cytoscape-web-app-examples"
   },
   {
-    "id": "claudeBridge",
-    "name": "Claude Bridge",
-    "url": "http://localhost:6100/remoteEntry.js",
-    "author": "Cytoscape Core Team",
-    "description": "Displays a live log of commands sent by Claude Code via the MCP bridge server.",
-    "version": "0.1.0",
-    "tags": [
-      "ai",
-      "mcp",
-      "bridge",
-      "developer-tools"
-    ],
-    "license": "MIT",
-    "repository": "https://github.com/cytoscape/cytoscape-web-app-examples"
-  },
-  {
     "id": "template",
     "name": "App Template",
     "url": "http://localhost:5555/remoteEntry.js",


### PR DESCRIPTION
`claude-bridge` moved out of `cytoscape-web-app-examples` into its own repository (https://github.com/keiono/cy-agent-bridge), so `dev-start.sh` — which discovers apps from that repository's `workspaces` — no longer starts anything on port 6100. The entry would keep advertising an app in the UI that fails only when activated, with nothing on screen connecting that to a dev server nobody ran.

Its dev server prints its own `?installApp=` link, which is the registration path for an app outside this workspace's app set.

One file: `src/assets/apps.local.json` (dev registry only; `apps.json` never listed it). Verified with `npm run test:checks:quiet` — 4219 tests and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the claudeBridge app from the local app registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->